### PR TITLE
Added new infra needed for API method of IDP invocation

### DIFF
--- a/src/lambda/jobs_api/index.py
+++ b/src/lambda/jobs_api/index.py
@@ -1,0 +1,98 @@
+from fastapi import FastAPI, HTTPException
+from mangum import Mangum
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+app = FastAPI()
+
+
+class Metadata(BaseModel):
+    source: str
+
+
+class Files(BaseModel):
+    pdfFileName: str
+    jsonFileName: str
+
+
+class UploadInfo(BaseModel):
+    bucket: str
+    keyPrefix: str
+    uploadUrl: str
+    expiresInSeconds: int
+    requiredHeaders: Dict[str, str]
+
+
+class Timestamps(BaseModel):
+    createdAt: str
+    updatedAt: str
+
+
+class Progress(BaseModel):
+    stage: str
+    percent: int
+
+
+class Result(BaseModel):
+    bucket: str
+    key: str
+    downloadUrl: str
+    expiresInSeconds: int
+
+
+class PostJobRequest(BaseModel):
+    documentType: str
+    metadata: Metadata
+    files: Files
+
+
+class PostJobResponse(BaseModel):
+    jobId: str
+    upload: UploadInfo
+
+
+class GetJobResponse(BaseModel):
+    jobId: str
+    status: str
+    timestamps: Timestamps
+    progress: Progress
+    result: Optional[Result] = None
+    error: Optional[str] = None
+
+
+@app.post("/jobs", response_model=PostJobResponse)
+async def create_job(job: PostJobRequest):
+    """Create a new job"""
+    # TODO: Implement job creation logic
+    job_id = "job-12345"  # Placeholder
+    return PostJobResponse(
+        jobId=job_id,
+        upload=UploadInfo(
+            bucket="idp-input-bucket",
+            keyPrefix=f"jobs/{job_id}/input/",
+            uploadUrl="https://s3-presigned-url-placeholder",
+            expiresInSeconds=604800,
+            requiredHeaders={
+                "x-amz-server-side-encryption": "aws:kms"
+            }
+        )
+    )
+
+
+@app.get("/jobs/{job_id}")
+async def get_job(job_id: str) -> Dict[str, Any]:
+    """Get job status by ID"""
+    # TODO: Implement job retrieval logic
+    # - Query DynamoDB TrackingTable by job_id
+    if not job_id:
+        raise HTTPException(status_code=400, detail="Job ID is required")
+    
+    return {
+        "job_id": job_id,
+        "status": "running",
+        "documentType": "Package",
+        "metadata": {}
+    }
+
+
+handler = Mangum(app)

--- a/src/lambda/jobs_api/requirements.txt
+++ b/src/lambda/jobs_api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+mangum
+pydantic

