### PR TITLE
Add support for third-party models (Meta Llama 4, Google Gemma, NVIDIA Nemotron)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 ## [Unreleased]
 
+### Added
+
+- **Third-Party Model Support** — Added Meta Llama 4 Maverick 17B, Llama 4 Scout 17B, Google Gemma 3 27B IT, and NVIDIA Nemotron Nano 12B v2 VL as selectable models across all pipeline stages (OCR, Classification, Extraction, Assessment, Summarization, Evaluation, Discovery, Agents, Rule Validation). Includes per-token pricing configuration and EU region fallback mappings for Llama 4 models. ([#217](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/217))
+
 ## [0.5.0]
 
 ### Added

--- a/config_library/pricing.yaml
+++ b/config_library/pricing.yaml
@@ -606,6 +606,35 @@ pricing:
       - name: outputTokens
         price: "2.66E-6"
 
+  - name: bedrock/us.meta.llama4-maverick-17b-instruct-v1:0
+    units:
+      - name: inputTokens
+        price: "2.4E-7"
+      - name: outputTokens
+        price: "9.7E-7"
+
+  - name: bedrock/us.meta.llama4-scout-17b-instruct-v1:0
+    units:
+      - name: inputTokens
+        price: "1.7E-7"
+      - name: outputTokens
+        price: "6.6E-7"
+
+  - name: bedrock/google.gemma-3-27b-it
+    units:
+      - name: inputTokens
+        price: "2.3E-7"
+      - name: outputTokens
+        price: "3.8E-7"
+
+  - name: bedrock/nvidia.nemotron-nano-12b-v2
+    units:
+      - name: inputTokens
+        price: "2.0E-7"
+      - name: outputTokens
+        price: "6.0E-7"
+
+
   # ---------------------------------------------------------------------------
   # AWS Lambda Pricing (US East - N. Virginia)
   # ---------------------------------------------------------------------------

--- a/docs/eu-region-model-support.md
+++ b/docs/eu-region-model-support.md
@@ -30,6 +30,8 @@ The following table shows all US to EU model mappings currently configured in th
 | `us.anthropic.claude-opus-4-5-20251101-v1:0` | `eu.anthropic.claude-opus-4-5-20251101-v1:0` | Direct mapping |
 | `us.anthropic.claude-opus-4-6-v1` | `eu.anthropic.claude-opus-4-6-v1` | Direct mapping |
 | `us.anthropic.claude-opus-4-6-v1:1m` | `eu.anthropic.claude-opus-4-6-v1:1m` | Direct mapping |
+| `us.meta.llama4-maverick-17b-instruct-v1:0` | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` | **Fallback mapping** |
+| `us.meta.llama4-scout-17b-instruct-v1:0` | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` | **Fallback mapping** |
 
 ### Mapping Types
 
@@ -91,12 +93,24 @@ The UpdateConfiguration lambda processes default configurations as follows:
 2. **Behavior Differences**: Different models may produce varying outputs for the same input
 3. **Cost Impact**: Fallback models may have different pricing structures
 
+### Third-Party Models (US-Only)
+
+The following third-party models are available in US regions only and have no EU cross-region inference profiles. In EU deployments, the Meta Llama 4 models fall back to Claude Sonnet 4.5, while the single-region models (Gemma, Nemotron) are not available and should not be selected:
+
+- **Meta Llama 4 Maverick 17B**: `us.meta.llama4-maverick-17b-instruct-v1:0` → `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` (fallback)
+- **Meta Llama 4 Scout 17B**: `us.meta.llama4-scout-17b-instruct-v1:0` → `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` (fallback)
+- **Google Gemma 3 27B IT**: `google.gemma-3-27b-it` — single-region only, no EU availability
+- **NVIDIA Nemotron Nano 12B v2**: `nvidia.nemotron-nano-12b-v2` — single-region only, no EU availability
+- **Qwen3 VL 235B A22B**: `qwen.qwen3-vl-235b-a22b` — single-region only, no EU availability
+
 ### Missing Direct EU Equivalents
 
 The following US models do not have direct EU equivalents:
 - Nova Premier
 - Claude 3.5 Haiku (specific version)
 - Claude Opus 4 variants
+- Meta Llama 4 Maverick/Scout (US cross-region only)
+- Google Gemma 3, NVIDIA Nemotron, Qwen (single-region US only)
 
 ## Best Practices
 

--- a/patterns/unified/template.yaml
+++ b/patterns/unified/template.yaml
@@ -292,6 +292,10 @@ Resources:
                   - "eu.anthropic.claude-opus-4-6-v1"
                   - "eu.anthropic.claude-opus-4-6-v1:1m"
                   - "qwen.qwen3-vl-235b-a22b"
+                  - "us.meta.llama4-maverick-17b-instruct-v1:0"
+                  - "us.meta.llama4-scout-17b-instruct-v1:0"
+                  - "google.gemma-3-27b-it"
+                  - "nvidia.nemotron-nano-12b-v2"
                   - "global.amazon.nova-2-lite-v1:0"
                   - "global.anthropic.claude-haiku-4-5-20251001-v1:0"
                   - "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -646,6 +650,10 @@ Resources:
                   - "eu.anthropic.claude-opus-4-6-v1"
                   - "eu.anthropic.claude-opus-4-6-v1:1m"
                   - "qwen.qwen3-vl-235b-a22b"
+                  - "us.meta.llama4-maverick-17b-instruct-v1:0"
+                  - "us.meta.llama4-scout-17b-instruct-v1:0"
+                  - "google.gemma-3-27b-it"
+                  - "nvidia.nemotron-nano-12b-v2"
                   - "global.amazon.nova-2-lite-v1:0"
                   - "global.anthropic.claude-haiku-4-5-20251001-v1:0"
                   - "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -816,6 +824,10 @@ Resources:
                   - "eu.anthropic.claude-opus-4-6-v1"
                   - "eu.anthropic.claude-opus-4-6-v1:1m"
                   - "qwen.qwen3-vl-235b-a22b"
+                  - "us.meta.llama4-maverick-17b-instruct-v1:0"
+                  - "us.meta.llama4-scout-17b-instruct-v1:0"
+                  - "google.gemma-3-27b-it"
+                  - "nvidia.nemotron-nano-12b-v2"
                   - "global.amazon.nova-2-lite-v1:0"
                   - "global.anthropic.claude-haiku-4-5-20251001-v1:0"
                   - "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -983,6 +995,10 @@ Resources:
                     "eu.anthropic.claude-opus-4-6-v1",
                     "eu.anthropic.claude-opus-4-6-v1:1m",
                     "qwen.qwen3-vl-235b-a22b",
+                    "us.meta.llama4-maverick-17b-instruct-v1:0",
+                    "us.meta.llama4-scout-17b-instruct-v1:0",
+                    "google.gemma-3-27b-it",
+                    "nvidia.nemotron-nano-12b-v2",
                     "global.amazon.nova-2-lite-v1:0",
                     "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                     "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1077,6 +1093,10 @@ Resources:
                     "eu.anthropic.claude-opus-4-6-v1",
                     "eu.anthropic.claude-opus-4-6-v1:1m",
                     "qwen.qwen3-vl-235b-a22b",
+                    "us.meta.llama4-maverick-17b-instruct-v1:0",
+                    "us.meta.llama4-scout-17b-instruct-v1:0",
+                    "google.gemma-3-27b-it",
+                    "nvidia.nemotron-nano-12b-v2",
                     "global.amazon.nova-2-lite-v1:0",
                     "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                     "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1167,6 +1187,10 @@ Resources:
                         "eu.anthropic.claude-opus-4-6-v1",
                         "eu.anthropic.claude-opus-4-6-v1:1m",
                         "qwen.qwen3-vl-235b-a22b",
+                        "us.meta.llama4-maverick-17b-instruct-v1:0",
+                        "us.meta.llama4-scout-17b-instruct-v1:0",
+                        "google.gemma-3-27b-it",
+                        "nvidia.nemotron-nano-12b-v2",
                         "global.amazon.nova-2-lite-v1:0",
                         "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                         "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1252,6 +1276,10 @@ Resources:
                         "eu.anthropic.claude-opus-4-6-v1",
                         "eu.anthropic.claude-opus-4-6-v1:1m",
                         "qwen.qwen3-vl-235b-a22b",
+                        "us.meta.llama4-maverick-17b-instruct-v1:0",
+                        "us.meta.llama4-scout-17b-instruct-v1:0",
+                        "google.gemma-3-27b-it",
+                        "nvidia.nemotron-nano-12b-v2",
                         "global.amazon.nova-2-lite-v1:0",
                         "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                         "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1337,6 +1365,10 @@ Resources:
                         "eu.anthropic.claude-opus-4-6-v1",
                         "eu.anthropic.claude-opus-4-6-v1:1m",
                         "qwen.qwen3-vl-235b-a22b",
+                        "us.meta.llama4-maverick-17b-instruct-v1:0",
+                        "us.meta.llama4-scout-17b-instruct-v1:0",
+                        "google.gemma-3-27b-it",
+                        "nvidia.nemotron-nano-12b-v2",
                         "global.amazon.nova-2-lite-v1:0",
                         "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                         "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1451,6 +1483,10 @@ Resources:
                       - "eu.anthropic.claude-opus-4-6-v1"
                       - "eu.anthropic.claude-opus-4-6-v1:1m"
                       - "qwen.qwen3-vl-235b-a22b"
+                      - "us.meta.llama4-maverick-17b-instruct-v1:0"
+                      - "us.meta.llama4-scout-17b-instruct-v1:0"
+                      - "google.gemma-3-27b-it"
+                      - "nvidia.nemotron-nano-12b-v2"
                     default: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
                     order: 0
               error_analyzer:
@@ -1558,6 +1594,10 @@ Resources:
                         "eu.anthropic.claude-opus-4-6-v1",
                         "eu.anthropic.claude-opus-4-6-v1:1m",
                         "qwen.qwen3-vl-235b-a22b",
+                        "us.meta.llama4-maverick-17b-instruct-v1:0",
+                        "us.meta.llama4-scout-17b-instruct-v1:0",
+                        "google.gemma-3-27b-it",
+                        "nvidia.nemotron-nano-12b-v2",
                         "global.amazon.nova-2-lite-v1:0",
                         "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                         "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -1645,6 +1685,10 @@ Resources:
                         "eu.anthropic.claude-opus-4-6-v1",
                         "eu.anthropic.claude-opus-4-6-v1:1m",
                         "qwen.qwen3-vl-235b-a22b",
+                        "us.meta.llama4-maverick-17b-instruct-v1:0",
+                        "us.meta.llama4-scout-17b-instruct-v1:0",
+                        "google.gemma-3-27b-it",
+                        "nvidia.nemotron-nano-12b-v2",
                         "global.amazon.nova-2-lite-v1:0",
                         "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                         "global.anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/src/lambda/update_configuration/index.py
+++ b/src/lambda/update_configuration/index.py
@@ -97,6 +97,9 @@ MODEL_MAPPINGS = {
     "us.anthropic.claude-opus-4-5-20251101-v1:0": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "us.anthropic.claude-opus-4-6-v1": "eu.anthropic.claude-opus-4-6-v1",
     "us.anthropic.claude-opus-4-6-v1:1m": "eu.anthropic.claude-opus-4-6-v1:1m",
+    # Third-party models (US-only, no EU equivalent - fall back to themselves)
+    "us.meta.llama4-maverick-17b-instruct-v1:0": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "us.meta.llama4-scout-17b-instruct-v1:0": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
 }
 
 def get_current_region() -> str:


### PR DESCRIPTION
## Summary

Adds support for additional open-source/third-party foundation models as requested in #217.

### New Models Added

| Model | Bedrock Model ID | Cross-Region | Input/Output Modalities |
|-------|-----------------|--------------|------------------------|
| Meta Llama 4 Maverick 17B | `us.meta.llama4-maverick-17b-instruct-v1:0` | US only | Text+Image → Text |
| Meta Llama 4 Scout 17B | `us.meta.llama4-scout-17b-instruct-v1:0` | US only | Text+Image → Text |
| Google Gemma 3 27B IT | `google.gemma-3-27b-it` | Single-region | Text+Image → Text |
| NVIDIA Nemotron Nano 12B v2 VL | `nvidia.nemotron-nano-12b-v2` | Single-region | Text+Image → Text |

### Changes

- **`patterns/unified/template.yaml`** — Added all 4 models to all 11 model enum/dropdown lists (OCR, Classification, Extraction, Assessment, Summarization, Evaluation, Discovery ×2, Error Analyzer, Chat Companion, Fact Extraction, Rule Validation)
- **`config_library/pricing.yaml`** — Added per-token pricing entries for all models based on AWS Bedrock pricing
- **`src/lambda/update_configuration/index.py`** — Added EU fallback mappings for Llama 4 models (→ Claude Sonnet 4.5 in EU regions)
- **`docs/eu-region-model-support.md`** — Documented new models with EU availability notes and fallback behavior
- **`CHANGELOG.md`** — Added entry under [Unreleased]

### EU Region Handling

- **Llama 4 models** (US cross-region only): Fall back to `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` in EU deployments
- **Gemma, Nemotron** (single-region only): Available in US regions; not available for EU deployments. The `filter_models_by_region()` function correctly handles these since they lack `us.`/`eu.` prefixes

### Testing

- All 653 existing tests pass
- Ruff lint clean on changed Python files
- YAML syntax validated

Closes #217