### PR TITLE
Remove default variable for BedrockClient.

### DIFF
--- a/lib/idp_common_pkg/idp_common/bedrock/client.py
+++ b/lib/idp_common_pkg/idp_common/bedrock/client.py
@@ -64,7 +64,7 @@ class BedrockClient:
             max_backoff: Maximum backoff time in seconds
             metrics_enabled: Whether to publish metrics
         """
-        self.region = region or os.environ.get('AWS_REGION', 'us-west-2')
+        self.region = region or os.environ.get('AWS_REGION')
         self.max_retries = max_retries
         self.initial_backoff = initial_backoff
         self.max_backoff = max_backoff


### PR DESCRIPTION
#27 

Remove the default region passed to the BedrockClient during initialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
