### PR TITLE
DRAFT: Add Embeddable Chatbot for Bedrock Knowledge Base

### DIFF
--- a/options/chatbot/README.md
+++ b/options/chatbot/README.md
@@ -1,0 +1,170 @@
+# Embeddable Chatbot for Amazon Bedrock Knowledge Base
+
+This guide provides all the necessary steps to deploy and integrate a secure, embeddable chat widget into your web application. The widget uses Amazon Lex V2 and a secure API Gateway backend to connect to your **existing** Amazon Bedrock Knowledge Base.
+
+## Architecture Overview
+
+The solution consists of three main parts:
+
+1.  **AWS Backend (CloudFormation)**: The provided `template.yaml` deploys an AWS Lambda, an Amazon API Gateway, and an Amazon Lex V2 bot. This creates a secure API endpoint that connects to your Bedrock Knowledge Base.
+2.  **Secure Authentication**: Access to the API is secured using a JSON Web Token (JWT). Your application's backend server will generate this token to authorize the frontend widget to communicate with the chatbot API.
+3.  **Frontend Widget**: The chat interface is powered by the open-source [AWS Lex Web UI](https://github.com/aws-samples/aws-lex-web-ui), which is embedded into your website.
+
+![Architecture Diagram](https://user-images.githubusercontent.com/12977329/222872332-9c16969b-92aa-450c-9120-2e0de795e691.png)
+
+---
+
+## 1. Deployment Steps
+
+### Prerequisites
+
+*   An AWS Account with permissions to create the resources in the template.
+*   The **AWS CLI** installed and configured.
+*   The **ID of your existing Amazon Bedrock Knowledge Base**.
+*   **Node.js** and **npm** installed on your backend server to generate the JWT.
+
+### Deploying the CloudFormation Stack
+
+1.  **Choose a Strong JWT Secret**: Create a secure, random string that is at least 32 characters long. You can use a password generator for this. This secret will be used to sign and verify authentication tokens.
+
+2.  **Deploy via AWS CLI**: Open your terminal and run the following command. Replace the placeholder values with your own.
+
+    ```bash
+    aws cloudformation deploy \
+      --template-file template.yaml \
+      --stack-name bedrock-chat-widget \
+      --parameter-overrides \
+        BedrockKnowledgeBaseId="YOUR_KB_ID_HERE" \
+        JwtSecret="YOUR_STRONG_JWT_SECRET_HERE" \
+      --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+      --region us-east-1 # Or your preferred AWS region
+    ```
+
+3.  **Get API Endpoint from Outputs**: Once the deployment is complete, go to the AWS CloudFormation console, select your stack (`bedrock-chat-widget`), and navigate to the **Outputs** tab. Copy the value for `ChatEndpointURL`. You will need this for the frontend integration.
+
+---
+
+## 2. Backend Integration: JWT Generation (Crucial Security Step)
+
+To prevent unauthorized use of your chatbot API, the chat widget must be initialized with a short-lived JSON Web Token (JWT). Your application's backend server is responsible for generating this token.
+
+Here is a sample implementation in **Node.js**.
+
+1.  **Install the library**:
+    ```bash
+    npm install jsonwebtoken
+    ```
+
+2.  **Create a token generation function**: Add this code to your backend, for example, in an API route that is called by your frontend when the page loads.
+
+    ```javascript
+    // Example: /pages/api/generate-token.js
+    const jwt = require('jsonwebtoken');
+
+    // IMPORTANT: Use the SAME secret you provided during CloudFormation deployment.
+    // Best practice is to store this in an environment variable (e.g., process.env.JWT_SECRET).
+    const JWT_SECRET = "YOUR_STRONG_JWT_SECRET_HERE";
+
+    /**
+     * Generates a short-lived JWT for the chat widget.
+     * @param {string} userId - A unique identifier for the user.
+     * @returns {string} The generated JWT.
+     */
+    function generateChatToken(userId) {
+      const payload = {
+        // 'sub' (subject) is a standard JWT claim for the user ID.
+        // You can add other relevant, non-sensitive data here.
+        sub: userId,
+      };
+
+      const options = {
+        // The token will expire in 15 minutes. The widget should request a
+        // new token if the session lasts longer.
+        expiresIn: '15m',
+      };
+
+      const token = jwt.sign(payload, JWT_SECRET, options);
+      return token;
+    }
+
+    // --- Example Usage ---
+    // In your authenticated API route, generate a token for the logged-in user.
+    const user = { id: 'user-12345' }; // Get the user from your session
+    const chatToken = generateChatToken(user.id);
+
+    // Send the token to the frontend
+    // res.status(200).json({ token: chatToken });
+    console.log('Generated Token:', chatToken);
+    ```
+
+---
+
+## 3. Frontend Embedding
+
+Embed the official `aws-lex-web-ui` component into your website's HTML. The following snippet includes the necessary configuration to connect to your new API Gateway endpoint and send the JWT for authentication.
+
+1.  **Fetch the Token**: Your frontend code should first make a request to your backend to get the `chatToken` generated in the previous step.
+
+2.  **Add the HTML Snippet**: Place this code in your HTML file where you want the chat widget to appear.
+
+    ```html
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>My Application</title>
+      <!-- The loader script for the AWS Lex Web UI -->
+      <script src="https://assets.amazonaws.com/connect-assets/lex-web-ui-loader.min.js"></script>
+    </head>
+    <body>
+      <h1>Welcome to my website</h1>
+      <p>Ask a question in the chat widget!</p>
+
+      <script>
+        // This function runs once the loader script is ready.
+        function onLexWebUiReady() {
+          // STEP 1: Fetch the JWT from your backend.
+          // This is an example using fetch. Replace with your actual API endpoint.
+          fetch('/api/generate-token') // Assumes you created this backend route
+            .then(response => response.json())
+            .then(data => {
+              const jwtToken = data.token;
+
+              // Configuration for the Lex Web UI
+              const config = {
+                ui: {
+                  // The title of the chat window
+                  toolbarTitle: 'Company Support',
+                  // You can disable the initial welcome message from the UI
+                  // since our bot has its own greetings.
+                  shouldShowIntroMessage: false,
+                },
+                aws: {
+                  // The API Gateway endpoint for your chatbot
+                  apiGateway: {
+                    invokeUrl: 'YOUR_CHAT_ENDPOINT_URL_HERE', // <-- PASTE THE URL FROM CLOUDFORMATION OUTPUTS
+                    // IMPORTANT: This passes the JWT to the API Gateway Authorizer
+                    customHeaders: {
+                      Authorization: 'Bearer ' + jwtToken,
+                    }
+                  }
+                }
+              };
+
+              // Instantiate the chat widget with the configuration
+              window.LexWebUi.newChat(config);
+            })
+            .catch(console.error);
+        }
+
+        // Add the function as an event listener
+        document.addEventListener('lexWebUiReady', onLexWebUiReady, false);
+      </script>
+    </body>
+    </html>
+    ```
+
+3.  **Final Configuration**:
+    *   Replace `YOUR_CHAT_ENDPOINT_URL_HERE` with the `ChatEndpointURL` value from your CloudFormation stack's outputs.
+    *   Ensure the `fetch` URL (`/api/generate-token`) matches the actual API endpoint you created on your backend for generating JWTs.
+
+You have now successfully deployed and integrated a secure, AI-powered chatbot into your website!

--- a/options/chatbot/template.yaml
+++ b/options/chatbot/template.yaml
@@ -1,0 +1,337 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Embeddable Chatbot solution using an existing Amazon Bedrock Knowledge Base.
+  This template provisions a Lex V2 Bot, an API Gateway with a Lambda proxy,
+  and a JWT-based Lambda Authorizer for secure frontend integration.
+
+Parameters:
+  BedrockKnowledgeBaseId:
+    Type: String
+    Description: The ID of the existing Amazon Bedrock Knowledge Base.
+    AllowedPattern: '^[A-Z0-9]{10}$'
+    ConstraintDescription: Must be a valid Bedrock Knowledge Base ID (e.g., ABC123DEFG).
+
+  JwtSecret:
+    Type: String
+    NoEcho: true
+    Description: A strong secret key for signing and verifying JWTs. Minimum 32 characters.
+    MinLength: 32
+    ConstraintDescription: Must be at least 32 characters long.
+
+Resources:
+  # IAM Role for the Lex Bot to access the Bedrock Knowledge Base
+  LexBotRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lex.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: BedrockKnowledgeBasePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: bedrock:RetrieveAndGenerate
+                Resource: !Sub 'arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:knowledge-base/${BedrockKnowledgeBaseId}'
+              # It's a best practice to also grant Kendra permissions as Bedrock KBs often use Kendra indexes.
+              - Effect: Allow
+                Action:
+                  - kendra:Query
+                  - kendra:Retrieve
+                Resource: !Sub 'arn:${AWS::Partition}:kendra:${AWS::Region}:${AWS::AccountId}:index/*'
+
+  # Lex V2 Bot configured with Bedrock Knowledge Base Fulfillment
+  LexBot:
+    Type: AWS::Lex::Bot
+    Properties:
+      Name: !Sub '${AWS::StackName}-BedrockKB-Bot'
+      DataPrivacy:
+        ChildDirected: false
+      IdleSessionTTLInSeconds: 300
+      RoleArn: !GetAtt LexBotRole.Arn
+      BotLocales:
+        - LocaleId: en_US
+          NluConfidenceThreshold: 0.40
+          Intents:
+            - Name: AMAZON.QnAIntent
+              Description: 'The primary intent to query the Bedrock Knowledge Base.'
+              ParentIntentSignature: AMAZON.QnAIntent
+              FulfillmentCodeHook:
+                Enabled: true
+                FulfillmentUpdatesSpecification:
+                  Active: true
+                  StartResponse:
+                    AllowInterrupt: true
+                    MessageGroups:
+                      - Message:
+                          PlainTextMessage:
+                            Value: "Searching for an answer..."
+                PostFulfillmentStatusSpecification:
+                  SuccessResponse:
+                    AllowInterrupt: true
+                    MessageGroups:
+                      - Message:
+                          PlainTextMessage:
+                            Value: "Let me know if you have other questions."
+              CodeHook:
+                IsActive: true
+                CodeHookInterface:
+                  Name: 'AMAZON.BedrockKnowledgeBase'
+                  Version: '1.0'
+                  LambdaArn: !Sub 'arn:${AWS::Partition}:lex:${AWS::Region}::kendra-search-bot' # This is a placeholder required by the schema but Bedrock manages the connection.
+              InitialResponseSetting:
+                CodeHook:
+                  IsActive: true
+                  CodeHookInterface:
+                    Name: 'AMAZON.BedrockKnowledgeBase'
+                    Version: '1.0'
+                    LambdaArn: !Sub 'arn:${AWS::Partition}:lex:${AWS::Region}::kendra-search-bot'
+                  InvocationLabel: 'Querying Knowledge Base'
+              InputContexts:
+                - Name: 'AMAZON.QnAIntent.Input'
+              OutputContexts:
+                - Name: 'AMAZON.QnAIntent.Output'
+                  TimeToLiveInSeconds: 300
+                  TurnsToLive: 5
+              KendraConfiguration:
+                KnowledgeBaseId: !Ref BedrockKnowledgeBaseId
+                QueryFilterStringEnabled: true
+                QueryFilterString: ''
+
+  LexBotAlias:
+    Type: AWS::Lex::BotAlias
+    Properties:
+      BotAliasName: 'live'
+      BotId: !GetAtt LexBot.Id
+
+  # IAM Role for the Authorizer Lambda
+  AuthorizerLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+
+  # Lambda function for JWT Authorization
+  AuthorizerLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-JwtAuthorizer'
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Role: !GetAtt AuthorizerLambdaRole.Arn
+      Environment:
+        Variables:
+          JWT_SECRET: !Ref JwtSecret
+      Code:
+        ZipFile: |
+          const jwt = require('jsonwebtoken');
+
+          exports.handler = async (event) => {
+            const token = event.headers.authorization?.split(' ')[1];
+
+            if (!token) {
+              return { statusCode: 401, body: 'Unauthorized' };
+            }
+
+            try {
+              const decoded = jwt.verify(token, process.env.JWT_SECRET);
+              // Successful verification
+              return {
+                isAuthorized: true,
+                principalId: decoded.sub || 'user',
+                context: {
+                  // You can pass additional context to the backend lambda here
+                  userId: decoded.sub,
+                },
+              };
+            } catch (err) {
+              console.error('JWT Verification Error:', err);
+              return { isAuthorized: false };
+            }
+          };
+
+  # IAM Role for the Lex Proxy Lambda
+  LexProxyLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: LexRecognizeTextPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: lex:RecognizeText
+                Resource: !GetAtt LexBotAlias.Arn
+
+  # Lambda function to proxy requests to Lex
+  LexProxyLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-LexProxy'
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Role: !GetAtt LexProxyLambdaRole.Arn
+      Environment:
+        Variables:
+          LEX_BOT_ID: !Ref LexBot
+          LEX_BOT_ALIAS_ID: !GetAtt LexBotAlias.BotAliasId
+          LEX_LOCALE_ID: 'en_US'
+      Code:
+        ZipFile: |
+          const { LexRuntimeV2Client, RecognizeTextCommand } = require('@aws-sdk/client-lex-runtime-v2');
+          const client = new LexRuntimeV2Client({});
+
+          exports.handler = async (event) => {
+            try {
+              const { message, sessionId } = JSON.parse(event.body);
+
+              if (!message || !sessionId) {
+                return {
+                  statusCode: 400,
+                  headers: { "Access-Control-Allow-Origin": "*" },
+                  body: JSON.stringify({ error: 'Missing message or sessionId' }),
+                };
+              }
+
+              const command = new RecognizeTextCommand({
+                botId: process.env.LEX_BOT_ID,
+                botAliasId: process.env.LEX_BOT_ALIAS_ID,
+                localeId: process.env.LEX_LOCALE_ID,
+                sessionId: sessionId,
+                text: message,
+              });
+
+              const response = await client.send(command);
+
+              return {
+                statusCode: 200,
+                headers: { "Access-Control-Allow-Origin": "*" },
+                body: JSON.stringify(response.messages),
+              };
+            } catch (error) {
+              console.error('Error proxying to Lex:', error);
+              return {
+                statusCode: 500,
+                headers: { "Access-Control-Allow-Origin": "*" },
+                body: JSON.stringify({ error: 'Failed to communicate with the chatbot.' }),
+              };
+            }
+          };
+
+  # API Gateway REST API
+  ChatApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Sub '${AWS::StackName}-ChatbotApi'
+      Description: 'API for the Bedrock KB Chatbot'
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+
+  ApiGatewayAuthorizer:
+    Type: AWS::ApiGateway::Authorizer
+    Properties:
+      Name: !Sub '${AWS::StackName}-JwtAuthorizer'
+      RestApiId: !Ref ChatApi
+      Type: REQUEST
+      AuthorizerUri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizerLambda.Arn}/invocations'
+      IdentitySource: 'method.request.header.Authorization'
+      AuthorizerResultTtlInSeconds: 300
+
+  ChatResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt ChatApi.RootResourceId
+      PathPart: 'chat'
+      RestApiId: !Ref ChatApi
+
+  ChatMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref ChatApi
+      ResourceId: !Ref ChatResource
+      HttpMethod: POST
+      AuthorizationType: CUSTOM
+      AuthorizerId: !Ref ApiGatewayAuthorizer
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LexProxyLambda.Arn}/invocations'
+
+  ApiGatewayCors:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref ChatApi
+      ResourceId: !Ref ChatResource
+      HttpMethod: OPTIONS
+      AuthorizationType: NONE
+      Integration:
+        Type: MOCK
+        RequestTemplates:
+          'application/json': '{ "statusCode": 200 }'
+        IntegrationResponses:
+          - StatusCode: 200
+            ResponseParameters:
+              'method.response.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              'method.response.header.Access-Control-Allow-Methods': "'OPTIONS,POST'"
+              'method.response.header.Access-control-allow-origin': "'*'"
+            ResponseTemplates:
+              'application/json': ''
+      MethodResponses:
+        - StatusCode: 200
+          ResponseParameters:
+            'method.response.header.Access-Control-Allow-Headers': true
+            'method.response.header.Access-Control-Allow-Methods': true
+            'method.response.header.Access-control-allow-origin': true
+
+  # Permissions for API Gateway to invoke the Lambda functions
+  AuthorizerLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt AuthorizerLambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ChatApi}/*'
+
+  LexProxyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt LexProxyLambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ChatApi}/*'
+
+Outputs:
+  ApiGatewayInvokeURL:
+    Description: 'The invoke URL for the API Gateway endpoint.'
+    Value: !Sub 'https://${ChatApi}.execute-api.${AWS::Region}.amazonaws.com/prod' # Assuming a 'prod' stage
+  ChatEndpointURL:
+    Description: 'The full URL for the /chat endpoint.'
+    Value: !Sub 'https://${ChatApi}.execute-api.${AWS::Region}.amazonaws.com/prod/chat'
+  LexBotId:
+    Description: 'The ID of the created Lex Bot.'
+    Value: !Ref LexBot
+  LexBotAliasId:
+    Description: 'The Alias ID of the created Lex Bot.'
+    Value: !GetAtt LexBotAlias.BotAliasId


### PR DESCRIPTION
## What
Secure chatbot widget that connects to existing Bedrock Knowledge Base via Lex V2.

## Files
- `template.yaml` - CloudFormation stack (Lex bot + API Gateway + Lambda auth)
- `README.md` - Deployment guide with JWT auth setup

## Architecture
Widget → API Gateway (JWT auth) → Lambda → Lex → Bedrock KB

## Deploy
```bash
aws cloudformation deploy --template-file template.yaml \
  --stack-name bedrock-chat-widget \
  --parameter-overrides BedrockKnowledgeBaseId="YOUR_KB_ID" JwtSecret="32char_secret" \
  --capabilities CAPABILITY_IAM
```

## Questions
1. Good for production use?
2. Security model acceptable?