### PR TITLE
Fix race condition in idp-cli generate-manifest --test-set (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: MIT-0
 ### Fixed
 
 - **GovCloud template: fix unresolved RBAC resource dependencies** — Added `AuthorGroup`, `ViewerGroup`, `GetMyProfileResolver`, and `UpdateUserResolver` to GovCloud removal lists so they are stripped alongside the `UserPool` they depend on.
+- **Fix race condition in `idp-cli generate-manifest --test-set`** — Added `.uploading` marker file protocol to prevent the test set resolver from prematurely validating test sets while the CLI is still uploading baseline files ([#193](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/193)).
 
 ## [0.5.2]
 

--- a/lib/idp_cli_pkg/idp_cli/cli.py
+++ b/lib/idp_cli_pkg/idp_cli/cli.py
@@ -2432,6 +2432,15 @@ def generate_manifest(
                     f"[yellow]Warning: Could not clear existing files: {e}[/yellow]"
                 )
 
+            # Place .uploading marker to prevent resolver race condition
+            # The test set resolver's auto-detection skips folders with this marker,
+            # preventing premature validation before all files are uploaded.
+            # See: https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/193
+            marker_key = f"{test_set}/.uploading"
+            s3_client.put_object(
+                Bucket=test_set_bucket, Key=marker_key, Body=b"upload-in-progress"
+            )
+
             # Upload input documents
             for i, doc in enumerate(documents):
                 doc_path = doc["document_path"]
@@ -2487,6 +2496,15 @@ def generate_manifest(
             console.print()
 
         if test_set:
+            # Remove .uploading marker now that all files are uploaded
+            marker_key = f"{test_set}/.uploading"
+            try:
+                s3_client.delete_object(Bucket=test_set_bucket, Key=marker_key)
+            except Exception as e:
+                console.print(
+                    f"[yellow]Warning: Could not remove upload marker: {e}[/yellow]"
+                )
+
             # Auto-register test set in tracking table
             from idp_cli.stack_info import StackInfo
 
@@ -2929,6 +2947,12 @@ def _create_test_set_from_manifest(
     except Exception as e:
         console.print(f"[yellow]Warning: Could not clear existing files: {e}[/yellow]")
 
+    # Place .uploading marker to prevent resolver race condition (issue #193)
+    marker_key = f"{test_set_name}/.uploading"
+    s3_client.put_object(
+        Bucket=test_set_bucket, Key=marker_key, Body=b"upload-in-progress"
+    )
+
     # Copy input files
     for _, row in df.iterrows():
         source_path = row["document_path"]
@@ -2965,6 +2989,12 @@ def _create_test_set_from_manifest(
                     rel_path = os.path.relpath(baseline_file, baseline_path)
                     s3_key = f"{test_set_name}/baseline/{filename}/{rel_path}"
                     s3_client.upload_file(baseline_file, test_set_bucket, s3_key)
+
+    # Remove .uploading marker now that all files are uploaded (issue #193)
+    try:
+        s3_client.delete_object(Bucket=test_set_bucket, Key=marker_key)
+    except Exception as e:
+        console.print(f"[yellow]Warning: Could not remove upload marker: {e}[/yellow]")
 
     console.print(
         f"[green]✓ Test set '{test_set_name}' created with {len(df)} files[/green]"

--- a/nested/appsync/src/lambda/test_set_resolver/index.py
+++ b/nested/appsync/src/lambda/test_set_resolver/index.py
@@ -413,8 +413,22 @@ def get_test_sets():
     return result
 
 def _is_valid_test_set_structure(s3_client, bucket, prefix):
-    """Check if prefix contains input/ and baseline/ folders"""
+    """Check if prefix contains input/ and baseline/ folders.
+    
+    Also checks for a .uploading marker file which indicates the CLI is still
+    uploading files. This prevents a race condition where the resolver auto-detects
+    and validates a test set before all files (especially baselines) are uploaded.
+    See: https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/193
+    """
     try:
+        # Check for upload-in-progress marker
+        try:
+            s3_client.head_object(Bucket=bucket, Key=f"{prefix}/.uploading")
+            logger.info(f"Skipping {prefix} - upload in progress (.uploading marker found)")
+            return False
+        except Exception:
+            pass  # No marker = not uploading, proceed with validation
+
         # Check for input/ folder
         input_response = s3_client.list_objects_v2(
             Bucket=bucket,


### PR DESCRIPTION
## Summary

Fixes #193 — Race condition in `idp-cli generate-manifest --test-set` that causes test sets to be marked as FAILED with "Missing baseline files" errors when the UI is open during CLI uploads.

## Root Cause

When the CLI uploads input files then baselines sequentially to S3, the test set resolver's auto-detection (triggered by UI polling via `getTestSets`) can validate the test set before all baseline files are uploaded. This creates a premature FAILED DynamoDB entry. The CLI's subsequent resolver call then skips re-validation because the entry already exists.

## Solution

Implemented a `.uploading` S3 marker file protocol:

1. **CLI places marker** — Before uploading files, the CLI creates `{test_set}/.uploading` in the test set bucket
2. **Resolver checks marker** — `_is_valid_test_set_structure()` checks for the marker via `head_object` and skips folders that have it
3. **CLI removes marker** — After all uploads complete, the CLI deletes the marker, then invokes the resolver for registration

## Changes

| File | Change |
|------|--------|
| `nested/appsync/src/lambda/test_set_resolver/index.py` | Added `.uploading` marker check in `_is_valid_test_set_structure()` |
| `lib/idp_cli_pkg/idp_cli/cli.py` | Added marker create/delete in `generate_manifest()` and `_create_test_set_from_manifest()` |
| `CHANGELOG.md` | Added fix entry under `[Unreleased]` |

## Backward Compatibility

- **Fully backward compatible** — Old CLIs without the marker continue to work (resolver only adds an additional skip check)
- **No infrastructure changes** — No new DynamoDB fields, Lambda APIs, or AppSync schema changes
- **Fail-safe** — If CLI crashes mid-upload, the marker persists and the test set stays hidden from auto-detection (correct behavior)