--- a/template.yaml
+++ b/template.yaml
@@ -411,6 +411,22 @@ Parameters:
     AllowedPattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]{1,2}(,\s*([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]{1,2})*$'
     ConstraintDescription: Must be valid comma-separated list of IPv4 CIDR ranges
 
+  # Jobs API VPC Configuration
+  VpcId:
+    Type: String
+    Default: ""
+    Description: Optional - Existing VPC ID for Jobs API deployment (leave blank to skip Jobs API deployment)
+
+  PrivateSubnetIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Optional - Comma-separated list of at least 2 private subnet IDs in different AZs (required if VpcId is provided)
+
+  VpcEndpointId:
+    Type: String
+    Default: ""
+    Description: Optional - Existing VPC Endpoint ID for execute-api service (required if VpcId is provided)
+
 Rules:
   Pattern3UDOPModelArtifactPath:
     RuleCondition:
@@ -423,6 +439,8 @@ Rules:
         AssertDescription: UDOP Model Artifact Path is required when IDPPattern is 'Pattern1'
 
 Conditions:
+  DeployJobsApi: !Not [!Equals [!Ref VpcId, ""]]
+  
   IsPattern1:
     !Equals [
       !Ref IDPPattern,
@@ -677,6 +695,165 @@ Resources:
       ServiceToken: !GetAtt StacknameCheckFunction.Arn
       InputString: !Ref "AWS::StackName"
       MaxLength: 25
+
+  JobsApiSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: DeployJobsApi
+    Properties:
+      GroupDescription: Security group for Jobs API Lambda
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: !Sub ${AWS::StackName}-JobsApiSG
+
+  JobsApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: DeployJobsApi
+    Properties:
+      KmsKeyId: !GetAtt CustomerManagedEncryptionKey.Arn
+      RetentionInDays: !Ref LogRetentionDays
+
+  JobsApiFunction:
+    Type: AWS::Serverless::Function
+    Condition: DeployJobsApi
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W92
+            reason: Reserved concurrency not required
+    Properties:
+      PermissionsBoundary:
+        !If [
+          HasPermissionsBoundary,
+          !Ref PermissionsBoundaryArn,
+          !Ref AWS::NoValue,
+        ]
+      CodeUri: src/lambda/jobs_api/
+      Handler: index.handler
+      Runtime: python3.12
+      MemorySize: 512
+      Timeout: 30
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref JobsApiSecurityGroup
+        SubnetIds: !Ref PrivateSubnetIds
+      Environment:
+        Variables:
+          LOG_LEVEL: !Ref LogLevel
+          TRACKING_TABLE_NAME: !Ref TrackingTable
+          INPUT_BUCKET_NAME: !Ref InputBucket
+      LoggingConfig:
+        LogGroup: !Ref JobsApiLogGroup
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TrackingTable
+        - S3CrudPolicy:
+            BucketName: !Ref InputBucket
+        - Statement:
+            - Effect: Allow
+              Action:
+                - kms:Encrypt
+                - kms:Decrypt
+                - kms:ReEncrypt*
+                - kms:GenerateDataKey*
+                - kms:DescribeKey
+              Resource: !GetAtt CustomerManagedEncryptionKey.Arn
+
+  JobsApi:
+    Type: AWS::ApiGateway::RestApi
+    Condition: DeployJobsApi
+    Properties:
+      Name: !Sub ${AWS::StackName}-JobsApi
+      EndpointConfiguration:
+        Types:
+          - PRIVATE
+        VpcEndpointIds:
+          - !Ref VpcEndpointId
+      Policy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Principal: '*'
+            Action: execute-api:Invoke
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce: !Ref VpcEndpointId
+          - Effect: Allow
+            Principal: '*'
+            Action: execute-api:Invoke
+            Resource: '*'
+
+  JobsApiDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Condition: DeployJobsApi
+    DependsOn:
+      - JobsApiPostMethod
+      - JobsApiGetMethod
+    Properties:
+      RestApiId: !Ref JobsApi
+
+  JobsApiStage:
+    Type: AWS::ApiGateway::Stage
+    Condition: DeployJobsApi
+    Properties:
+      RestApiId: !Ref JobsApi
+      DeploymentId: !Ref JobsApiDeployment
+      StageName: prod
+
+  JobsApiResource:
+    Type: AWS::ApiGateway::Resource
+    Condition: DeployJobsApi
+    Properties:
+      RestApiId: !Ref JobsApi
+      ParentId: !GetAtt JobsApi.RootResourceId
+      PathPart: jobs
+
+  JobsApiJobIdResource:
+    Type: AWS::ApiGateway::Resource
+    Condition: DeployJobsApi
+    Properties:
+      RestApiId: !Ref JobsApi
+      ParentId: !Ref JobsApiResource
+      PathPart: '{job_id}'
+
+  JobsApiPostMethod:
+    Type: AWS::ApiGateway::Method
+    Condition: DeployJobsApi
+    Properties:
+      RestApiId: !Ref JobsApi
+      ResourceId: !Ref JobsApiResource
+      HttpMethod: POST
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JobsApiFunction.Arn}/invocations
+
+  JobsApiGetMethod:
+    Type: AWS::ApiGateway::Method
+    Condition: DeployJobsApi
+    Properties:
+      RestApiId: !Ref JobsApi
+      ResourceId: !Ref JobsApiJobIdResource
+      HttpMethod: GET
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${JobsApiFunction.Arn}/invocations
+
+  JobsApiLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Condition: DeployJobsApi
+    Properties:
+      FunctionName: !Ref JobsApiFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${JobsApi}/*
 
   ConfigurationCopyFunction:
     Type: AWS::Serverless::Function
@@ -6961,3 +7138,7 @@ Outputs:
     Condition: CreateAgentCoreLambda
     Description: MCP Authorization URL
     Value: !Sub "https://${GetDomain.OutputString}.auth.${AWS::Region}.amazoncognito.com/oauth2/authorize"
+  JobsApiEndpoint:
+    Condition: DeployJobsApi
+    Description: Jobs API endpoint URL
+    Value: !Sub "https://${JobsApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/prod"


### PR DESCRIPTION
*Description of changes:* 
- Added Support for provisioning Private API GW and Lambda when VPCId,  subnets, and vpce are provided while running deployment script. 
- Added basic placeholder lambda logic for new endpoints with expected Request/Response models defined

Example of CLI command which will also deploy new infra:
```
 aws cloudformation deploy \
  --template-file .aws-sam/idp-govcloud.yaml \
  --stack-name my-idp-govcloud-stack \
  --region us-gov-west-1 \
  --s3-bucket development-bucket-govcloud-us-gov-west-1 \
  --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
  --parameter-overrides \
    IDPPattern="Pattern2 - Packet processing with Textract and Bedrock" \
    VpcId=vpc-0132de0f92f84360c \
    PrivateSubnetIds=subnet-06802171f650d1a48,subnet-0c4103fa37f4939bc,subnet-0cd54f3651e93e3ee \
    VpcEndpointId=vpce-03ed3b06f7d1cb41c
```

Note: I need to update the Readme with these steps as well AFAIK there are other readme updates that have not been merged in yet. To avoid merge conflict I have held off on those chanages.

*Testing*
Successfully Deployed this to development gov cloud account and validated that infra is deployed successfully

<img width="1695" height="543" alt="Screenshot 2026-01-21 at 10 31 22 AM" src="https://github.com/user-attachments/assets/321f3ebc-354d-468f-a167-9442b63bf2d1" />

<img width="1727" height="489" alt="Screenshot 2026-01-21 at 10 31 48 AM" src="https://github.com/user-attachments/assets/43edaca2-a0bd-4ef2-a75f-daf9c2c61ebc" />
<img width="1746" height="582" alt="Screenshot 2026-01-21 at 10 32 42 AM" src="https://github.com/user-attachments/assets/9e01e331-7ca0-44df-894c-1aafce27566d" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
