### PR TITLE
tiny fix for parsing --lint option in publish.py

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -467,6 +467,7 @@ STDERR:
                     self.print_usage()
                     sys.exit(1)
                 self.lint_enabled = lint_value == "on"
+                i += 1 #increment arg counter to avoid parsing "on/off" as an arg of its own
             elif arg == "--clean-build":
                 self.clean_checksums()
             else:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Tiny change to improve parsing of `--lint on|off` which should avoid parsing the `on|off` flag as its own argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
