### PR TITLE
feat: Add ALB+S3 hosting mode for private network and GovCloud deployments

### DIFF
--- a/lib/idp_cli_pkg/idp_cli/cli.py
+++ b/lib/idp_cli_pkg/idp_cli/cli.py
@@ -442,10 +442,18 @@ def deploy(
         # Parse additional parameters
         additional_params = {}
         if parameters:
-            for param in parameters.split(","):
-                if "=" in param:
-                    key, value = param.split("=", 1)
-                    additional_params[key.strip()] = value.strip()
+            # Parse key=value pairs separated by commas, but handle values
+            # that themselves contain commas (e.g., subnet lists).
+            # Strategy: split on commas that are followed by a key= pattern.
+            import re
+
+            for match in re.finditer(
+                r"([A-Za-z][A-Za-z0-9]*)=((?:(?![A-Za-z][A-Za-z0-9]*=).)*)",
+                parameters,
+            ):
+                key = match.group(1).strip()
+                value = match.group(2).strip().rstrip(",")
+                additional_params[key] = value
 
         # Build parameters - only pass explicitly provided values
         # Convert Click defaults to None when not explicitly provided by user

--- a/nested/alb-hosting/template.yaml
+++ b/nested/alb-hosting/template.yaml
@@ -1,0 +1,469 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  ALB hosting nested stack for GenAI IDP Web UI.
+  Creates an Application Load Balancer with S3 VPC Interface Endpoint
+  to serve static web content without CloudFront.
+
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC ID for the ALB and S3 VPC endpoint
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Subnet IDs for the ALB (minimum 2 in different AZs)
+
+  CertificateArn:
+    Type: String
+    Description: ACM certificate ARN for the ALB HTTPS listener
+
+  ALBScheme:
+    Type: String
+    Default: internal
+    AllowedValues: [internal, internet-facing]
+    Description: ALB scheme
+
+  ALBAllowedCIDRs:
+    Type: String
+    Default: ""
+    Description: >-
+      Comma-separated CIDR ranges for ALB security group ingress.
+      Empty means use VPC CIDR.
+
+  WebUIBucketName:
+    Type: String
+    Description: S3 bucket name for static web content
+
+  WebUIBucketArn:
+    Type: String
+    Description: S3 bucket ARN
+
+  StackName:
+    Type: String
+    Description: Parent stack name for resource naming
+
+  PermissionsBoundaryArn:
+    Type: String
+    Default: ""
+    Description: Optional IAM permissions boundary ARN
+
+  LoggingBucketName:
+    Type: String
+    Description: S3 bucket name for ALB access logs
+
+Conditions:
+  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryArn, ""]]
+  UseVpcCidr: !Equals [!Ref ALBAllowedCIDRs, ""]
+
+Resources:
+  ##########################################################################
+  # VPC CIDR Lookup (when ALBAllowedCIDRs is empty)
+  ##########################################################################
+
+  VpcCidrLookupRole:
+    Type: AWS::IAM::Role
+    Condition: UseVpcCidr
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub "lambda.${AWS::URLSuffix}"
+            Action: sts:AssumeRole
+      PermissionsBoundary: !If
+        - HasPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: VpcCidrLookup
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeVpcs
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  VpcCidrLookupFunction:
+    Type: AWS::Lambda::Function
+    Condition: UseVpcCidr
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "Custom resource Lambda does not need VPC access"
+          - id: W92
+            reason: "Custom resource Lambda does not need reserved concurrency"
+    # checkov:skip=CKV_AWS_116: "DLQ not required for CloudFormation custom resource"
+    # checkov:skip=CKV_AWS_117: "Function does not need VPC access"
+    # checkov:skip=CKV_AWS_115: "Function does not need reserved concurrency"
+    Properties:
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 30
+      MemorySize: 128
+      Role: !GetAtt VpcCidrLookupRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          def handler(event, context):
+              if event["RequestType"] == "Delete":
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                  return
+              try:
+                  vpc_id = event["ResourceProperties"]["VpcId"]
+                  ec2 = boto3.client("ec2")
+                  resp = ec2.describe_vpcs(VpcIds=[vpc_id])
+                  cidr = resp["Vpcs"][0]["CidrBlock"]
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {"CidrBlock": cidr})
+              except Exception as e:
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
+
+  VpcCidrLookup:
+    Type: Custom::VpcCidrLookup
+    Condition: UseVpcCidr
+    Properties:
+      ServiceToken: !GetAtt VpcCidrLookupFunction.Arn
+      VpcId: !Ref VpcId
+
+  ##########################################################################
+  # Security Groups
+  ##########################################################################
+
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W5
+            reason: "Egress restricted to VPC endpoint security group on port 443"
+    Properties:
+      GroupDescription: !Sub "${StackName} ALB Security Group"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !If
+            - UseVpcCidr
+            - !GetAtt VpcCidrLookup.CidrBlock
+            - !Select [0, !Split [",", !Ref ALBAllowedCIDRs]]
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-alb-sg"
+
+  EndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "${StackName} S3 VPC Endpoint Security Group"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref ALBSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-s3-endpoint-sg"
+
+  ALBToEndpointEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref ALBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      DestinationSecurityGroupId: !Ref EndpointSecurityGroup
+
+  ##########################################################################
+  # S3 Interface VPC Endpoint
+  ##########################################################################
+
+  S3InterfaceEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.s3"
+      VpcId: !Ref VpcId
+      SubnetIds: !Ref SubnetIds
+      SecurityGroupIds:
+        - !Ref EndpointSecurityGroup
+      PrivateDnsEnabled: false
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowWebUIBucketOnly
+            Effect: Allow
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}"
+              - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}/*"
+
+  ##########################################################################
+  # ALB Target Group & Target Registration
+  ##########################################################################
+
+  S3TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${StackName}-s3-tg"
+      TargetType: ip
+      Protocol: HTTPS
+      Port: 443
+      VpcId: !Ref VpcId
+      HealthCheckProtocol: HTTPS
+      HealthCheckPort: "443"
+      HealthCheckPath: /
+      Matcher:
+        HttpCode: "200,307,405"
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-s3-target-group"
+
+  RegisterTargetsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub "lambda.${AWS::URLSuffix}"
+            Action: sts:AssumeRole
+      PermissionsBoundary: !If
+        - HasPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: RegisterTargets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeVpcEndpoints
+                  - ec2:DescribeNetworkInterfaces
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - elasticloadbalancing:RegisterTargets
+                  - elasticloadbalancing:DeregisterTargets
+                Resource: !Sub "arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  RegisterTargetsFunction:
+    Type: AWS::Lambda::Function
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "Custom resource Lambda does not need VPC access"
+          - id: W92
+            reason: "Custom resource Lambda does not need reserved concurrency"
+    # checkov:skip=CKV_AWS_116: "DLQ not required for CloudFormation custom resource"
+    # checkov:skip=CKV_AWS_117: "Function does not need VPC access"
+    # checkov:skip=CKV_AWS_115: "Function does not need reserved concurrency"
+    Properties:
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 60
+      MemorySize: 128
+      Role: !GetAtt RegisterTargetsRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          def handler(event, context):
+              try:
+                  ec2 = boto3.client("ec2")
+                  elbv2 = boto3.client("elbv2")
+                  vpce_id = event["ResourceProperties"]["VpcEndpointId"]
+                  tg_arn = event["ResourceProperties"]["TargetGroupArn"]
+
+                  # Get VPC endpoint ENI IDs
+                  vpce_resp = ec2.describe_vpc_endpoints(VpcEndpointIds=[vpce_id])
+                  eni_ids = vpce_resp["VpcEndpoints"][0]["NetworkInterfaceIds"]
+
+                  # Get private IPs from ENIs
+                  eni_resp = ec2.describe_network_interfaces(NetworkInterfaceIds=eni_ids)
+                  ips = [eni["PrivateIpAddress"] for eni in eni_resp["NetworkInterfaces"]]
+
+                  if event["RequestType"] == "Delete":
+                      # Deregister targets
+                      targets = [{"Id": ip, "Port": 443} for ip in ips]
+                      try:
+                          elbv2.deregister_targets(TargetGroupArn=tg_arn, Targets=targets)
+                      except Exception:
+                          pass  # Best effort on delete
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                      return
+
+                  # Register targets
+                  targets = [{"Id": ip, "Port": 443} for ip in ips]
+                  elbv2.register_targets(TargetGroupArn=tg_arn, Targets=targets)
+
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {
+                      "IpAddresses": ",".join(ips),
+                      "TargetCount": str(len(ips)),
+                  })
+              except Exception as e:
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
+
+  RegisterTargetsCustomResource:
+    Type: Custom::RegisterTargets
+    DependsOn:
+      - S3InterfaceEndpoint
+      - S3TargetGroup
+    Properties:
+      ServiceToken: !GetAtt RegisterTargetsFunction.Arn
+      VpcEndpointId: !Ref S3InterfaceEndpoint
+      TargetGroupArn: !Ref S3TargetGroup
+
+  ##########################################################################
+  # Application Load Balancer
+  ##########################################################################
+
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W52
+            reason: "ALB access logging is configured to the logging bucket"
+    Properties:
+      Name: !Sub "${StackName}-webui-alb"
+      Type: application
+      Scheme: !Ref ALBScheme
+      Subnets: !Ref SubnetIds
+      SecurityGroups:
+        - !Ref ALBSecurityGroup
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: "60"
+        - Key: routing.http2.enabled
+          Value: "true"
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: "true"
+        - Key: access_logs.s3.enabled
+          Value: "true"
+        - Key: access_logs.s3.bucket
+          Value: !Ref LoggingBucketName
+        - Key: access_logs.s3.prefix
+          Value: alb-access-logs
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-webui-alb"
+
+  ##########################################################################
+  # ALB Listener and Rules
+  ##########################################################################
+
+  ALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      DefaultActions:
+        - Type: fixed-response
+          FixedResponseConfig:
+            StatusCode: "404"
+            ContentType: text/plain
+            MessageBody: "Not Found"
+
+  # Rule 1: Root path - rewrite to /index.html for SPA entry point
+  ALBListenerRuleRoot:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn: RegisterTargetsCustomResource
+    Properties:
+      ListenerArn: !Ref ALBListener
+      Priority: 1
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/"
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref S3TargetGroup
+      Transforms:
+        - Type: host-header-rewrite
+          HostHeaderRewriteConfig:
+            Rewrites:
+              - Regex: ".*"
+                Replace: !Sub "${WebUIBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}"
+        - Type: url-rewrite
+          UrlRewriteConfig:
+            Rewrites:
+              - Regex: "^/$"
+                Replace: "/index.html"
+
+  # Rule 2: All other paths - serve static assets (JS, CSS, images, fonts, etc.)
+  ALBListenerRuleCatchAll:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn: RegisterTargetsCustomResource
+    Properties:
+      ListenerArn: !Ref ALBListener
+      Priority: 2
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/*"
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref S3TargetGroup
+      Transforms:
+        - Type: host-header-rewrite
+          HostHeaderRewriteConfig:
+            Rewrites:
+              - Regex: ".*"
+                Replace: !Sub "${WebUIBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}"
+
+Outputs:
+  WebUIURL:
+    Description: Web UI URL via ALB
+    Value: !Sub "https://${ALB.DNSName}"
+
+  ALBDNSName:
+    Description: ALB DNS name
+    Value: !GetAtt ALB.DNSName
+
+  ALBArn:
+    Description: ALB ARN
+    Value: !Ref ALB
+
+  S3VPCEndpointId:
+    Description: S3 VPC Interface Endpoint ID
+    Value: !Ref S3InterfaceEndpoint
+
+  ALBHostedZoneID:
+    Description: ALB Canonical Hosted Zone ID (for Route53 alias records)
+    Value: !GetAtt ALB.CanonicalHostedZoneID

--- a/publish.py
+++ b/publish.py
@@ -1768,6 +1768,9 @@ STDERR:
                 "nested/bedrockkb/src",
                 "nested/bedrockkb/template.yaml",
             ],
+            "nested/alb-hosting": [
+                "nested/alb-hosting/template.yaml",
+            ],
             # Unified pattern (combines BDA + Pipeline)
             "patterns/unified": [
                 LIB_DEPENDENCY,

--- a/scripts/generate_self_signed_cert.sh
+++ b/scripts/generate_self_signed_cert.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Generates a self-signed TLS certificate and imports it to AWS Certificate Manager (ACM).
+# Use this for demo/testing with the ALB hosting option.
+#
+# Usage:
+#   ./scripts/generate_self_signed_cert.sh [--region REGION] [--domain DOMAIN] [--days DAYS]
+#
+# Options:
+#   --region  AWS region for ACM import (default: from AWS_DEFAULT_REGION or aws configure)
+#   --domain  Domain name for the certificate CN/SAN (default: self-signed.internal)
+#   --days    Certificate validity in days (default: 365)
+#
+# Output:
+#   Prints the ACM certificate ARN to stdout (last line).
+#
+# Example:
+#   CERT_ARN=$(./scripts/generate_self_signed_cert.sh --region us-gov-west-1 --domain myapp.internal)
+#   echo "Use this ARN for ALBCertificateArn parameter: $CERT_ARN"
+
+set -euo pipefail
+
+REGION=""
+DOMAIN="self-signed.internal"
+DAYS=365
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
+        --domain)
+            DOMAIN="$2"
+            shift 2
+            ;;
+        --days)
+            DAYS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -20 "$0" | grep '^#' | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate dependencies
+for cmd in openssl aws; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is required but not installed." >&2
+        exit 1
+    fi
+done
+
+# Build region flag
+REGION_FLAG=""
+if [[ -n "$REGION" ]]; then
+    REGION_FLAG="--region $REGION"
+fi
+
+# Create temporary directory for certificate files
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+KEY_FILE="$TMPDIR/private.key"
+CERT_FILE="$TMPDIR/certificate.pem"
+
+echo "Generating self-signed certificate for domain: $DOMAIN (valid for $DAYS days)" >&2
+
+# Generate private key and self-signed certificate
+openssl req -x509 -nodes \
+    -days "$DAYS" \
+    -newkey rsa:2048 \
+    -keyout "$KEY_FILE" \
+    -out "$CERT_FILE" \
+    -subj "/CN=$DOMAIN" \
+    -addext "subjectAltName=DNS:$DOMAIN" \
+    2>/dev/null
+
+echo "Importing certificate to ACM..." >&2
+
+# Import certificate to ACM
+# shellcheck disable=SC2086
+CERT_ARN=$(aws acm import-certificate \
+    --certificate fileb://"$CERT_FILE" \
+    --private-key fileb://"$KEY_FILE" \
+    --query 'CertificateArn' \
+    --output text \
+    $REGION_FLAG)
+
+echo "" >&2
+echo "Certificate imported successfully." >&2
+echo "ACM Certificate ARN: $CERT_ARN" >&2
+echo "" >&2
+echo "Use this value for the ALBCertificateArn CloudFormation parameter." >&2
+echo "" >&2
+echo "NOTE: This is a self-signed certificate. Browsers will show a security warning." >&2
+echo "For production use, use a certificate issued by a trusted CA or AWS ACM." >&2
+
+# Print just the ARN to stdout for scripting
+echo "$CERT_ARN"

--- a/template.yaml
+++ b/template.yaml
@@ -312,13 +312,63 @@ Parameters:
         3653,
       ]
 
+  WebUIHosting:
+    Type: String
+    Default: CloudFront
+    AllowedValues:
+      - CloudFront
+      - ALB
+    Description: >-
+      Frontend hosting method. Use CloudFront for public/standard deployments.
+      Use ALB for GovCloud or private network deployments that require
+      VPC-based hosting.
+
+  ALBVpcId:
+    Type: String
+    Default: ""
+    Description: >-
+      (Required when WebUIHosting=ALB) VPC ID for the ALB and S3 VPC endpoint.
+
+  ALBSubnetIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      (Required when WebUIHosting=ALB) Comma-separated subnet IDs for the ALB
+      (minimum 2 subnets in different AZs).
+
+  ALBCertificateArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Required when WebUIHosting=ALB) ACM certificate ARN for the ALB HTTPS
+      listener. Can be ACM-issued or imported (including self-signed). Use
+      scripts/generate_self_signed_cert.sh for demo/testing.
+
+  ALBScheme:
+    Type: String
+    Default: internal
+    AllowedValues:
+      - internal
+      - internet-facing
+    Description: >-
+      (ALB hosting only) ALB scheme. Use 'internal' for private network access,
+      'internet-facing' for public access.
+
+  ALBAllowedCIDRs:
+    Type: String
+    Default: ""
+    Description: >-
+      (ALB hosting only) Comma-separated CIDR ranges allowed to access the ALB.
+      Leave empty to automatically use the VPC CIDR range (recommended for
+      internal ALBs). Specify explicit CIDRs to override.
+
   CloudFrontPriceClass:
     Type: String
     Default: PriceClass_100
     Description: >-
-      Specify the CloudFront price class. See https://aws.amazon.com/cloudfront/pricing/
-      for a
-      description of each price class.
+      (CloudFront hosting only) Specify the CloudFront price class. See
+      https://aws.amazon.com/cloudfront/pricing/ for a description of each
+      price class.
     AllowedValues:
       - PriceClass_100
       - PriceClass_200
@@ -376,6 +426,8 @@ Conditions:
   IsS3VectorsVectorStore: !Equals [ !Ref KnowledgeBaseVectorStore, "S3_VECTORS" ]
   CreateAgentCoreLambda: !Equals [ !Ref EnableMCP, "true" ]
   CreateExternalAppClient: !Equals [ !Ref EnableMCP, "true" ]
+  UseCloudFrontHosting: !Equals [ !Ref WebUIHosting, "CloudFront" ]
+  UseALBHosting: !Equals [ !Ref WebUIHosting, "ALB" ]
 
 Metadata:
   cfn-lint:
@@ -430,6 +482,20 @@ Metadata:
         Parameters:
           - EnableMCP
       - Label:
+          default: "Web UI Hosting"
+        Parameters:
+          - WebUIHosting
+          - CloudFrontPriceClass
+          - CloudFrontAllowedGeos
+      - Label:
+          default: "ALB Hosting (when WebUIHosting=ALB)"
+        Parameters:
+          - ALBVpcId
+          - ALBSubnetIds
+          - ALBCertificateArn
+          - ALBScheme
+          - ALBAllowedCIDRs
+      - Label:
           default: "General Configuration"
         Parameters:
           - MaxConcurrentWorkflows
@@ -438,8 +504,6 @@ Metadata:
           - ExecutionTimeThresholdMs
           - LogLevel
           - LogRetentionDays
-          - CloudFrontPriceClass
-          - CloudFrontAllowedGeos
 
     ParameterLabels:
       AdminEmail:
@@ -490,6 +554,18 @@ Metadata:
         default: "WAF Allowed IPv4 Ranges"
       EnableMCP:
         default: "Enable MCP Integration"
+      WebUIHosting:
+        default: "Web UI Hosting Method"
+      ALBVpcId:
+        default: "ALB - VPC ID"
+      ALBSubnetIds:
+        default: "ALB - Subnet IDs"
+      ALBCertificateArn:
+        default: "ALB - ACM Certificate ARN"
+      ALBScheme:
+        default: "ALB - Scheme (internal/internet-facing)"
+      ALBAllowedCIDRs:
+        default: "ALB - Allowed CIDR Ranges"
 
 Resources:
   # Custom resource to enforce max length of StackName - prevent downstream failures
@@ -1545,6 +1621,32 @@ Resources:
             Condition:
               StringEquals:
                 "AWS:SourceAccount": !Ref "AWS::AccountId"
+          - !If
+            - UseALBHosting
+            - Sid: AllowALBAccessLogs
+              Effect: Allow
+              Principal:
+                Service: !Sub "logdelivery.elasticloadbalancing.${AWS::URLSuffix}"
+              Action:
+                - s3:PutObject
+              Resource: !Sub "${LoggingBucket.Arn}/alb-access-logs/*"
+              Condition:
+                StringEquals:
+                  "aws:SourceAccount": !Ref "AWS::AccountId"
+            - !Ref AWS::NoValue
+          - !If
+            - UseALBHosting
+            - Sid: AllowALBAccessLogsBucketACL
+              Effect: Allow
+              Principal:
+                Service: !Sub "logdelivery.elasticloadbalancing.${AWS::URLSuffix}"
+              Action:
+                - s3:GetBucketAcl
+              Resource: !Sub "${LoggingBucket.Arn}"
+              Condition:
+                StringEquals:
+                  "aws:SourceAccount": !Ref "AWS::AccountId"
+            - !Ref AWS::NoValue
           - Sid: EnforceSSLOnly
             Effect: Deny
             Principal: "*"
@@ -1576,7 +1678,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1645,7 +1750,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1710,7 +1818,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2156,7 +2267,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2268,7 +2382,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2334,7 +2451,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2785,7 +2905,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2850,9 +2973,11 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
-      WebsiteConfiguration:
-        IndexDocument: index.html
-        ErrorDocument: index.html
+      WebsiteConfiguration: !If
+        - UseCloudFrontHosting
+        - IndexDocument: index.html
+          ErrorDocument: index.html
+        - !Ref AWS::NoValue
       LoggingConfiguration:
         DestinationBucketName: !Ref LoggingBucket
         LogFilePrefix: webapp-bucket-logs/
@@ -2864,11 +2989,24 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
-            Principal:
-              CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
-            Action: s3:GetObject
-            Resource: !Sub "${WebUIBucket.Arn}/*"
+          - !If
+            - UseCloudFrontHosting
+            - Effect: Allow
+              Principal:
+                CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+              Action: s3:GetObject
+              Resource: !Sub "${WebUIBucket.Arn}/*"
+            - !Ref AWS::NoValue
+          - !If
+            - UseALBHosting
+            - Effect: Allow
+              Principal: "*"
+              Action: s3:GetObject
+              Resource: !Sub "${WebUIBucket.Arn}/*"
+              Condition:
+                StringEquals:
+                  "aws:sourceVpce": !GetAtt ALBHostingStack.Outputs.S3VPCEndpointId
+            - !Ref AWS::NoValue
           - Effect: "Deny"
             Action:
               - "s3:*"
@@ -5288,7 +5426,10 @@ Resources:
         - profile
       CallbackURLs:
         - !Sub "https://${GetDomain.OutputString}.auth.${AWS::Region}.amazoncognito.com"
-        - !Sub "https://${CloudFrontDistribution.DomainName}/"
+        - !If
+          - UseCloudFrontHosting
+          - !Sub "https://${CloudFrontDistribution.DomainName}/"
+          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5296,7 +5437,10 @@ Resources:
         - https://ap-southeast-2.quicksight.aws.amazon.com/sn/oauthcallback
       LogoutURLs:
         - !Sub "https://${GetDomain.OutputString}.auth.${AWS::Region}.amazoncognito.com"
-        - !Sub "https://${CloudFrontDistribution.DomainName}/"
+        - !If
+          - UseCloudFrontHosting
+          - !Sub "https://${CloudFrontDistribution.DomainName}/"
+          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5323,16 +5467,21 @@ Resources:
           - true
         InviteMessageTemplate:
           EmailSubject: Welcome to GenAI-IDP!
-          EmailMessage: !Sub |-
-            <p>Hello {username},</p>
-            <p>Welcome to the AWS GenAIIDP Solution! Your temporary password is: <strong>{####}</strong></p>
-            <p>When the CloudFormation stack is COMPLETE, use the link below to log in and set your permanent password.
-            <p>     https://${CloudFrontDistribution.DomainName}/
-            <p>
-            <p>Thanks,</p>
-            <p>AWS GenAIIDP Team</p>
-            <p>
-            <p><em>Stack: ${AWS::StackName}, v<VERSION>, <BUILD_DATE_TIME></em>
+          EmailMessage: !Sub
+            - |-
+              <p>Hello {username},</p>
+              <p>Welcome to the AWS GenAIIDP Solution! Your temporary password is: <strong>{####}</strong></p>
+              <p>When the CloudFormation stack is COMPLETE, use the link below to log in and set your permanent password.
+              <p>     ${WebUIURL}
+              <p>
+              <p>Thanks,</p>
+              <p>AWS GenAIIDP Team</p>
+              <p>
+              <p><em>Stack: ${AWS::StackName}, v<VERSION>, <BUILD_DATE_TIME></em>
+            - WebUIURL: !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}/"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
       AutoVerifiedAttributes:
         - email
       EmailConfiguration:
@@ -5375,7 +5524,10 @@ Resources:
         - phone
         - profile
       CallbackURLs:
-        - !Sub "https://${CloudFrontDistribution.DomainName}"
+        - !If
+          - UseCloudFrontHosting
+          - !Sub "https://${CloudFrontDistribution.DomainName}"
+          - !GetAtt ALBHostingStack.Outputs.WebUIURL
       AccessTokenValidity: 1
       EnableTokenRevocation: true
       ExplicitAuthFlows:
@@ -6402,6 +6554,7 @@ Resources:
 
   CloudFrontOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Condition: UseCloudFrontHosting
     Properties:
       CloudFrontOriginAccessIdentityConfig:
         Comment: !Sub "${AWS::StackName} CloudFront OAI for ${WebUIBucket}"
@@ -6409,6 +6562,7 @@ Resources:
   # Define a custom response headers policy for security headers
   SecurityHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
+    Condition: UseCloudFrontHosting
     Properties:
       ResponseHeadersPolicyConfig:
         Name: !Sub "${AWS::StackName}-security-headers-policy"
@@ -6433,6 +6587,7 @@ Resources:
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
+    Condition: UseCloudFrontHosting
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -6494,6 +6649,27 @@ Resources:
           - GeoRestriction:
               RestrictionType: none
 
+  ##########################################################################
+  # ALB Hosting (alternative to CloudFront for GovCloud / private networks)
+  ##########################################################################
+
+  ALBHostingStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: UseALBHosting
+    Properties:
+      TemplateURL: ./nested/alb-hosting/.aws-sam/packaged.yaml
+      Parameters:
+        VpcId: !Ref ALBVpcId
+        SubnetIds: !Join [",", !Ref ALBSubnetIds]
+        CertificateArn: !Ref ALBCertificateArn
+        ALBScheme: !Ref ALBScheme
+        ALBAllowedCIDRs: !Ref ALBAllowedCIDRs
+        WebUIBucketName: !Ref WebUIBucket
+        WebUIBucketArn: !GetAtt WebUIBucket.Arn
+        StackName: !Ref AWS::StackName
+        PermissionsBoundaryArn: !Ref PermissionsBoundaryArn
+        LoggingBucketName: !Ref LoggingBucket
+
   UICodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -6541,11 +6717,14 @@ Resources:
                   - s3:DeleteObject
                 Resource:
                   - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucket}/*"
-              - Effect: Allow
-                Action:
-                  - cloudfront:CreateInvalidation
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}"
+              - !If
+                - UseCloudFrontHosting
+                - Effect: Allow
+                  Action:
+                    - cloudfront:CreateInvalidation
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}"
+                - !Ref AWS::NoValue
 
   UICodeBuildProject:
     Type: AWS::CodeBuild::Project
@@ -6589,10 +6768,13 @@ Resources:
                 - echo Copying Web UI
                 - find build -ls
                 - aws s3 cp --recursive build s3://${WEBAPP_BUCKET}/
-                - echo Invalidating CloudFront Distribution
-                - >
-                  aws cloudfront create-invalidation
-                  --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths '/*'
+                - |
+                  if [ "$WEB_UI_HOSTING" = "CloudFront" ]; then
+                    echo "Invalidating CloudFront Distribution"
+                    aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths '/*'
+                  else
+                    echo "ALB hosting mode - skipping CloudFront invalidation"
+                  fi
           artifacts:
             files:
               - build.json
@@ -6610,8 +6792,13 @@ Resources:
             Value: !Sub "<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>"
           - Name: WEBAPP_BUCKET
             Value: !Ref WebUIBucket
+          - Name: WEB_UI_HOSTING
+            Value: !Ref WebUIHosting
           - Name: CLOUDFRONT_DISTRIBUTION_ID
-            Value: !Ref CloudFrontDistribution
+            Value: !If
+              - UseCloudFrontHosting
+              - !Ref CloudFrontDistribution
+              - ""
             # These VITE variables are used by the web ui in the
             # aws-exports.js Amplify config. The values are embedded in the
             # code at build time.
@@ -6633,7 +6820,10 @@ Resources:
               - "false"
               - "true"
           - Name: VITE_CLOUDFRONT_DOMAIN
-            Value: !Sub "https://${CloudFrontDistribution.DomainName}/"
+            Value: !If
+              - UseCloudFrontHosting
+              - !Sub "https://${CloudFrontDistribution.DomainName}/"
+              - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
           - Name: VITE_TEST_SET_BUCKET_NAME
             Value: !Ref TestSetBucket
           - Name: VITE_INPUT_BUCKET_NAME
@@ -7059,7 +7249,10 @@ Outputs:
     Value: !GetAtt CustomerManagedEncryptionKey.Arn
   ApplicationWebURL:
     Description: Application Web URL
-    Value: !Sub "https://${CloudFrontDistribution.DomainName}/"
+    Value: !If
+      - UseCloudFrontHosting
+      - !Sub "https://${CloudFrontDistribution.DomainName}/"
+      - !GetAtt ALBHostingStack.Outputs.WebUIURL
   S3InstallBucket:
     Description: Install S3 bucket name
     Value: !Ref InputBucket

--- a/template.yaml
+++ b/template.yaml
@@ -1681,7 +1681,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1753,7 +1753,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1821,7 +1821,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2270,7 +2270,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2385,7 +2385,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2454,7 +2454,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2908,7 +2908,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -3005,7 +3005,7 @@ Resources:
               Resource: !Sub "${WebUIBucket.Arn}/*"
               Condition:
                 StringEquals:
-                  "aws:sourceVpce": !GetAtt ALBHostingStack.Outputs.S3VPCEndpointId
+                  "aws:sourceVpce": !GetAtt ALBHOSTINGSTACK.Outputs.S3VPCEndpointId
             - !Ref AWS::NoValue
           - Effect: "Deny"
             Action:
@@ -5429,7 +5429,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
+          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5440,7 +5440,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
+          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5481,7 +5481,7 @@ Resources:
             - WebUIURL: !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}/"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
       AutoVerifiedAttributes:
         - email
       EmailConfiguration:
@@ -5527,7 +5527,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}"
-          - !GetAtt ALBHostingStack.Outputs.WebUIURL
+          - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
       AccessTokenValidity: 1
       EnableTokenRevocation: true
       ExplicitAuthFlows:
@@ -6653,7 +6653,7 @@ Resources:
   # ALB Hosting (alternative to CloudFront for GovCloud / private networks)
   ##########################################################################
 
-  ALBHostingStack:
+  ALBHOSTINGSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: UseALBHosting
     Properties:
@@ -6823,7 +6823,7 @@ Resources:
             Value: !If
               - UseCloudFrontHosting
               - !Sub "https://${CloudFrontDistribution.DomainName}/"
-              - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
+              - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
           - Name: VITE_TEST_SET_BUCKET_NAME
             Value: !Ref TestSetBucket
           - Name: VITE_INPUT_BUCKET_NAME
@@ -7252,7 +7252,7 @@ Outputs:
     Value: !If
       - UseCloudFrontHosting
       - !Sub "https://${CloudFrontDistribution.DomainName}/"
-      - !GetAtt ALBHostingStack.Outputs.WebUIURL
+      - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
   S3InstallBucket:
     Description: Install S3 bucket name
     Value: !Ref InputBucket


### PR DESCRIPTION
Adds an alternative web UI hosting option using Application Load Balancer
with S3 VPC Interface Endpoint, replacing CloudFront for environments
that require VPC-based hosting (GovCloud, private networks).

- New WebUIHosting parameter (CloudFront | ALB) with conditional resource creation
- ALB nested stack with S3 VPC endpoint, security groups, target registration
- Host-header and URL rewrite transforms for S3 static content serving
- All CORS origins, Cognito callbacks, and CodeBuild env vars resolve
  conditionally based on hosting mode
- Self-signed certificate helper script for demo/testing
- Fix CLI --parameters parsing for comma-delimited values (e.g., subnet lists)
