### PR TITLE
feat: document tracking choice - appsync or ddb

### DIFF
--- a/lib/idp_common_pkg/idp_common/__init__.py
+++ b/lib/idp_common_pkg/idp_common/__init__.py
@@ -13,6 +13,9 @@ def __getattr__(name):
     if name in [
         "bedrock",
         "s3",
+        "dynamodb",
+        "appsync",
+        "docs_service",
         "metrics",
         "image",
         "utils",
@@ -45,6 +48,9 @@ def __getattr__(name):
 __all__ = [
     "bedrock",
     "s3",
+    "dynamodb",
+    "appsync",
+    "docs_service",
     "metrics",
     "image",
     "utils",

--- a/lib/idp_common_pkg/idp_common/docs_service.py
+++ b/lib/idp_common_pkg/idp_common/docs_service.py
@@ -1,0 +1,184 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Document service factory module for IDP Common package.
+
+This module provides a factory function to create document services based on
+the DOCUMENT_TRACKING_MODE environment variable. It allows switching between
+AppSync and DynamoDB implementations while maintaining the same interface.
+"""
+
+import os
+import logging
+from typing import Optional, Union
+
+from idp_common.appsync import DocumentAppSyncService
+from idp_common.dynamodb import DocumentDynamoDBService
+
+logger = logging.getLogger(__name__)
+
+# Supported document tracking modes
+APPSYNC_MODE = "appsync"
+DYNAMODB_MODE = "dynamodb"
+SUPPORTED_MODES = [APPSYNC_MODE, DYNAMODB_MODE]
+
+# Default mode
+DEFAULT_MODE = APPSYNC_MODE
+
+
+class DocumentServiceFactory:
+    """
+    Factory class for creating document services based on configuration.
+    
+    This factory allows switching between AppSync and DynamoDB implementations
+    while maintaining the same interface for document operations.
+    """
+    
+    @staticmethod
+    def create_service(
+        mode: Optional[str] = None,
+        **kwargs
+    ) -> Union[DocumentAppSyncService, DocumentDynamoDBService]:
+        """
+        Create a document service based on the specified mode.
+        
+        Args:
+            mode: Optional mode override. If not provided, uses DOCUMENT_TRACKING_MODE
+                  environment variable, defaulting to 'appsync'
+            **kwargs: Additional arguments passed to the service constructor
+            
+        Returns:
+            DocumentAppSyncService or DocumentDynamoDBService instance
+            
+        Raises:
+            ValueError: If an unsupported mode is specified
+            
+        Examples:
+            # Use environment variable (default behavior)
+            service = DocumentServiceFactory.create_service()
+            
+            # Override mode explicitly
+            service = DocumentServiceFactory.create_service(mode='dynamodb')
+            
+            # Pass additional arguments
+            service = DocumentServiceFactory.create_service(
+                mode='appsync',
+                api_url='https://example.appsync-api.us-east-1.amazonaws.com/graphql'
+            )
+        """
+        # Determine the mode
+        if mode is None:
+            mode = os.environ.get("DOCUMENT_TRACKING_MODE", DEFAULT_MODE).lower()
+        else:
+            mode = mode.lower()
+            
+        # Validate mode
+        if mode not in SUPPORTED_MODES:
+            raise ValueError(
+                f"Unsupported document tracking mode: '{mode}'. "
+                f"Supported modes are: {', '.join(SUPPORTED_MODES)}"
+            )
+        
+        logger.info(f"Creating document service with mode: {mode}")
+        
+        # Create the appropriate service
+        if mode == APPSYNC_MODE:
+            return DocumentAppSyncService(**kwargs)
+        elif mode == DYNAMODB_MODE:
+            return DocumentDynamoDBService(**kwargs)
+        else:
+            # This should never happen due to validation above, but included for completeness
+            raise ValueError(f"Unsupported mode: {mode}")
+    
+    @staticmethod
+    def get_current_mode() -> str:
+        """
+        Get the current document tracking mode from environment variable.
+        
+        Returns:
+            Current mode string ('appsync' or 'dynamodb')
+        """
+        return os.environ.get("DOCUMENT_TRACKING_MODE", DEFAULT_MODE).lower()
+    
+    @staticmethod
+    def is_appsync_mode() -> bool:
+        """
+        Check if current mode is AppSync.
+        
+        Returns:
+            True if current mode is AppSync, False otherwise
+        """
+        return DocumentServiceFactory.get_current_mode() == APPSYNC_MODE
+    
+    @staticmethod
+    def is_dynamodb_mode() -> bool:
+        """
+        Check if current mode is DynamoDB.
+        
+        Returns:
+            True if current mode is DynamoDB, False otherwise
+        """
+        return DocumentServiceFactory.get_current_mode() == DYNAMODB_MODE
+
+
+# Convenience function for creating services
+def create_document_service(
+    mode: Optional[str] = None,
+    **kwargs
+) -> Union[DocumentAppSyncService, DocumentDynamoDBService]:
+    """
+    Convenience function to create a document service.
+    
+    This is a shorthand for DocumentServiceFactory.create_service().
+    
+    Args:
+        mode: Optional mode override. If not provided, uses DOCUMENT_TRACKING_MODE
+              environment variable, defaulting to 'appsync'
+        **kwargs: Additional arguments passed to the service constructor
+        
+    Returns:
+        DocumentAppSyncService or DocumentDynamoDBService instance
+        
+    Examples:
+        # Simple usage
+        service = create_document_service()
+        
+        # With mode override
+        service = create_document_service(mode='dynamodb')
+        
+        # With additional parameters
+        service = create_document_service(
+            mode='appsync',
+            api_url='https://example.appsync-api.us-east-1.amazonaws.com/graphql'
+        )
+    """
+    return DocumentServiceFactory.create_service(mode=mode, **kwargs)
+
+
+# Convenience functions for mode checking
+def get_document_tracking_mode() -> str:
+    """Get the current document tracking mode."""
+    return DocumentServiceFactory.get_current_mode()
+
+
+def is_appsync_mode() -> bool:
+    """Check if current mode is AppSync."""
+    return DocumentServiceFactory.is_appsync_mode()
+
+
+def is_dynamodb_mode() -> bool:
+    """Check if current mode is DynamoDB."""
+    return DocumentServiceFactory.is_dynamodb_mode()
+
+
+__all__ = [
+    "DocumentServiceFactory",
+    "create_document_service",
+    "get_document_tracking_mode",
+    "is_appsync_mode",
+    "is_dynamodb_mode",
+    "APPSYNC_MODE",
+    "DYNAMODB_MODE",
+    "DEFAULT_MODE",
+]

--- a/lib/idp_common_pkg/idp_common/docs_service_README.md
+++ b/lib/idp_common_pkg/idp_common/docs_service_README.md
@@ -1,0 +1,250 @@
+# Document Service Factory
+
+The `docs_service` module provides a factory pattern for creating document services, allowing you to switch between AppSync and DynamoDB implementations while maintaining the same interface.
+
+## Overview
+
+This module enables runtime switching between different document tracking backends:
+
+- **AppSync Mode**: Uses AWS AppSync GraphQL API for document operations
+- **DynamoDB Mode**: Uses direct DynamoDB operations for document tracking
+
+The factory pattern ensures that your Lambda functions can work with either backend without code changes, controlled by environment variables.
+
+## Key Components
+
+### DocumentServiceFactory
+
+The main factory class that creates appropriate service instances:
+
+```python
+from idp_common.docs_service import DocumentServiceFactory
+
+# Create service based on environment variable
+service = DocumentServiceFactory.create_service()
+
+# Override mode explicitly
+service = DocumentServiceFactory.create_service(mode='dynamodb')
+
+# Pass additional parameters
+service = DocumentServiceFactory.create_service(
+    mode='appsync',
+    api_url='https://example.appsync-api.us-east-1.amazonaws.com/graphql'
+)
+```
+
+### Convenience Functions
+
+Simplified functions for common operations:
+
+```python
+from idp_common.docs_service import (
+    create_document_service,
+    get_document_tracking_mode,
+    is_appsync_mode,
+    is_dynamodb_mode
+)
+
+# Create service using convenience function
+service = create_document_service()
+
+# Check current mode
+current_mode = get_document_tracking_mode()
+if is_appsync_mode():
+    print("Using AppSync backend")
+elif is_dynamodb_mode():
+    print("Using DynamoDB backend")
+```
+
+## Environment Configuration
+
+The factory uses the `DOCUMENT_TRACKING_MODE` environment variable to determine which service to create:
+
+```bash
+# Use AppSync (default)
+export DOCUMENT_TRACKING_MODE=appsync
+
+# Use DynamoDB
+export DOCUMENT_TRACKING_MODE=dynamodb
+```
+
+## Usage Patterns
+
+### Basic Usage
+
+```python
+from idp_common.docs_service import create_document_service
+from idp_common.models import Document, Status
+
+# Create service (mode determined by environment)
+service = create_document_service()
+
+# Use the service (same interface regardless of backend)
+document = Document(
+    input_key="my-document.pdf",
+    status=Status.QUEUED,
+    queued_time="2024-01-01T12:00:00Z"
+)
+
+# These methods work with both AppSync and DynamoDB services
+service.create_document(document)
+service.update_document(document)
+retrieved_doc = service.get_document("my-document.pdf")
+```
+
+### Lambda Function Integration
+
+```python
+import os
+from idp_common.docs_service import create_document_service
+
+def lambda_handler(event, context):
+    # Service type determined by environment variable
+    service = create_document_service()
+    
+    # Your document processing logic here
+    document = process_document(event)
+    
+    # Update document status
+    service.update_document(document)
+    
+    return {"statusCode": 200}
+```
+
+### Testing with Different Backends
+
+```python
+import pytest
+from unittest.mock import patch
+from idp_common.docs_service import create_document_service
+
+def test_with_appsync():
+    with patch.dict(os.environ, {"DOCUMENT_TRACKING_MODE": "appsync"}):
+        service = create_document_service()
+        assert service.__class__.__name__ == "DocumentAppSyncService"
+
+def test_with_dynamodb():
+    with patch.dict(os.environ, {"DOCUMENT_TRACKING_MODE": "dynamodb"}):
+        service = create_document_service()
+        assert service.__class__.__name__ == "DocumentDynamoDBService"
+```
+
+### Configuration-based Service Creation
+
+```python
+from idp_common.docs_service import DocumentServiceFactory
+
+class DocumentProcessor:
+    def __init__(self, config):
+        # Create service based on configuration
+        self.service = DocumentServiceFactory.create_service(
+            mode=config.get('tracking_mode', 'appsync'),
+            **config.get('service_params', {})
+        )
+    
+    def process(self, document):
+        # Process document using configured service
+        return self.service.update_document(document)
+```
+
+## Service Interface Compatibility
+
+Both AppSync and DynamoDB services implement the same interface:
+
+### Common Methods
+
+- `create_document(document, expires_after=None) -> str`
+- `update_document(document) -> Document`
+- `calculate_ttl(days=30) -> int`
+
+### AppSync-specific Methods
+
+- Uses GraphQL mutations for operations
+- Requires AppSync API URL configuration
+- Handles GraphQL-specific error responses
+
+### DynamoDB-specific Methods
+
+- Uses direct DynamoDB operations
+- Requires DynamoDB table name configuration
+- Includes additional query methods:
+  - `get_document(object_key) -> Optional[Document]`
+  - `list_documents(...) -> Dict[str, Any]`
+  - `list_documents_date_hour(...) -> Dict[str, Any]`
+  - `list_documents_date_shard(...) -> Dict[str, Any]`
+
+## Error Handling
+
+The factory provides consistent error handling:
+
+```python
+from idp_common.docs_service import DocumentServiceFactory
+
+try:
+    service = DocumentServiceFactory.create_service(mode='invalid')
+except ValueError as e:
+    print(f"Invalid mode: {e}")
+
+# Service-specific errors are handled by the individual services
+try:
+    service.create_document(document)
+except Exception as e:
+    # Handle AppSync or DynamoDB specific errors
+    logger.error(f"Document creation failed: {e}")
+```
+
+## Migration Guide
+
+### From Direct AppSync Usage
+
+```python
+# Old code
+from idp_common.appsync import DocumentAppSyncService
+service = DocumentAppSyncService(api_url=appsync_url)
+
+# New code
+from idp_common.docs_service import create_document_service
+service = create_document_service()  # Mode controlled by environment
+```
+
+### From Direct DynamoDB Usage
+
+```python
+# Old code
+from idp_common.dynamodb import DocumentDynamoDBService
+service = DocumentDynamoDBService(table_name=table_name)
+
+# New code
+from idp_common.docs_service import create_document_service
+service = create_document_service()  # Mode controlled by environment
+```
+
+## Best Practices
+
+1. **Use Environment Variables**: Control service type through `DOCUMENT_TRACKING_MODE` rather than hardcoding
+2. **Consistent Interface**: Write code that works with both service types
+3. **Error Handling**: Handle service-specific errors appropriately
+4. **Testing**: Test with both service types to ensure compatibility
+5. **Configuration**: Use the factory for flexible service creation
+
+## Environment Variables
+
+The module recognizes these environment variables:
+
+- `DOCUMENT_TRACKING_MODE`: Service type ('appsync' or 'dynamodb')
+- `APPSYNC_API_URL`: AppSync GraphQL endpoint (for AppSync mode)
+- `TRACKING_TABLE`: DynamoDB table name (for DynamoDB mode)
+- `AWS_REGION`: AWS region for service operations
+
+## Supported Modes
+
+- `appsync` (default): Use AWS AppSync GraphQL API
+- `dynamodb`: Use direct DynamoDB operations
+
+## Examples
+
+See `idp_common/dynamodb/example.py` for comprehensive usage examples including:
+- Basic service creation and usage
+- Factory pattern usage
+- Environment-based mode switching
+- Complex document operations with pages and sections

--- a/lib/idp_common_pkg/idp_common/dynamodb/README.md
+++ b/lib/idp_common_pkg/idp_common/dynamodb/README.md
@@ -1,0 +1,198 @@
+# DynamoDB Module - Direct DynamoDB Integration
+
+The `dynamodb` module provides direct DynamoDB integration for the IDP Common package, allowing Lambda functions to interact with the TrackingTable without going through AppSync GraphQL API.
+
+## Overview
+
+This module is designed to replace AppSync dependencies in Lambda functions while maintaining the same functionality and data structures. It provides:
+
+- Direct DynamoDB operations using boto3
+- Document CRUD operations matching AppSync schema
+- Transaction support for atomic operations
+- Error handling and logging
+- TTL support for document expiration
+
+## Key Components
+
+### DynamoDBClient
+
+Low-level client for DynamoDB operations:
+- `put_item()` - Insert items
+- `update_item()` - Update existing items
+- `get_item()` - Retrieve items by key
+- `transact_write_items()` - Execute transactions
+- `scan()` - Scan table with filters
+- `query()` - Query with key conditions
+
+### DocumentDynamoDBService
+
+High-level service for document operations:
+- `create_document()` - Create new documents with list partitioning
+- `update_document()` - Update existing documents
+- `get_document()` - Retrieve documents by object key
+- `list_documents()` - List documents with date filtering
+- `list_documents_date_hour()` - List by specific date/hour
+- `list_documents_date_shard()` - List by date/shard
+- `calculate_ttl()` - Generate TTL timestamps
+
+## Usage
+
+### Basic Usage
+
+```python
+from idp_common.dynamodb import DocumentDynamoDBService
+from idp_common.models import Document, Status
+
+# Initialize service (uses TRACKING_TABLE env var)
+service = DocumentDynamoDBService()
+
+# Create a document
+document = Document(
+    input_key="my-document.pdf",
+    status=Status.QUEUED,
+    queued_time="2024-01-01T12:00:00Z"
+)
+
+# Create in DynamoDB
+service.create_document(document)
+
+# Update document
+document.status = Status.PROCESSING
+updated_doc = service.update_document(document)
+
+# Retrieve document
+retrieved_doc = service.get_document("my-document.pdf")
+```
+
+### Advanced Usage
+
+```python
+# Custom client configuration
+from idp_common.dynamodb import DynamoDBClient, DocumentDynamoDBService
+
+client = DynamoDBClient(
+    table_name="my-tracking-table",
+    region="us-east-1"
+)
+service = DocumentDynamoDBService(dynamodb_client=client)
+
+# Create with TTL
+ttl = service.calculate_ttl(days=30)
+service.create_document(document, expires_after=ttl)
+
+# List documents with filtering
+results = service.list_documents(
+    start_date_time="2024-01-01T00:00:00Z",
+    end_date_time="2024-01-31T23:59:59Z",
+    limit=100
+)
+
+# Query by date and hour
+hourly_docs = service.list_documents_date_hour(
+    date="2024-01-01",
+    hour=14
+)
+```
+
+## Data Structure Compatibility
+
+The module maintains full compatibility with the existing AppSync schema:
+
+### Document Table Structure
+- **PK**: `doc#{ObjectKey}` - Primary partition key
+- **SK**: `none` - Sort key (always "none" for documents)
+- **ObjectKey**: Document identifier
+- **ObjectStatus**: Document processing status
+- **Pages**: List of page objects with Id, Class, ImageUri, TextUri
+- **Sections**: List of section objects with Id, PageIds, Class, OutputJSONUri
+- **Metering**: JSON string of metering data
+- **TTL**: ExpiresAfter timestamp
+
+### List Partition Structure
+- **PK**: `list#{date}#s#{shard}` - Time-based partition key
+- **SK**: `ts#{timestamp}#id#{ObjectKey}` - Sort key for chronological ordering
+- **ObjectKey**: Document identifier
+- **QueuedTime**: When document was queued
+
+## Error Handling
+
+The module provides comprehensive error handling:
+
+```python
+from idp_common.dynamodb import DynamoDBError
+
+try:
+    service.create_document(document)
+except DynamoDBError as e:
+    logger.error(f"DynamoDB operation failed: {e}")
+    logger.error(f"Error code: {e.error_code}")
+```
+
+## Environment Variables
+
+The module uses these environment variables:
+
+- `TRACKING_TABLE` - DynamoDB table name
+- `AWS_REGION` - AWS region
+
+## Migration from AppSync
+
+To migrate from AppSync to direct DynamoDB:
+
+1. Replace imports:
+   ```python
+   # Old
+   from idp_common.appsync import DocumentAppSyncService
+   
+   # New
+   from idp_common.dynamodb import DocumentDynamoDBService
+   ```
+
+2. Update service initialization:
+   ```python
+   # Old
+   service = DocumentAppSyncService(api_url=appsync_url)
+   
+   # New
+   service = DocumentDynamoDBService(table_name=table_name)
+   ```
+
+3. Method calls remain the same:
+   ```python
+   # These work with both services
+   service.create_document(document)
+   service.update_document(document)
+   service.get_document(object_key)
+   ```
+
+## Performance Considerations
+
+- **Transactions**: Document creation uses DynamoDB transactions for consistency
+- **Sharding**: List partitions are sharded by time to distribute load
+- **Pagination**: All list operations support pagination via `exclusive_start_key`
+- **Filtering**: Date-based filtering uses efficient query operations when possible
+
+## Logging
+
+The module provides detailed logging at DEBUG and INFO levels:
+- Operation success/failure
+- Performance metrics
+- Data conversion warnings
+- Error details with context
+
+## Testing
+
+The module is designed to be easily testable with mocked DynamoDB clients:
+
+```python
+from unittest.mock import Mock
+from idp_common.dynamodb import DocumentDynamoDBService
+
+# Mock client for testing
+mock_client = Mock()
+service = DocumentDynamoDBService(dynamodb_client=mock_client)
+
+# Test operations
+service.create_document(test_document)
+mock_client.transact_write_items.assert_called_once()
+```

--- a/lib/idp_common_pkg/idp_common/dynamodb/__init__.py
+++ b/lib/idp_common_pkg/idp_common/dynamodb/__init__.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Direct DynamoDB integration module for IDP Common package.
+
+This module provides classes and functions for interacting directly with DynamoDB
+to store and retrieve document data, bypassing AppSync GraphQL API.
+"""
+
+from idp_common.dynamodb.client import DynamoDBClient, DynamoDBError
+from idp_common.dynamodb.service import DocumentDynamoDBService
+
+__all__ = [
+    "DynamoDBClient",
+    "DynamoDBError",
+    "DocumentDynamoDBService",
+]

--- a/lib/idp_common_pkg/idp_common/dynamodb/client.py
+++ b/lib/idp_common_pkg/idp_common/dynamodb/client.py
@@ -1,0 +1,312 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+DynamoDB client for direct table operations.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError, BotoCoreError
+
+logger = logging.getLogger(__name__)
+
+
+class DynamoDBError(Exception):
+    """Custom exception for DynamoDB errors"""
+
+    def __init__(self, message: str, error_code: str = None):
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class DynamoDBClient:
+    """
+    Client for executing DynamoDB operations directly against the TrackingTable.
+
+    This client handles authentication, error handling, and provides methods
+    for document CRUD operations without going through AppSync.
+    """
+
+    def __init__(self, table_name: Optional[str] = None, region: Optional[str] = None):
+        """
+        Initialize the DynamoDB client.
+
+        Args:
+            table_name: Optional DynamoDB table name. If not provided, will be read from TRACKING_TABLE env var.
+            region: Optional AWS region. If not provided, will be read from AWS_REGION env var.
+        """
+        self.table_name = table_name or os.environ.get("TRACKING_TABLE")
+        self.region = region or os.environ.get("AWS_REGION")
+
+        if not self.table_name:
+            raise ValueError(
+                "DynamoDB table name must be provided or set in TRACKING_TABLE environment variable"
+            )
+
+        if not self.region:
+            raise ValueError(
+                "AWS region must be provided or set in AWS_REGION environment variable"
+            )
+
+        try:
+            self.dynamodb = boto3.resource("dynamodb", region_name=self.region)
+            self.table = self.dynamodb.Table(self.table_name)
+        except Exception as e:
+            logger.error(f"Failed to initialize DynamoDB client: {str(e)}")
+            raise DynamoDBError(f"Failed to initialize DynamoDB client: {str(e)}")
+
+    def put_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Put an item into the DynamoDB table.
+
+        Args:
+            item: The item to put into the table
+
+        Returns:
+            Dict containing the response from DynamoDB
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        try:
+            response = self.table.put_item(Item=item)
+            logger.debug(f"Successfully put item with PK: {item.get('PK')}")
+            return response
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"DynamoDB put_item failed: {error_code} - {error_message}")
+            raise DynamoDBError(f"Put item failed: {error_message}", error_code)
+        except BotoCoreError as e:
+            logger.error(f"BotoCore error during put_item: {str(e)}")
+            raise DynamoDBError(f"BotoCore error: {str(e)}")
+
+    def update_item(
+        self,
+        key: Dict[str, Any],
+        update_expression: str,
+        expression_attribute_names: Optional[Dict[str, str]] = None,
+        expression_attribute_values: Optional[Dict[str, Any]] = None,
+        return_values: str = "ALL_NEW",
+    ) -> Dict[str, Any]:
+        """
+        Update an item in the DynamoDB table.
+
+        Args:
+            key: The primary key of the item to update
+            update_expression: The update expression
+            expression_attribute_names: Optional attribute name mappings
+            expression_attribute_values: Optional attribute value mappings
+            return_values: What to return after the update
+
+        Returns:
+            Dict containing the response from DynamoDB
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        try:
+            update_params = {
+                "Key": key,
+                "UpdateExpression": update_expression,
+                "ReturnValues": return_values,
+            }
+
+            if expression_attribute_names:
+                update_params["ExpressionAttributeNames"] = expression_attribute_names
+
+            if expression_attribute_values:
+                update_params["ExpressionAttributeValues"] = expression_attribute_values
+
+            response = self.table.update_item(**update_params)
+            logger.debug(f"Successfully updated item with key: {key}")
+            return response
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"DynamoDB update_item failed: {error_code} - {error_message}")
+            raise DynamoDBError(f"Update item failed: {error_message}", error_code)
+        except BotoCoreError as e:
+            logger.error(f"BotoCore error during update_item: {str(e)}")
+            raise DynamoDBError(f"BotoCore error: {str(e)}")
+
+    def get_item(self, key: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Get an item from the DynamoDB table.
+
+        Args:
+            key: The primary key of the item to retrieve
+
+        Returns:
+            The item if found, None otherwise
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        try:
+            response = self.table.get_item(Key=key)
+            item = response.get("Item")
+            if item:
+                logger.debug(f"Successfully retrieved item with key: {key}")
+            else:
+                logger.debug(f"Item not found with key: {key}")
+            return item
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"DynamoDB get_item failed: {error_code} - {error_message}")
+            raise DynamoDBError(f"Get item failed: {error_message}", error_code)
+        except BotoCoreError as e:
+            logger.error(f"BotoCore error during get_item: {str(e)}")
+            raise DynamoDBError(f"BotoCore error: {str(e)}")
+
+    def transact_write_items(self, transact_items: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Execute a transaction with multiple write operations.
+
+        Args:
+            transact_items: List of transaction items
+
+        Returns:
+            Dict containing the response from DynamoDB
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        try:
+            # Convert table references to use the table name
+            processed_items = []
+            for item in transact_items:
+                processed_item = item.copy()
+                if "Put" in processed_item:
+                    processed_item["Put"]["TableName"] = self.table_name
+                elif "Update" in processed_item:
+                    processed_item["Update"]["TableName"] = self.table_name
+                elif "Delete" in processed_item:
+                    processed_item["Delete"]["TableName"] = self.table_name
+                processed_items.append(processed_item)
+
+            response = self.dynamodb.meta.client.transact_write_items(
+                TransactItems=processed_items
+            )
+            logger.debug(f"Successfully executed transaction with {len(transact_items)} items")
+            return response
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"DynamoDB transact_write_items failed: {error_code} - {error_message}")
+            raise DynamoDBError(f"Transaction failed: {error_message}", error_code)
+        except BotoCoreError as e:
+            logger.error(f"BotoCore error during transact_write_items: {str(e)}")
+            raise DynamoDBError(f"BotoCore error: {str(e)}")
+
+    def scan(
+        self,
+        filter_expression: Optional[str] = None,
+        expression_attribute_names: Optional[Dict[str, str]] = None,
+        expression_attribute_values: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        exclusive_start_key: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Scan the DynamoDB table.
+
+        Args:
+            filter_expression: Optional filter expression
+            expression_attribute_names: Optional attribute name mappings
+            expression_attribute_values: Optional attribute value mappings
+            limit: Optional limit on number of items to return
+            exclusive_start_key: Optional key to start scanning from
+
+        Returns:
+            Dict containing the scan results
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        try:
+            scan_params = {}
+
+            if filter_expression:
+                scan_params["FilterExpression"] = filter_expression
+
+            if expression_attribute_names:
+                scan_params["ExpressionAttributeNames"] = expression_attribute_names
+
+            if expression_attribute_values:
+                scan_params["ExpressionAttributeValues"] = expression_attribute_values
+
+            if limit:
+                scan_params["Limit"] = limit
+
+            if exclusive_start_key:
+                scan_params["ExclusiveStartKey"] = exclusive_start_key
+
+            response = self.table.scan(**scan_params)
+            logger.debug(f"Successfully scanned table, returned {len(response.get('Items', []))} items")
+            return response
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"DynamoDB scan failed: {error_code} - {error_message}")
+            raise DynamoDBError(f"Scan failed: {error_message}", error_code)
+        except BotoCoreError as e:
+            logger.error(f"BotoCore error during scan: {str(e)}")
+            raise DynamoDBError(f"BotoCore error: {str(e)}")
+
+    def query(
+        self,
+        key_condition_expression: str,
+        expression_attribute_names: Optional[Dict[str, str]] = None,
+        expression_attribute_values: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        exclusive_start_key: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Query the DynamoDB table.
+
+        Args:
+            key_condition_expression: The key condition expression
+            expression_attribute_names: Optional attribute name mappings
+            expression_attribute_values: Optional attribute value mappings
+            limit: Optional limit on number of items to return
+            exclusive_start_key: Optional key to start querying from
+
+        Returns:
+            Dict containing the query results
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        try:
+            query_params = {
+                "KeyConditionExpression": key_condition_expression,
+            }
+
+            if expression_attribute_names:
+                query_params["ExpressionAttributeNames"] = expression_attribute_names
+
+            if expression_attribute_values:
+                query_params["ExpressionAttributeValues"] = expression_attribute_values
+
+            if limit:
+                query_params["Limit"] = limit
+
+            if exclusive_start_key:
+                query_params["ExclusiveStartKey"] = exclusive_start_key
+
+            response = self.table.query(**query_params)
+            logger.debug(f"Successfully queried table, returned {len(response.get('Items', []))} items")
+            return response
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"DynamoDB query failed: {error_code} - {error_message}")
+            raise DynamoDBError(f"Query failed: {error_message}", error_code)
+        except BotoCoreError as e:
+            logger.error(f"BotoCore error during query: {str(e)}")
+            raise DynamoDBError(f"BotoCore error: {str(e)}")

--- a/lib/idp_common_pkg/idp_common/dynamodb/example.py
+++ b/lib/idp_common_pkg/idp_common/dynamodb/example.py
@@ -1,0 +1,208 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Example usage of the DynamoDB module for document tracking.
+
+This example demonstrates how to use the DocumentDynamoDBService
+to create, update, and retrieve documents directly from DynamoDB.
+"""
+
+import os
+from datetime import datetime
+from idp_common.dynamodb import DocumentDynamoDBService
+from idp_common.models import Document, Page, Section, Status
+
+
+def example_basic_usage():
+    """
+    Basic example of using DocumentDynamoDBService.
+    """
+    print("=== Basic DynamoDB Service Usage ===")
+    
+    # Initialize service (requires TRACKING_TABLE and AWS_REGION env vars)
+    service = DocumentDynamoDBService()
+    
+    # Create a new document
+    document = Document(
+        input_key="example-document.pdf",
+        status=Status.QUEUED,
+        queued_time=datetime.now().isoformat() + "Z",
+        initial_event_time=datetime.now().isoformat() + "Z"
+    )
+    
+    print(f"Creating document: {document.input_key}")
+    
+    # Create document in DynamoDB
+    object_key = service.create_document(document)
+    print(f"Document created with key: {object_key}")
+    
+    # Update document status
+    document.status = Status.PROCESSING
+    document.start_time = datetime.now().isoformat() + "Z"
+    
+    print("Updating document status to PROCESSING")
+    updated_doc = service.update_document(document)
+    print(f"Document updated. Status: {updated_doc.status}")
+    
+    # Retrieve document
+    print("Retrieving document from DynamoDB")
+    retrieved_doc = service.get_document(object_key)
+    if retrieved_doc:
+        print(f"Retrieved document: {retrieved_doc.input_key}, Status: {retrieved_doc.status}")
+    else:
+        print("Document not found")
+
+
+def example_with_pages_and_sections():
+    """
+    Example with pages and sections data.
+    """
+    print("\n=== Document with Pages and Sections ===")
+    
+    service = DocumentDynamoDBService()
+    
+    # Create document with pages and sections
+    document = Document(
+        input_key="complex-document.pdf",
+        status=Status.PROCESSING,
+        queued_time=datetime.now().isoformat() + "Z",
+        initial_event_time=datetime.now().isoformat() + "Z",
+        num_pages=3
+    )
+    
+    # Add pages
+    for i in range(1, 4):
+        page = Page(
+            page_id=str(i),
+            image_uri=f"s3://bucket/images/page-{i}.png",
+            raw_text_uri=f"s3://bucket/text/page-{i}.txt",
+            classification=f"page-type-{i}"
+        )
+        document.pages[str(i)] = page
+    
+    # Add sections
+    section = Section(
+        section_id="section-1",
+        classification="form",
+        page_ids=["1", "2"],
+        extraction_result_uri="s3://bucket/results/section-1.json",
+        confidence_threshold_alerts=[
+            {
+                "attribute_name": "customer_name",
+                "confidence": 0.75,
+                "confidence_threshold": 0.8
+            }
+        ]
+    )
+    document.sections.append(section)
+    
+    print(f"Creating complex document: {document.input_key}")
+    object_key = service.create_document(document)
+    
+    # Update with completion
+    document.status = Status.COMPLETED
+    document.completion_time = datetime.now().isoformat() + "Z"
+    document.metering = {
+        "textract_pages": 3,
+        "bedrock_input_tokens": 1500,
+        "bedrock_output_tokens": 300
+    }
+    
+    print("Updating document with completion data")
+    updated_doc = service.update_document(document)
+    print(f"Document completed. Pages: {len(updated_doc.pages)}, Sections: {len(updated_doc.sections)}")
+
+
+def example_factory_usage():
+    """
+    Example of using the DocumentServiceFactory.
+    """
+    print("\n=== Using DocumentServiceFactory ===")
+    
+    from idp_common.docs_service import DocumentServiceFactory, create_document_service
+    
+    # Create service using factory (defaults to environment variable)
+    service = DocumentServiceFactory.create_service()
+    print(f"Created service using factory. Type: {type(service).__name__}")
+    
+    # Create service with explicit mode
+    try:
+        dynamodb_service = DocumentServiceFactory.create_service(mode='dynamodb')
+        print(f"Created DynamoDB service: {type(dynamodb_service).__name__}")
+    except Exception as e:
+        print(f"Could not create DynamoDB service: {e}")
+    
+    try:
+        appsync_service = DocumentServiceFactory.create_service(mode='appsync')
+        print(f"Created AppSync service: {type(appsync_service).__name__}")
+    except Exception as e:
+        print(f"Could not create AppSync service: {e}")
+    
+    # Use convenience function
+    service = create_document_service()
+    print(f"Created service using convenience function: {type(service).__name__}")
+    
+    # Check current mode
+    current_mode = DocumentServiceFactory.get_current_mode()
+    print(f"Current tracking mode: {current_mode}")
+
+
+def example_environment_switching():
+    """
+    Example of switching between modes using environment variables.
+    """
+    print("\n=== Environment-based Mode Switching ===")
+    
+    from idp_common.docs_service import create_document_service, get_document_tracking_mode
+    
+    # Show current mode
+    current_mode = get_document_tracking_mode()
+    print(f"Current mode from environment: {current_mode}")
+    
+    # Temporarily set environment variable
+    original_mode = os.environ.get("DOCUMENT_TRACKING_MODE")
+    
+    # Test DynamoDB mode
+    os.environ["DOCUMENT_TRACKING_MODE"] = "dynamodb"
+    service = create_document_service()
+    print(f"With DOCUMENT_TRACKING_MODE=dynamodb: {type(service).__name__}")
+    
+    # Test AppSync mode
+    os.environ["DOCUMENT_TRACKING_MODE"] = "appsync"
+    service = create_document_service()
+    print(f"With DOCUMENT_TRACKING_MODE=appsync: {type(service).__name__}")
+    
+    # Restore original environment
+    if original_mode:
+        os.environ["DOCUMENT_TRACKING_MODE"] = original_mode
+    else:
+        os.environ.pop("DOCUMENT_TRACKING_MODE", None)
+
+
+if __name__ == "__main__":
+    print("DynamoDB Module Example")
+    print("=" * 50)
+    
+    # Note: These examples require proper AWS credentials and environment variables
+    print("Note: These examples require:")
+    print("- AWS credentials configured")
+    print("- TRACKING_TABLE environment variable set")
+    print("- AWS_REGION environment variable set")
+    print()
+    
+    try:
+        # Run examples (will fail without proper environment setup)
+        example_factory_usage()
+        example_environment_switching()
+        
+        # These require actual AWS resources
+        # example_basic_usage()
+        # example_with_pages_and_sections()
+        
+    except Exception as e:
+        print(f"Example failed (expected without proper AWS setup): {e}")
+        print("\nTo run the full examples, ensure you have:")
+        print("1. AWS credentials configured (aws configure or IAM role)")
+        print("2. TRACKING_TABLE environment variable set to your DynamoDB table name")
+        print("3. AWS_REGION environment variable set to your AWS region")

--- a/lib/idp_common_pkg/idp_common/dynamodb/service.py
+++ b/lib/idp_common_pkg/idp_common/dynamodb/service.py
@@ -1,0 +1,604 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+DynamoDB service for handling document operations directly.
+
+This module provides the DocumentDynamoDBService class for managing document
+storage and retrieval through direct DynamoDB operations, bypassing AppSync.
+"""
+
+import datetime
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from boto3.dynamodb.conditions import Key, Attr
+from idp_common.dynamodb.client import DynamoDBClient
+from idp_common.models import Document, Page, Section, Status
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentDynamoDBService:
+    """
+    Service for interacting directly with DynamoDB to manage Documents.
+
+    This service provides methods to convert between Document objects and the
+    DynamoDB item format, and to create and update documents directly in DynamoDB.
+    """
+
+    def __init__(
+        self,
+        dynamodb_client: Optional[DynamoDBClient] = None,
+        table_name: Optional[str] = None,
+    ):
+        """
+        Initialize the DocumentDynamoDBService.
+
+        Args:
+            dynamodb_client: Optional DynamoDBClient instance. If not provided, a new one will be created.
+            table_name: Optional DynamoDB table name. Used only if dynamodb_client is not provided.
+        """
+        self.client = dynamodb_client or DynamoDBClient(table_name=table_name)
+
+    def _generate_shard_info(self, queued_time: str) -> tuple[str, str]:
+        """
+        Generate shard information for list partitioning based on queued time.
+
+        Args:
+            queued_time: ISO 8601 timestamp string
+
+        Returns:
+            Tuple of (list_pk, list_sk) for the list partition
+        """
+        shards_in_day = 6
+        shard_divider = 24 // shards_in_day
+
+        # Extract date and hour from timestamp
+        date = queued_time[:10]  # YYYY-MM-DD
+        hour_string = queued_time[11:13]  # HH
+        hour = int(hour_string)
+
+        # Calculate shard
+        hour_shard = hour // shard_divider
+        shard_pad = f"{hour_shard:02d}"
+
+        list_pk = f"list#{date}#s#{shard_pad}"
+        list_sk = f"ts#{queued_time}#id#{queued_time}"
+
+        return list_pk, list_sk
+
+    def _document_to_create_item(
+        self, document: Document, expires_after: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        Convert a Document object to a DynamoDB item for creation.
+
+        Args:
+            document: The Document object to convert
+            expires_after: Optional TTL timestamp for document expiration
+
+        Returns:
+            Dictionary compatible with DynamoDB item format
+        """
+        item = {
+            "PK": f"doc#{document.input_key}",
+            "SK": "none",
+            "ObjectKey": document.input_key,
+            "ObjectStatus": document.status.value,
+            "InitialEventTime": document.initial_event_time,
+            "QueuedTime": document.queued_time,
+        }
+
+        if expires_after:
+            item["ExpiresAfter"] = expires_after
+
+        return item
+
+    def _document_to_update_expressions(self, document: Document) -> tuple[str, Dict[str, str], Dict[str, Any]]:
+        """
+        Convert a Document object to DynamoDB update expressions.
+
+        Args:
+            document: The Document object to convert
+
+        Returns:
+            Tuple of (update_expression, expression_attribute_names, expression_attribute_values)
+        """
+        set_expressions = []
+        expression_names = {}
+        expression_values = {}
+
+        # Always update ObjectStatus
+        set_expressions.append("#ObjectStatus = :ObjectStatus")
+        expression_names["#ObjectStatus"] = "ObjectStatus"
+        expression_values[":ObjectStatus"] = document.status.value
+
+        # Add optional fields if they exist
+        if document.queued_time:
+            set_expressions.append("#QueuedTime = :QueuedTime")
+            expression_names["#QueuedTime"] = "QueuedTime"
+            expression_values[":QueuedTime"] = document.queued_time
+
+        if document.start_time:
+            set_expressions.append("#WorkflowStartTime = :WorkflowStartTime")
+            expression_names["#WorkflowStartTime"] = "WorkflowStartTime"
+            expression_values[":WorkflowStartTime"] = document.start_time
+
+        if document.completion_time:
+            set_expressions.append("#CompletionTime = :CompletionTime")
+            expression_names["#CompletionTime"] = "CompletionTime"
+            expression_values[":CompletionTime"] = document.completion_time
+
+        if document.workflow_execution_arn:
+            set_expressions.append("#WorkflowExecutionArn = :WorkflowExecutionArn")
+            expression_names["#WorkflowExecutionArn"] = "WorkflowExecutionArn"
+            expression_values[":WorkflowExecutionArn"] = document.workflow_execution_arn
+
+        # Set workflow status based on document status
+        if document.status == Status.FAILED:
+            workflow_status = "FAILED"
+        elif document.status == Status.COMPLETED:
+            workflow_status = "SUCCEEDED"
+        else:
+            workflow_status = "RUNNING"
+
+        set_expressions.append("#WorkflowStatus = :WorkflowStatus")
+        expression_names["#WorkflowStatus"] = "WorkflowStatus"
+        expression_values[":WorkflowStatus"] = workflow_status
+
+        if document.num_pages > 0:
+            set_expressions.append("#PageCount = :PageCount")
+            expression_names["#PageCount"] = "PageCount"
+            expression_values[":PageCount"] = document.num_pages
+
+        # Convert pages
+        if document.pages:
+            pages_data = []
+            for page_id, page in document.pages.items():
+                # In the DynamoDB schema, page IDs are integers
+                try:
+                    page_id_int = int(page_id)
+                except ValueError:
+                    logger.warning(f"Skipping page {page_id} - ID is not an integer")
+                    continue
+
+                page_data = {
+                    "Id": page_id_int,
+                    "Class": page.classification or "",
+                    "ImageUri": page.image_uri or "",
+                    "TextUri": page.parsed_text_uri or page.raw_text_uri or "",
+                }
+                pages_data.append(page_data)
+
+            if pages_data:
+                set_expressions.append("#Pages = :Pages")
+                expression_names["#Pages"] = "Pages"
+                expression_values[":Pages"] = pages_data
+
+        # Convert sections
+        if document.sections:
+            sections_data = []
+            for section in document.sections:
+                # Convert page IDs to integers for DynamoDB
+                page_ids = []
+                for page_id in section.page_ids:
+                    try:
+                        page_ids.append(int(page_id))
+                    except ValueError:
+                        logger.warning(
+                            f"Skipping page ID {page_id} in section {section.section_id} - not an integer"
+                        )
+
+                section_data = {
+                    "Id": section.section_id,
+                    "PageIds": page_ids,
+                    "Class": section.classification,
+                    "OutputJSONUri": section.extraction_result_uri or "",
+                }
+
+                # Convert confidence threshold alerts (matching current AppSync interface)
+                if section.confidence_threshold_alerts:
+                    alerts_data = []
+                    for alert in section.confidence_threshold_alerts:
+                        alert_data = {
+                            "attributeName": alert.get("attribute_name"),
+                            "confidence": alert.get("confidence"),
+                            "confidenceThreshold": alert.get("confidence_threshold"),
+                        }
+                        alerts_data.append(alert_data)
+                    section_data["ConfidenceThresholdAlerts"] = alerts_data
+
+                sections_data.append(section_data)
+
+            if sections_data:
+                set_expressions.append("#Sections = :Sections")
+                expression_names["#Sections"] = "Sections"
+                expression_values[":Sections"] = sections_data
+
+        # Add metering data if available
+        if document.metering:
+            set_expressions.append("#Metering = :Metering")
+            expression_names["#Metering"] = "Metering"
+            expression_values[":Metering"] = json.dumps(document.metering)
+
+        # Add evaluation status & report if available
+        if document.evaluation_status:
+            set_expressions.append("#EvaluationStatus = :EvaluationStatus")
+            expression_names["#EvaluationStatus"] = "EvaluationStatus"
+            expression_values[":EvaluationStatus"] = document.evaluation_status
+
+        if document.evaluation_report_uri:
+            set_expressions.append("#EvaluationReportUri = :EvaluationReportUri")
+            expression_names["#EvaluationReportUri"] = "EvaluationReportUri"
+            expression_values[":EvaluationReportUri"] = document.evaluation_report_uri
+
+        # Add summary report if available
+        if document.summary_report_uri:
+            set_expressions.append("#SummaryReportUri = :SummaryReportUri")
+            expression_names["#SummaryReportUri"] = "SummaryReportUri"
+            expression_values[":SummaryReportUri"] = document.summary_report_uri
+
+        update_expression = "SET " + ", ".join(set_expressions)
+
+        return update_expression, expression_names, expression_values
+
+    def _dynamodb_item_to_document(self, item: Dict[str, Any]) -> Document:
+        """
+        Convert DynamoDB item data to a Document object.
+
+        Args:
+            item: The document item returned from DynamoDB
+
+        Returns:
+            Document object populated with data from DynamoDB
+        """
+        # Create document with basic properties
+        doc = Document(
+            id=item.get("ObjectKey"),
+            input_key=item.get("ObjectKey"),
+            num_pages=item.get("PageCount", 0),
+            queued_time=item.get("QueuedTime"),
+            start_time=item.get("WorkflowStartTime"),
+            completion_time=item.get("CompletionTime"),
+            workflow_execution_arn=item.get("WorkflowExecutionArn"),
+            evaluation_report_uri=item.get("EvaluationReportUri"),
+            summary_report_uri=item.get("SummaryReportUri"),
+        )
+
+        # Convert status
+        object_status = item.get("ObjectStatus")
+        if object_status:
+            try:
+                doc.status = Status(object_status)
+            except ValueError:
+                logger.warning(f"Unknown status '{object_status}', using QUEUED")
+                doc.status = Status.QUEUED
+
+        # Convert metering data
+        metering_json = item.get("Metering")
+        if metering_json:
+            try:
+                doc.metering = json.loads(metering_json)
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse metering data")
+
+        # Convert pages
+        pages_data = item.get("Pages", [])
+        if pages_data is not None:  # Ensure pages_data is not None before iterating
+            for page_data in pages_data:
+                page_id = str(page_data.get("Id"))
+                doc.pages[page_id] = Page(
+                    page_id=page_id,
+                    image_uri=page_data.get("ImageUri"),
+                    raw_text_uri=page_data.get("TextUri"),
+                    classification=page_data.get("Class"),
+                )
+
+        # Convert sections
+        sections_data = item.get("Sections", [])
+        if sections_data is not None:  # Ensure sections_data is not None before iterating
+            for section_data in sections_data:
+                # Convert page IDs to strings
+                page_ids = [str(page_id) for page_id in section_data.get("PageIds", [])]
+
+                # Convert confidence threshold alerts (matching current AppSync interface)
+                confidence_threshold_alerts = []
+                alerts_data = section_data.get("ConfidenceThresholdAlerts", [])
+                if alerts_data:
+                    for alert in alerts_data:
+                        confidence_threshold_alerts.append(
+                            {
+                                "attribute_name": alert.get("attributeName"),
+                                "confidence": alert.get("confidence"),
+                                "confidence_threshold": alert.get(
+                                    "confidenceThreshold"
+                                ),
+                            }
+                        )
+
+                doc.sections.append(
+                    Section(
+                        section_id=section_data.get("Id", ""),
+                        classification=section_data.get("Class", ""),
+                        page_ids=page_ids,
+                        extraction_result_uri=section_data.get("OutputJSONUri"),
+                        confidence_threshold_alerts=confidence_threshold_alerts,
+                    )
+                )
+
+        return doc
+
+    def create_document(
+        self, document: Document, expires_after: Optional[int] = None
+    ) -> str:
+        """
+        Create a new document in DynamoDB using a transaction.
+
+        Args:
+            document: The Document object to create
+            expires_after: Optional TTL timestamp for document expiration
+
+        Returns:
+            The ObjectKey of the created document
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        # Create the main document item
+        doc_item = self._document_to_create_item(document, expires_after)
+
+        # Generate shard information for list partition
+        list_pk, list_sk = self._generate_shard_info(document.queued_time)
+
+        # Create list item for time-based queries
+        list_item = {
+            "PK": list_pk,
+            "SK": list_sk,
+            "ObjectKey": document.input_key,
+            "QueuedTime": document.queued_time,
+        }
+
+        if expires_after:
+            list_item["ExpiresAfter"] = expires_after
+
+        # Execute transaction to create both items
+        transact_items = [
+            {
+                "Put": {
+                    "Item": doc_item,
+                }
+            },
+            {
+                "Put": {
+                    "Item": list_item,
+                }
+            },
+        ]
+
+        self.client.transact_write_items(transact_items)
+        logger.info(f"Successfully created document: {document.input_key}")
+
+        return document.input_key
+
+    def update_document(self, document: Document) -> Document:
+        """
+        Update an existing document in DynamoDB.
+
+        Args:
+            document: The Document object to update
+
+        Returns:
+            Updated Document object with any data returned from DynamoDB
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        key = {
+            "PK": f"doc#{document.input_key}",
+            "SK": "none",
+        }
+
+        update_expression, expression_names, expression_values = self._document_to_update_expressions(document)
+
+        response = self.client.update_item(
+            key=key,
+            update_expression=update_expression,
+            expression_attribute_names=expression_names,
+            expression_attribute_values=expression_values,
+            return_values="ALL_NEW",
+        )
+
+        # Convert the response back to a Document object
+        updated_item = response.get("Attributes", {})
+        updated_document = self._dynamodb_item_to_document(updated_item)
+
+        logger.info(f"Successfully updated document: {document.input_key}")
+        return updated_document
+
+    def get_document(self, object_key: str) -> Optional[Document]:
+        """
+        Get a document from DynamoDB by its object key.
+
+        Args:
+            object_key: The object key of the document to retrieve
+
+        Returns:
+            Document object if found, None otherwise
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        key = {
+            "PK": f"doc#{object_key}",
+            "SK": "none",
+        }
+
+        item = self.client.get_item(key)
+        if item:
+            return self._dynamodb_item_to_document(item)
+        return None
+
+    def list_documents(
+        self,
+        start_date_time: Optional[str] = None,
+        end_date_time: Optional[str] = None,
+        limit: Optional[int] = None,
+        exclusive_start_key: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        List documents with optional date filtering.
+
+        Args:
+            start_date_time: Optional start datetime filter (ISO 8601)
+            end_date_time: Optional end datetime filter (ISO 8601)
+            limit: Optional limit on number of items to return
+            exclusive_start_key: Optional key to start scanning from
+
+        Returns:
+            Dict containing documents and pagination info
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        filter_expression = None
+        expression_attribute_values = {}
+
+        if start_date_time and end_date_time:
+            filter_expression = "InitialEventTime BETWEEN :start_date AND :end_date"
+            expression_attribute_values[":start_date"] = start_date_time
+            expression_attribute_values[":end_date"] = end_date_time
+        elif start_date_time:
+            filter_expression = "InitialEventTime >= :start_date"
+            expression_attribute_values[":start_date"] = start_date_time
+        elif end_date_time:
+            filter_expression = "InitialEventTime <= :end_date"
+            expression_attribute_values[":end_date"] = end_date_time
+
+        response = self.client.scan(
+            filter_expression=filter_expression,
+            expression_attribute_values=expression_attribute_values if expression_attribute_values else None,
+            limit=limit or 50,
+            exclusive_start_key=exclusive_start_key,
+        )
+
+        # Convert items to Document objects
+        documents = []
+        for item in response.get("Items", []):
+            try:
+                documents.append(self._dynamodb_item_to_document(item))
+            except Exception as e:
+                logger.warning(f"Failed to convert item to document: {e}")
+
+        return {
+            "Documents": documents,
+            "nextToken": response.get("LastEvaluatedKey"),
+        }
+
+    def list_documents_date_hour(
+        self, date: Optional[str] = None, hour: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        List documents for a specific date and hour using the list partition.
+
+        Args:
+            date: Date in YYYY-MM-DD format (defaults to today)
+            hour: Hour in 24-hour format 0-23 (defaults to current hour)
+
+        Returns:
+            Dict containing documents and pagination info
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        shards_in_day = 6
+        shard_divider = 24 // shards_in_day
+
+        # Use current time if not provided
+        now = datetime.datetime.now()
+        if date is None:
+            date = now.strftime("%Y-%m-%d")
+        if hour is None:
+            hour = now.hour
+
+        if hour < 0 or hour > 23:
+            raise ValueError("Invalid hour parameter - value should be between 0 and 23")
+
+        # Calculate shard
+        hour_shard = hour // shard_divider
+        shard_pad = f"{hour_shard:02d}"
+        hour_pad = f"{hour:02d}"
+
+        list_pk = f"list#{date}#s#{shard_pad}"
+        sk_prefix = f"ts#{date}T{hour_pad}"
+
+        response = self.client.query(
+            key_condition_expression="PK = :pk AND begins_with(SK, :sk_prefix)",
+            expression_attribute_values={
+                ":pk": list_pk,
+                ":sk_prefix": sk_prefix,
+            },
+        )
+
+        return {
+            "Documents": response.get("Items", []),
+            "nextToken": response.get("LastEvaluatedKey"),
+        }
+
+    def list_documents_date_shard(
+        self, date: Optional[str] = None, shard: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        List documents for a specific date and shard using the list partition.
+
+        Args:
+            date: Date in YYYY-MM-DD format (defaults to today)
+            shard: Shard number (defaults to current shard)
+
+        Returns:
+            Dict containing documents and pagination info
+
+        Raises:
+            DynamoDBError: If the DynamoDB operation fails
+        """
+        shards_in_day = 6
+        shard_divider = 24 // shards_in_day
+
+        # Use current time if not provided
+        now = datetime.datetime.now()
+        if date is None:
+            date = now.strftime("%Y-%m-%d")
+        if shard is None:
+            shard = now.hour // shard_divider
+
+        if shard >= shards_in_day or shard < 0:
+            raise ValueError(f"Invalid shard parameter value - must be positive and less than {shards_in_day}")
+
+        shard_pad = f"{shard:02d}"
+        list_pk = f"list#{date}#s#{shard_pad}"
+
+        response = self.client.query(
+            key_condition_expression="PK = :pk",
+            expression_attribute_values={
+                ":pk": list_pk,
+            },
+        )
+
+        return {
+            "Documents": response.get("Items", []),
+            "nextToken": response.get("LastEvaluatedKey"),
+        }
+
+    def calculate_ttl(self, days: int = 30) -> int:
+        """
+        Calculate a TTL timestamp for document expiration.
+
+        Args:
+            days: Number of days until expiration
+
+        Returns:
+            Unix timestamp (seconds since epoch) for the expiration date
+        """
+        expiration_date = datetime.datetime.now() + datetime.timedelta(days=days)
+        return int(expiration_date.timestamp())

--- a/lib/idp_common_pkg/pyproject.toml
+++ b/lib/idp_common_pkg/pyproject.toml
@@ -81,6 +81,12 @@ appsync = [
     "requests==2.32.4",
 ]
 
+# Document service factory dependencies (includes both appsync and dynamodb support)
+# This includes all dependencies needed for both backends
+docs_service = [
+    "requests==2.32.4",  # Required for appsync module (dynamodb only needs boto3 which is core)
+]
+
 # Testing dependencies
 test = [
     "pytest>=7.4.0",

--- a/patterns/pattern-1/src/processresults_function/index.py
+++ b/patterns/pattern-1/src/processresults_function/index.py
@@ -15,7 +15,7 @@ import boto3
 import fitz  # PyMuPDF
 from botocore.exceptions import ClientError
 from idp_common import metrics
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 from idp_common.config import get_config
 from idp_common.models import Document, HitlMetadata, Page, Section, Status
 from idp_common.s3 import get_s3_client, write_content
@@ -1036,9 +1036,9 @@ def handler(event, context):
     logger.info(f"Using confidence threshold: {confidence_threshold}")
 
     # Update document status
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
    
     # Create page images (only need to do this once)
     try:
@@ -1174,7 +1174,7 @@ def handler(event, context):
         document.completion_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
         logger.info(f"Document processing complete, setting status to {document.status}")
     
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     # Prepare response using new serialization method
     # Use working bucket for document compression

--- a/patterns/pattern-1/src/processresults_function/requirements.txt
+++ b/patterns/pattern-1/src/processresults_function/requirements.txt
@@ -1,3 +1,3 @@
 PyMuPDF==1.25.5
 boto3
-../../lib/idp_common_pkg[core,appsync]  # core utilities and AppSync with dependencies
+../../lib/idp_common_pkg[core,docs_service]  # core utilities and document service with dependencies

--- a/patterns/pattern-1/src/summarization_function/index.py
+++ b/patterns/pattern-1/src/summarization_function/index.py
@@ -12,7 +12,7 @@ import time
 # Import the SummarizationService from idp_common
 from idp_common import get_config, summarization
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -51,9 +51,9 @@ def handler(event, context):
         
         # Update document status to SUMMARIZING
         document.status = Status.SUMMARIZING
-        appsync_service = DocumentAppSyncService()
+        document_service = create_document_service()
         logger.info(f"Updating document status to {document.status}")
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         
         # Load configuration and create the summarization service
         config = get_config()
@@ -89,9 +89,9 @@ def handler(event, context):
             if 'document' in locals() and document:
                 document.status = Status.FAILED
                 document.status_reason = str(e)
-                appsync_service = DocumentAppSyncService()
+                document_service = create_document_service()
                 logger.info(f"Updating document status to {document.status} due to error")
-                appsync_service.update_document(document)
+                document_service.update_document(document)
         except Exception as status_error:
             logger.error(f"Failed to update document status: {str(status_error)}", exc_info=True)
             

--- a/patterns/pattern-1/src/summarization_function/requirements.txt
+++ b/patterns/pattern-1/src/summarization_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[summarization,appsync]  # summarization and AppSync modules with dependencies
+../../lib/idp_common_pkg[summarization,docs_service]  # summarization and AppSync modules with dependencies

--- a/patterns/pattern-2/src/assessment_function/index.py
+++ b/patterns/pattern-2/src/assessment_function/index.py
@@ -8,7 +8,7 @@ import logging
 
 from idp_common import get_config, assessment
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -50,9 +50,9 @@ def handler(event, context):
         input_key=document.input_key,
         status=Status.ASSESSING,
     )
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {status.status}")
-    appsync_service.update_document(status)
+    document_service.update_document(status)
 
     # Initialize assessment service
     assessment_service = assessment.AssessmentService(config=config)

--- a/patterns/pattern-2/src/assessment_function/requirements.txt
+++ b/patterns/pattern-2/src/assessment_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[assessment,appsync]  # assessment module and AppSync with dependencies
+../../lib/idp_common_pkg[assessment,docs_service]  # assessment module and document service with dependencies

--- a/patterns/pattern-2/src/classification_function/index.py
+++ b/patterns/pattern-2/src/classification_function/index.py
@@ -13,7 +13,7 @@ import time
 
 from idp_common import classification, metrics, get_config
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 region = os.environ['AWS_REGION']
@@ -39,9 +39,9 @@ def handler(event, context):
     # Update document status to CLASSIFYING
     document.status = Status.CLASSIFYING
     document.workflow_execution_arn = event.get("execution_arn")
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     if not document.pages:
         error_message = "Document has no pages to classify"
@@ -89,7 +89,7 @@ def handler(event, context):
         
         logger.error(error_message)
         # Update document status in AppSync before raising exception
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         
         # Raise the original exception type if available, otherwise raise generic exception
         if primary_exception:

--- a/patterns/pattern-2/src/classification_function/requirements.txt
+++ b/patterns/pattern-2/src/classification_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[classification,appsync]  # classification module and AppSync with dependencies
+../../lib/idp_common_pkg[classification,docs_service]  # classification module and document service with dependencies

--- a/patterns/pattern-2/src/extraction_function/index.py
+++ b/patterns/pattern-2/src/extraction_function/index.py
@@ -9,7 +9,7 @@ import logging
 
 from idp_common import metrics, get_config, extraction
 from idp_common.models import Document, Section, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -56,9 +56,9 @@ def handler(event, context):
     
     # Update document status to EXTRACTING
     full_document.status = Status.EXTRACTING
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {full_document.status}")
-    appsync_service.update_document(full_document)
+    document_service.update_document(full_document)
        
     # Create a section-specific document by modifying the original document
     section_document = full_document

--- a/patterns/pattern-2/src/extraction_function/requirements.txt
+++ b/patterns/pattern-2/src/extraction_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[extraction,appsync]  # extraction module and AppSync with dependencies
+../../lib/idp_common_pkg[extraction,docs_service]  # extraction module and document service with dependencies

--- a/patterns/pattern-2/src/ocr_function/index.py
+++ b/patterns/pattern-2/src/ocr_function/index.py
@@ -13,7 +13,7 @@ import time
 
 from idp_common import get_config, ocr
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -38,9 +38,9 @@ def handler(event, context):
     # Update document status to OCR and update in AppSync
     document.status = Status.OCR
     document.workflow_execution_arn = event.get("execution_arn")
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     t0 = time.time()
     
@@ -116,7 +116,7 @@ def handler(event, context):
         error_message = f"OCR processing failed for document {document.id}"
         logger.error(error_message)
         # Update status in AppSync before raising exception
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         raise Exception(error_message)
     
     t1 = time.time()

--- a/patterns/pattern-2/src/ocr_function/requirements.txt
+++ b/patterns/pattern-2/src/ocr_function/requirements.txt
@@ -1,3 +1,3 @@
-../../lib/idp_common_pkg[ocr,appsync]  # OCR module and AppSync with dependencies
+../../lib/idp_common_pkg[ocr,docs_service]  # OCR module and document service with dependencies
 numpy>=1.24.0,<2.0.0  # Pin numpy to stable version
 pandas>=1.5.0,<3.0.0  # Pin pandas to stable version

--- a/patterns/pattern-2/src/processresults_function/index.py
+++ b/patterns/pattern-2/src/processresults_function/index.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from idp_common import s3, utils
 from idp_common.models import Document, Page, Section, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -38,9 +38,9 @@ def handler(event, context):
     
     # Update document status to POSTPROCESSING
     document.status = Status.POSTPROCESSING
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     # Clear sections list to rebuild from extraction results
     document.sections = []
@@ -76,7 +76,7 @@ def handler(event, context):
         
     # Update final status in AppSync
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     # Return the completed document with compression
     response = {

--- a/patterns/pattern-2/src/processresults_function/requirements.txt
+++ b/patterns/pattern-2/src/processresults_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[core,appsync]  # core utilities and AppSync with dependencies
+../../lib/idp_common_pkg[core,docs_service]  # core utilities and document service with dependencies

--- a/patterns/pattern-2/src/summarization_function/index.py
+++ b/patterns/pattern-2/src/summarization_function/index.py
@@ -12,7 +12,7 @@ import time
 # Import the SummarizationService from idp_common
 from idp_common import get_config, summarization
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -47,9 +47,9 @@ def handler(event, context):
         
         # Update document status to SUMMARIZING
         document.status = Status.SUMMARIZING
-        appsync_service = DocumentAppSyncService()
+        document_service = create_document_service()
         logger.info(f"Updating document status to {document.status}")
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         
         # Load configuration and create the summarization service
         config = get_config()
@@ -85,9 +85,9 @@ def handler(event, context):
             if 'document' in locals() and document:
                 document.status = Status.FAILED
                 document.status_reason = str(e)
-                appsync_service = DocumentAppSyncService()
+                document_service = create_document_service()
                 logger.info(f"Updating document status to {document.status} due to error")
-                appsync_service.update_document(document)
+                document_service.update_document(document)
         except Exception as status_error:
             logger.error(f"Failed to update document status: {str(status_error)}", exc_info=True)
             

--- a/patterns/pattern-2/src/summarization_function/requirements.txt
+++ b/patterns/pattern-2/src/summarization_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[summarization,appsync]  # summarization and AppSync modules with dependencies
+../../lib/idp_common_pkg[summarization,docs_service]  # summarization and AppSync modules with dependencies

--- a/patterns/pattern-3/src/assessment_function/index.py
+++ b/patterns/pattern-3/src/assessment_function/index.py
@@ -8,7 +8,7 @@ import logging
 
 from idp_common import get_config, assessment
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -50,9 +50,9 @@ def handler(event, context):
         input_key=document.input_key,
         status=Status.ASSESSING,
     )
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {status.status}")
-    appsync_service.update_document(status)
+    document_service.update_document(status)
 
     # Initialize assessment service
     assessment_service = assessment.AssessmentService(config=config)

--- a/patterns/pattern-3/src/assessment_function/requirements.txt
+++ b/patterns/pattern-3/src/assessment_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[assessment,appsync]  # assessment module and AppSync with dependencies
+../../lib/idp_common_pkg[assessment,docs_service]  # assessment module and document service with dependencies

--- a/patterns/pattern-3/src/classification_function/index.py
+++ b/patterns/pattern-3/src/classification_function/index.py
@@ -13,7 +13,7 @@ import time
 
 from idp_common import classification, metrics, get_config
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 region = os.environ['AWS_REGION']
@@ -37,16 +37,16 @@ def handler(event, context):
     # Update document status to CLASSIFYING
     document.status = Status.CLASSIFYING
     document.workflow_execution_arn = event.get("execution_arn")
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     if not document.pages:
         error_message = "Document has no pages to classify"
         logger.error(error_message)
         document.status = Status.FAILED
         document.errors.append(error_message)
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         raise ValueError(error_message)
     
     t0 = time.time()
@@ -95,7 +95,7 @@ def handler(event, context):
         
         logger.error(error_message)
         # Update document status in AppSync before raising exception
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         
         # Raise the original exception type if available, otherwise raise generic exception
         if primary_exception:

--- a/patterns/pattern-3/src/classification_function/requirements.txt
+++ b/patterns/pattern-3/src/classification_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[classification,appsync]  # classification module and AppSync with dependencies
+../../lib/idp_common_pkg[classification,docs_service]  # classification module and document service with dependencies

--- a/patterns/pattern-3/src/extraction_function/index.py
+++ b/patterns/pattern-3/src/extraction_function/index.py
@@ -9,7 +9,7 @@ import logging
 
 from idp_common import metrics, get_config, extraction
 from idp_common.models import Document, Section, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -56,9 +56,9 @@ def handler(event, context):
     
     # Update document status to EXTRACTING
     full_document.status = Status.EXTRACTING
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {full_document.status}")
-    appsync_service.update_document(full_document)
+    document_service.update_document(full_document)
        
     # Create a section-specific document by modifying the original document
     section_document = full_document

--- a/patterns/pattern-3/src/extraction_function/requirements.txt
+++ b/patterns/pattern-3/src/extraction_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[extraction,appsync]  # extraction module and AppSync with dependencies
+../../lib/idp_common_pkg[extraction,docs_service]  # extraction module and document service with dependencies

--- a/patterns/pattern-3/src/ocr_function/index.py
+++ b/patterns/pattern-3/src/ocr_function/index.py
@@ -13,7 +13,7 @@ import time
 
 from idp_common import get_config, ocr
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -38,9 +38,9 @@ def handler(event, context):
     # Update document status to OCR and update in AppSync
     document.status = Status.OCR
     document.workflow_execution_arn = event.get("execution_arn")
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     t0 = time.time()
     
@@ -116,7 +116,7 @@ def handler(event, context):
         error_message = f"OCR processing failed for document {document.id}"
         logger.error(error_message)
         # Update status in AppSync before raising exception
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         raise Exception(error_message)
     
     t1 = time.time()

--- a/patterns/pattern-3/src/ocr_function/requirements.txt
+++ b/patterns/pattern-3/src/ocr_function/requirements.txt
@@ -1,3 +1,3 @@
-../../lib/idp_common_pkg[ocr,appsync]  # OCR module and AppSync with dependencies
+../../lib/idp_common_pkg[ocr,docs_service]  # OCR module and document service with dependencies
 numpy>=1.24.0,<2.0.0  # Pin numpy to stable version
 pandas>=1.5.0,<3.0.0  # Pin pandas to stable version

--- a/patterns/pattern-3/src/processresults_function/index.py
+++ b/patterns/pattern-3/src/processresults_function/index.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from idp_common import s3, utils
 from idp_common.models import Document, Page, Section, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -38,9 +38,9 @@ def handler(event, context):
     
     # Update document status to POSTPROCESSING
     document.status = Status.POSTPROCESSING
-    appsync_service = DocumentAppSyncService()
+    document_service = create_document_service()
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     # Clear sections list to rebuild from extraction results
     document.sections = []
@@ -76,7 +76,7 @@ def handler(event, context):
         
     # Update final status in AppSync
     logger.info(f"Updating document status to {document.status}")
-    appsync_service.update_document(document)
+    document_service.update_document(document)
     
     # Return the completed document with compression
     response = {

--- a/patterns/pattern-3/src/processresults_function/requirements.txt
+++ b/patterns/pattern-3/src/processresults_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[core,appsync]  # core utilities and AppSync with dependencies
+../../lib/idp_common_pkg[core,docs_service]  # core utilities and document service with dependencies

--- a/patterns/pattern-3/src/summarization_function/index.py
+++ b/patterns/pattern-3/src/summarization_function/index.py
@@ -12,7 +12,7 @@ import time
 # Import the SummarizationService from idp_common
 from idp_common import get_config, summarization
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configuration will be loaded in handler function
 
@@ -47,9 +47,9 @@ def handler(event, context):
         
         # Update document status to SUMMARIZING
         document.status = Status.SUMMARIZING
-        appsync_service = DocumentAppSyncService()
+        document_service = create_document_service()
         logger.info(f"Updating document status to {document.status}")
-        appsync_service.update_document(document)
+        document_service.update_document(document)
         
         # Load configuration and create the summarization service
         config = get_config()
@@ -85,9 +85,9 @@ def handler(event, context):
             if 'document' in locals() and document:
                 document.status = Status.FAILED
                 document.status_reason = str(e)
-                appsync_service = DocumentAppSyncService()
+                document_service = create_document_service()
                 logger.info(f"Updating document status to {document.status} due to error")
-                appsync_service.update_document(document)
+                document_service.update_document(document)
         except Exception as status_error:
             logger.error(f"Failed to update document status: {str(status_error)}", exc_info=True)
             

--- a/patterns/pattern-3/src/summarization_function/requirements.txt
+++ b/patterns/pattern-3/src/summarization_function/requirements.txt
@@ -1,1 +1,1 @@
-../../lib/idp_common_pkg[summarization,appsync]  # summarization and AppSync modules with dependencies
+../../lib/idp_common_pkg[summarization,docs_service]  # summarization and AppSync modules with dependencies

--- a/src/lambda/copy_to_baseline_resolver/index.py
+++ b/src/lambda/copy_to_baseline_resolver/index.py
@@ -231,7 +231,7 @@ def update_document_copy_status(object_key, evaluation_status=None):
     try:
         # Import at function level to avoid circular imports
         from idp_common.models import Document, Status
-        from idp_common.appsync.service import DocumentAppSyncService
+        from idp_common.docs_service import create_document_service
         
         logger.info("Imported required modules")
         
@@ -252,16 +252,16 @@ def update_document_copy_status(object_key, evaluation_status=None):
         if not document.metering:
             document.metering = {}
         
-        # Update the document in AppSync
-        logger.info("Creating AppSync service")
-        appsync_service = DocumentAppSyncService()
+        # Update the document in document service
+        logger.info("Creating document service")
+        document_service = create_document_service()
         
         # Check if APPSYNC_API_URL is set in environment
         from os import environ
         logger.info(f"APPSYNC_API_URL from environment: {environ.get('APPSYNC_API_URL')}")
         
-        logger.info("Calling update_document on AppSync service")
-        result = appsync_service.update_document(document)
+        logger.info("Calling update_document on document service")
+        result = document_service.update_document(document)
         logger.info(f"Document update result: {result}")
         
         logger.info(f"Successfully updated document {object_key} with baseline copy status")

--- a/src/lambda/copy_to_baseline_resolver/requirements.txt
+++ b/src/lambda/copy_to_baseline_resolver/requirements.txt
@@ -1,2 +1,2 @@
 # Requirements for copy_to_baseline_resolver Lambda
-./lib/idp_common_pkg[appsync]  # idp_common package with Document model and AppSync integration
+./lib/idp_common_pkg[docs_service]  # idp_common package with Document model and document service integration

--- a/src/lambda/evaluation_function/index.py
+++ b/src/lambda/evaluation_function/index.py
@@ -18,7 +18,7 @@ from typing import Dict, Any, Optional
 
 from idp_common import get_config, evaluation
 from idp_common.models import Document, Status
-from idp_common.appsync.service import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Environment variables
 BASELINE_BUCKET = os.environ.get('BASELINE_BUCKET')
@@ -29,8 +29,8 @@ SAVE_REPORTING_FUNCTION_NAME = os.environ.get('SAVE_REPORTING_FUNCTION_NAME', 'S
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
-# Create AppSync service
-appsync_service = DocumentAppSyncService()
+# Create document service
+document_service = create_document_service()
 
 # Define evaluation status constants
 class EvaluationStatus(Enum):
@@ -41,7 +41,7 @@ class EvaluationStatus(Enum):
 
 def update_document_evaluation_status(document: Document, status: EvaluationStatus) -> Document:
     """
-    Update document evaluation status via AppSync
+    Update document evaluation status via document service
     
     Args:
         document: The Document object to update
@@ -51,12 +51,12 @@ def update_document_evaluation_status(document: Document, status: EvaluationStat
         The updated Document object
         
     Raises:
-        AppSyncError: If the GraphQL operation fails
+        DocumentServiceError: If the operation fails
     """
     document.status = Status.COMPLETED
     document.evaluation_status = status.value
-    logger.info(f"Updating document via AppSync: {document.input_key} with status: {status.value}")
-    return appsync_service.update_document(document)
+    logger.info(f"Updating document via document service: {document.input_key} with status: {status.value}")
+    return document_service.update_document(document)
 
 def extract_document_from_event(event: Dict[str, Any]) -> Optional[Document]:
     """

--- a/src/lambda/evaluation_function/requirements.txt
+++ b/src/lambda/evaluation_function/requirements.txt
@@ -1,1 +1,1 @@
-./lib/idp_common_pkg[evaluation,appsync]  # Evaluation module and AppSync with dependencies
+./lib/idp_common_pkg[evaluation,docs_service]  # Evaluation module and document service with dependencies

--- a/src/lambda/queue_processor/index.py
+++ b/src/lambda/queue_processor/index.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 import logging
 from typing import Dict, Any, Tuple
 from idp_common.models import Document, Status
-from idp_common.appsync import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -18,7 +18,7 @@ logging.getLogger('idp_common.bedrock.client').setLevel(os.environ.get("BEDROCK_
 
 sfn = boto3.client('stepfunctions')
 dynamodb = boto3.resource('dynamodb')
-appsync_service = DocumentAppSyncService()
+document_service = create_document_service()
 concurrency_table = dynamodb.Table(os.environ['CONCURRENCY_TABLE'])
 state_machine_arn = os.environ['STATE_MACHINE_ARN']
 MAX_CONCURRENT = int(os.environ.get('MAX_CONCURRENT', '5'))
@@ -135,8 +135,8 @@ def process_message(record: Dict[str, Any]) -> Tuple[bool, str]:
             # Start workflow with the document
             execution = start_workflow(document)
             
-            # Update document status in AppSync
-            updated_doc = appsync_service.update_document(document)
+            # Update document status in document service
+            updated_doc = document_service.update_document(document)
             logger.info(f"Document updated: {updated_doc}")
             
             return True, message_id

--- a/src/lambda/queue_processor/requirements.txt
+++ b/src/lambda/queue_processor/requirements.txt
@@ -1,1 +1,1 @@
-./lib/idp_common_pkg[appsync]  # idp_common package with Document model and AppSync integration
+./lib/idp_common_pkg[docs_service]  # idp_common package with Document model and document service integration

--- a/src/lambda/queue_sender/index.py
+++ b/src/lambda/queue_sender/index.py
@@ -8,7 +8,7 @@ import json
 from datetime import datetime, timezone, timedelta
 import logging
 from idp_common.models import Document, Status
-from idp_common.appsync import DocumentAppSyncService
+from idp_common.docs_service import create_document_service
 
 # Configure logging
 logger = logging.getLogger()
@@ -18,7 +18,7 @@ logging.getLogger('idp_common.bedrock.client').setLevel(os.environ.get("BEDROCK_
 
 # Initialize clients
 sqs = boto3.client('sqs')
-appsync_service = DocumentAppSyncService()
+document_service = create_document_service()
 queue_url = os.environ['QUEUE_URL']
 retentionDays = int(os.environ['DATA_RETENTION_IN_DAYS'])
 
@@ -43,11 +43,11 @@ def handler(event, context):
     # Calculate expiry date
     expires_after = int((datetime.now(timezone.utc) + timedelta(days=retentionDays)).timestamp())
 
-    # Create document in DynamoDB via AppSync
-    logger.info(f"Creating document via AppSync: {document.input_key}")
+    # Create document in DynamoDB via document service
+    logger.info(f"Creating document via document service: {document.input_key}")
     
-    # Create document in AppSync with TTL
-    created_key = appsync_service.create_document(document, expires_after=expires_after)
+    # Create document in document service with TTL
+    created_key = document_service.create_document(document, expires_after=expires_after)
     logger.info(f"Document created with key: {created_key}")
     
     # Send serialized document to SQS queue

--- a/src/lambda/queue_sender/requirements.txt
+++ b/src/lambda/queue_sender/requirements.txt
@@ -1,1 +1,1 @@
-./lib/idp_common_pkg[appsync]  # idp_common package with Document model and AppSync integration
+./lib/idp_common_pkg[docs_service]  # idp_common package with Document model and document service integration

--- a/src/lambda/workflow_tracker/requirements.txt
+++ b/src/lambda/workflow_tracker/requirements.txt
@@ -1,1 +1,1 @@
-./lib/idp_common_pkg[appsync]  # idp_common package with Document model and AppSync integration
+./lib/idp_common_pkg[docs_service]  # idp_common package with Document model and document service integration


### PR DESCRIPTION
*Description of changes:*
This PR modified `idp_common` in that it now has a factory for using a service to track document processing progress. Before the only option was to use `appsync` module which wrote to the DynamoDB TrackingTable indirectly. With this PR there are two modules `appsync` and `dynamodb` that expose service classes which share the same usage interface. With that, there is added a factory that by default creates an `appsync` module originating service to track document processing progress, but can also create `dynamodb` module originating service. The `dynamodb` choice requires `TRACKING_TABLE` environment variable to be present to instrument the service where to write updates.

This PR does not change the solution behavior, but introduces the change to `idp_common` as well as all AWS Lambda function code to rely on the factory rather than specific (i.e. `appsync`) service implementation. This is a building block that is to be used to allow users a choice for writing document processing progress information.

NOTE: if `dynamodb` is to be selected this means that the change is not going through an AppSync/GraphQL mutation which means that the subscription in the UI would not be triggered. Hence, if `dynamodb` module was selected - the UI will either not have real-time notifications or the real-time notification would need to be recreated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
