### PR TITLE
fix: Add compression support to 3 Lambdas with direct DynamoDB config access

### DIFF
--- a/nested/appsync/src/lambda/chat_with_document_resolver/index.py
+++ b/nested/appsync/src/lambda/chat_with_document_resolver/index.py
@@ -86,6 +86,7 @@ def get_full_text(bucket, key):
 def get_summarization_model():
     """Get the summarization model from configuration table"""
     try:
+        from idp_common.config.configuration_manager import ConfigurationManager
         dynamodb = boto3.resource('dynamodb')
         config_table = dynamodb.Table(os.environ['CONFIGURATION_TABLE_NAME'])
         
@@ -95,7 +96,8 @@ def get_summarization_model():
         )
         
         if 'Item' in response:
-            config_data = response['Item']
+            # Decompress if stored in compressed format
+            config_data = ConfigurationManager._decompress_item(response['Item'])
             # Extract summarization model from the configuration
             if 'summarization' in config_data and 'model' in config_data['summarization']:
                 return config_data['summarization']['model']

--- a/nested/appsync/src/lambda/test_runner/index.py
+++ b/nested/appsync/src/lambda/test_runner/index.py
@@ -112,6 +112,35 @@ def _get_test_set(tracking_table, test_set_id):
         logger.error(f"Error getting test set {test_set_id}: {e}")
         return None
 
+def _decompress_config_item(item):
+    """
+    Decompress a DynamoDB config item if it uses compressed storage format.
+    Inlined here to avoid dependency on idp_common (not available in this Lambda).
+    """
+    import gzip as _gzip
+
+    if item.get('_config_storage') != 'compressed':
+        return item  # Legacy inline format — return as-is
+
+    compressed_data = item.get('_compressed_config')
+    if compressed_data is None:
+        return item
+
+    raw_bytes = bytes(compressed_data) if not isinstance(compressed_data, bytes) else compressed_data
+
+    try:
+        config_data = json.loads(_gzip.decompress(raw_bytes).decode('utf-8'))
+    except Exception as e:
+        logger.error(f"Failed to decompress config data: {e}")
+        return item
+
+    # Reconstruct: metadata fields + decompressed config data
+    metadata_fields = {'Configuration', 'CreatedAt', 'UpdatedAt', 'IsActive', 'Description'}
+    full_item = {k: v for k, v in item.items() if k in metadata_fields}
+    full_item.update(config_data)
+    return full_item
+
+
 def _capture_config(config_table, config_version=None):
     """Capture configuration - specific version or current active config"""
     table = dynamodb.Table(config_table)  # type: ignore[attr-defined]
@@ -125,7 +154,7 @@ def _capture_config(config_table, config_version=None):
             key = f"Config#{config_version}"
             response = table.get_item(Key={'Configuration': key})
             if 'Item' in response:
-                config['Config'] = response['Item']
+                config['Config'] = _decompress_config_item(response['Item'])
             else:
                 logger.warning(f"Config version {config_version} not found")
         else:
@@ -139,7 +168,7 @@ def _capture_config(config_table, config_version=None):
             )
             items = scan_response.get('Items', [])
             if items:
-                config['Config'] = items[0]
+                config['Config'] = _decompress_config_item(items[0])
             
     except Exception as e:
         logger.warning(f"Could not retrieve Config: {e}")

--- a/src/lambda/update_configuration/index.py
+++ b/src/lambda/update_configuration/index.py
@@ -299,6 +299,9 @@ def save_configuration_bypass_manager(config_type: str, config_data: Any, versio
         key = {'Configuration': f"{config_type}#{version}" if version else config_type}
         response = table.get_item(Key=key)
         existing_item = response.get('Item')
+        # Decompress if stored in compressed format
+        if existing_item:
+            existing_item = ConfigurationManager._decompress_item(existing_item)
     except Exception as e:
         logger.warning(f"Could not retrieve existing record: {e}")
     
@@ -338,7 +341,9 @@ def save_configuration_bypass_manager(config_type: str, config_data: Any, versio
         from datetime import datetime
         item['UpdatedAt'] = datetime.utcnow().isoformat() + 'Z'
     
-    table.put_item(Item=item)
+    # Compress config data to match ConfigurationManager storage format
+    compressed_item = ConfigurationManager._compress_item(item)
+    table.put_item(Item=compressed_item)
     logger.info(f"Saved {config_type}{f'#{version}' if version else ''} configuration bypassing ConfigurationManager")
 
 


### PR DESCRIPTION
Follow-up to #201 (DynamoDB compression fix).

Three Lambda functions access the ConfigurationTable directly (bypassing `ConfigurationManager`) and need to handle the new compressed storage format:

| Lambda | Fix |
|--------|-----|
| `src/lambda/update_configuration/index.py` | Added `_decompress_item()` on read + `_compress_item()` on write in `save_configuration_bypass_manager()` |
| `nested/appsync/src/lambda/test_runner/index.py` | Added `_decompress_item()` on both `get_item` and `scan` paths in `_capture_config()` |
| `nested/appsync/src/lambda/chat_with_document_resolver/index.py` | Added `_decompress_item()` in `get_summarization_model()` |

Without this fix, these Lambdas would read compressed Binary data instead of config fields (e.g., `summarization.model` would be missing).

`make test` passes: 772 tests, 0 failures.