### PR TITLE
feat(ui): replace native file input with Cloudscape FileUpload component

### DIFF
--- a/src/ui/src/components/upload-document/UploadDocumentPanel.jsx
+++ b/src/ui/src/components/upload-document/UploadDocumentPanel.jsx
@@ -3,7 +3,17 @@
 
 // src/components/upload-document/UploadDocumentPanel.jsx
 import React, { useState } from 'react';
-import { Button, Container, Header, SpaceBetween, FormField, StatusIndicator, Alert, Input } from '@cloudscape-design/components';
+import {
+  Button,
+  Container,
+  Header,
+  SpaceBetween,
+  FormField,
+  StatusIndicator,
+  Alert,
+  Input,
+  FileUpload,
+} from '@cloudscape-design/components';
 import { generateClient } from 'aws-amplify/api';
 
 import uploadDocument from '../../graphql/queries/uploadDocument';
@@ -28,8 +38,8 @@ const UploadDocumentPanel = () => {
     );
   }
 
-  const handleFileChange = (e) => {
-    setSelectedFiles(Array.from(e.target.files));
+  const handleFileChange = (files) => {
+    setSelectedFiles(files);
     setUploadStatus([]);
     setError(null);
   };
@@ -151,8 +161,25 @@ const UploadDocumentPanel = () => {
           <Input value={prefix} onChange={handlePrefixChange} placeholder="Leave empty for root folder" disabled={isUploading} />
         </FormField>
 
-        <FormField label="Select files to upload">
-          <input type="file" multiple onChange={handleFileChange} disabled={isUploading} />
+        <FormField label="Select files to upload" constraintText="Supported formats: PDF, PNG, JPEG, TIFF. Multiple files allowed.">
+          <FileUpload
+            onChange={({ detail }) => handleFileChange(detail.value)}
+            value={selectedFiles}
+            i18nStrings={{
+              uploadButtonText: (multiple) => (multiple ? 'Choose files' : 'Choose file'),
+              dropzoneText: (multiple) => (multiple ? 'Drop files to upload' : 'Drop file to upload'),
+              removeFileAriaLabel: (fileIndex) => `Remove file ${fileIndex + 1}`,
+              errorIconAriaLabel: 'Error',
+              warningIconAriaLabel: 'Warning',
+            }}
+            accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif"
+            multiple
+            showFileSize
+            showFileLastModified
+            showFileThumbnail
+            tokenLimit={10}
+            disabled={isUploading}
+          />
         </FormField>
 
         <Button variant="primary" onClick={uploadFiles} loading={isUploading} disabled={selectedFiles.length === 0 || isUploading}>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replace the native HTML `<input type="file">` in `UploadDocumentPanel.jsx` with Cloudscape's `FileUpload`  component for a more consistent and clean UI.

  Changes:
  - Added `FileUpload` to Cloudscape imports
  - Updated `handleFileChange` to work with `FileUpload`'s value format
  - Configured FileUpload with drag-and-drop, file tokens, and metadata display

  Benefits:
  - Drag-and-drop file selection
  - Visual file tokens with remove buttons
  - File metadata display (size, last modified, thumbnails for images)
  - Constraint text showing supported formats (PDF, PNG, JPEG, TIFF)
  - Proper accessibility labels
  - Consistent Cloudscape styling with the rest of the UI

Reference Images from PR (locally):

<img width="1203" height="676" alt="image" src="https://github.com/user-attachments/assets/d62dac92-114c-429c-90b7-742e9396c569" />

<img width="1203" height="676" alt="image" src="https://github.com/user-attachments/assets/9a30e500-609c-422c-a1d9-82fb72d8920f" />

<img width="1145" height="346" alt="image" src="https://github.com/user-attachments/assets/dfc9e528-cb1b-46e0-9953-bb6d46079870" />
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
