### PR TITLE
Fix: Schema Builder few-shot examples input focus loss (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ SPDX-License-Identifier: MIT-0
 
 ### Fixed
 
+- **Schema Builder Few-Shot Examples Input Focus Loss** - [GitHub Issue #174](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/174)
+  - Fixed cursor jumping out of input fields after each keystroke when editing few-shot examples in the Schema Builder
+
+
 - **Code Intelligence Agent - DeepWiki MCP Transport Migration**
   - Fixed "client initialization failed" error when using Code Intelligence Agent in Agent Companion Chat
   - **Root Cause**: DeepWiki deprecated their SSE transport endpoint (`/sse`) and now returns HTTP 410 Gone

--- a/src/ui/src/components/json-schema-builder/constraints/ExamplesEditor.jsx
+++ b/src/ui/src/components/json-schema-builder/constraints/ExamplesEditor.jsx
@@ -29,6 +29,7 @@ const ExamplesEditor = ({ examples = [], onChange }) => {
 
   const handleAddExample = () => {
     const newExample = {
+      id: crypto.randomUUID(),
       name: `Example ${examples.length + 1}`,
       classPrompt: '',
       attributesPrompt: '',
@@ -93,13 +94,11 @@ const ExamplesEditor = ({ examples = [], onChange }) => {
       </Box>
 
       {examples.map((example, index) => {
-        // Generate a stable unique key from example properties
-        const uniqueKey = `${example.name || 'unnamed'}-${example.imagePath || 'noimage'}-${
-          example.classPrompt?.substring(0, 20) || 'noprompt'
-        }`;
+        // Use stable ID as key to prevent focus loss on content changes
+        const stableKey = example.id || `example-${index}`;
         return (
           <ExpandableSection
-            key={uniqueKey}
+            key={stableKey}
             headerText={example.name || `Example ${index + 1}`}
             expanded={expandedSections[index] || false}
             onChange={() => toggleSection(index)}


### PR DESCRIPTION
## Summary

Fixes cursor jumping out of input fields after each keystroke when editing few-shot examples in the Schema Builder.

**Closes #174**

## Root Cause

The React `key` for each `ExpandableSection` in `ExamplesEditor.jsx` was derived from the example's own content (`name`, `imagePath`, `classPrompt`). Every keystroke mutated the key, causing React to unmount/remount the component and destroy the focused input element.

## Changes

**`src/ui/src/components/json-schema-builder/constraints/ExamplesEditor.jsx`**
- Added stable `id` field (via `crypto.randomUUID()`) to each newly created example
- Replaced content-derived key with `example.id || \`example-${index}\`` — stable across re-renders, with fallback for pre-existing examples without an `id`

## Impact

- All input fields in few-shot examples (Example Name, Classification Prompt, Image Path) now retain focus during typing
- The `id` field is harmless if serialized to config — the backend uses `.get()` dictionary access and ignores unknown fields
- Backwards compatible — pre-existing examples without `id` fall back to index-based keys