### PR TITLE
fix(iam): add bedrock application-inference-profile to lambda executi…

### DIFF
--- a/patterns/unified/template.yaml
+++ b/patterns/unified/template.yaml
@@ -2441,6 +2441,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
             - Effect: Allow
               Action:
                 - aws-marketplace:Subscribe
@@ -2566,6 +2567,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
                 - !If
                   - HasCustomClassificationModelARN
                   - !Ref CustomClassificationModelARN
@@ -2695,6 +2697,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
                 - !If
                   - HasCustomExtractionModelARN
                   - !Ref CustomExtractionModelARN
@@ -2815,6 +2818,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
             - Effect: Allow
               Action:
                 - aws-marketplace:Subscribe
@@ -3021,6 +3025,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
             - Effect: Allow
               Action:
                 - aws-marketplace:Subscribe
@@ -3140,6 +3145,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
             # Lambda invoke permission for SaveReportingFunction (in main template)
             - Effect: Allow
               Action:
@@ -3250,6 +3256,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
             - !If
               - HasGuardrailConfig
               - Effect: Allow
@@ -3361,6 +3368,7 @@ Resources:
               Resource:
                 - !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
                 - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/*"
+                - !Sub "arn:${AWS::Partition}:bedrock:${AWS::Region}:${AWS::AccountId}:application-inference-profile/*"
             - Effect: Allow
               Action:
                 - aws-marketplace:Subscribe


### PR DESCRIPTION
…on roles

**What changed:**
Added the `application-inference-profile/*` ARN pattern to the `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` IAM policy statements across the document processing Lambda functions (Classification, Extraction, Assessment, and Summarization). 

**Why it matters:**
Previously, the IAM policies in the SAM templates only permitted invocation of standard Foundation Models (`foundation-model/*`) and cross-region inference profiles (`inference-profile/*`). This strict string matching blocked the use of custom Application Inference Profiles (`application-inference-profile/*`). 

By adding this ARN pattern, users can now successfully map custom inference profiles (like Nova 2 Lite) to the IDP pipeline. This unlocks the ability to:
* Tag Bedrock invocations for granular cost allocation.
* Track custom model throughput and performance metrics.
* Avoid `AccessDeniedException` errors when substituting default models with application-specific profiles.

**Related Issue(s):**
https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/235

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
