### PR TITLE
feat: Add ALB+S3 VPC hosting mode as alternative to CloudFront for private network deployments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,7 @@ This folder contains detailed documentation on various aspects of the GenAI Inte
 
 - [Well-Architected Framework Assessment](./well-architected.md) - Analysis based on AWS Well-Architected Framework
 - [AWS Services & IAM Roles](./aws-services-and-roles.md) - AWS services used and IAM role requirements
+- [ALB Hosting](./alb-hosting.md) - ALB+S3 hosting for private network and GovCloud deployments
 - [GovCloud Deployment](./govcloud-deployment.md) - Deployment guide for AWS GovCloud regions
 - [EU Region Model Support](./eu-region-model-support.md) - Model availability in EU regions
 

--- a/docs/alb-hosting.md
+++ b/docs/alb-hosting.md
@@ -1,0 +1,273 @@
+---
+title: "ALB Hosting Guide"
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+# ALB Hosting Guide
+
+## Overview
+
+The GenAI IDP Accelerator supports an alternative web UI hosting mode using an Application Load Balancer (ALB) with an S3 VPC Interface Endpoint, replacing CloudFront for environments that require VPC-based hosting.
+
+> **Note**: For standard deployments, CloudFront hosting (the default) is recommended. Use ALB hosting only when your environment has specific requirements that prevent using CloudFront.
+
+## When to Use ALB Hosting
+
+ALB hosting is designed for organizations that need the full IDP web UI but cannot use CloudFront due to network or compliance constraints:
+
+- **Private network requirements** — environments where all web traffic must remain within a VPC and internet-facing CDN endpoints are not permitted
+- **Regulated environments** — deployments that require all traffic to traverse private network paths with VPC-level security controls (security groups, NACLs, VPC Flow Logs)
+- **Corporate network restrictions** — organizations where users access applications exclusively through VPN or Direct Connect, and public CDN endpoints are blocked by policy
+- **Air-gapped or isolated VPCs** — environments with no internet egress where CloudFront cannot function
+
+> **Note on GovCloud**: GovCloud deployments use a separate headless template (no web UI or AppSync). ALB hosting is not applicable to GovCloud — see [GovCloud Deployment](./govcloud-deployment.md) instead.
+
+## Architecture
+
+### Standard Hosting (CloudFront)
+
+```
+Internet Users → CloudFront (Edge) → S3 Origin (WebUI Bucket)
+```
+
+### ALB Hosting
+
+```
+VPC Users → ALB → S3 VPC Interface Endpoint → S3 (WebUI Bucket)
+```
+
+The ALB hosting nested stack creates:
+
+- An Application Load Balancer (internal or internet-facing)
+- An S3 Interface VPC Endpoint for private connectivity to S3
+- Security groups controlling traffic between ALB and VPC endpoint
+- Listener rules with host-header rewrite and URL rewrite transforms to serve S3 static content as a single-page application
+- Custom resource Lambda functions for VPC CIDR lookup and VPC endpoint target registration
+
+## Prerequisites
+
+### VPC Requirements
+
+You need an existing VPC with the following:
+
+1. **At least 2 subnets in different Availability Zones** — required by ALB. These can be:
+   - **Private subnets** (recommended for internal ALBs) — must have a route to S3 via VPC endpoint (created by the stack) and to AWS service endpoints for SSM, CloudWatch, etc.
+   - **Public subnets** (for internet-facing ALBs) — must have an Internet Gateway route
+2. **DNS resolution enabled** — the VPC must have `enableDnsSupport` and `enableDnsHostnames` set to `true`
+3. **Sufficient IP space** — the S3 VPC Interface Endpoint creates ENIs in each subnet (one IP per subnet)
+
+### ACM Certificate
+
+An ACM certificate is required for the ALB HTTPS listener. Options:
+
+- **ACM-issued certificate** (recommended for production) — request via ACM with DNS or email validation
+- **Imported certificate** — import your organization's CA-signed certificate into ACM
+- **Self-signed certificate** (demo/testing only) — use the provided helper script:
+
+```bash
+# Generate and import a self-signed certificate
+CERT_ARN=$(./scripts/generate_self_signed_cert.sh --region us-east-1 --domain myapp.internal)
+echo "Certificate ARN: $CERT_ARN"
+
+# Options:
+#   --region   AWS region for ACM import (default: from AWS config)
+#   --domain   Domain name for the certificate CN/SAN (default: self-signed.internal)
+#   --days     Certificate validity in days (default: 365)
+```
+
+### Network Connectivity
+
+Users must be able to reach the ALB:
+
+- **Internal ALB**: Users need VPN, Direct Connect, or access from within the VPC (e.g., WorkSpaces, Cloud9, SSM port forwarding)
+- **Internet-facing ALB**: Users can access directly, but the ALB security group controls which source IPs are allowed
+
+## Deployment
+
+### Option 1: IDP CLI
+
+```bash
+idp-cli deploy \
+    --stack-name my-idp-stack \
+    --admin-email user@example.com \
+    --from-code . \
+    --parameters "WebUIHosting=ALB,ALBVpcId=vpc-xxxxx,ALBSubnetIds=subnet-aaaa,subnet-bbbb,ALBCertificateArn=arn:aws:acm:REGION:ACCOUNT:certificate/xxxxx,ALBScheme=internal" \
+    --wait
+```
+
+### Option 2: CloudFormation Console
+
+When deploying via the CloudFormation console, set the following parameters in the **Web UI Hosting** and **ALB Hosting** parameter sections:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `WebUIHosting` | `ALB` | Switches from CloudFront to ALB hosting |
+| `ALBVpcId` | `vpc-xxxxx` | VPC for the ALB and S3 VPC endpoint |
+| `ALBSubnetIds` | `subnet-aaaa,subnet-bbbb` | Minimum 2 subnets in different AZs |
+| `ALBCertificateArn` | `arn:aws:acm:...` | ACM certificate ARN for HTTPS |
+| `ALBScheme` | `internal` or `internet-facing` | ALB accessibility |
+| `ALBAllowedCIDRs` | *(optional)* | Comma-separated CIDRs for ALB ingress. Empty = VPC CIDR |
+
+### Switching an Existing Stack
+
+You can switch an existing CloudFront-hosted stack to ALB hosting (or vice versa) by updating the stack with the new `WebUIHosting` parameter value and providing the required ALB parameters. CloudFormation will conditionally create or remove the appropriate resources.
+
+## Parameters Reference
+
+### WebUIHosting
+
+- **Type**: String
+- **Default**: `CloudFront`
+- **Allowed Values**: `CloudFront`, `ALB`
+- **Description**: Selects the frontend hosting method. CloudFront is the default for standard deployments. ALB is for private network deployments that require VPC-based hosting.
+
+### ALBVpcId
+
+- **Type**: String
+- **Required when**: `WebUIHosting=ALB`
+- **Description**: The VPC ID where the ALB and S3 VPC Interface Endpoint will be created.
+
+### ALBSubnetIds
+
+- **Type**: CommaDelimitedList
+- **Required when**: `WebUIHosting=ALB`
+- **Description**: At least 2 subnet IDs in different Availability Zones. Use private subnets for internal ALBs, public subnets for internet-facing ALBs.
+
+### ALBCertificateArn
+
+- **Type**: String
+- **Required when**: `WebUIHosting=ALB`
+- **Description**: ACM certificate ARN for the ALB HTTPS listener. Can be an ACM-issued certificate, an imported certificate, or a self-signed certificate (for testing).
+
+### ALBScheme
+
+- **Type**: String
+- **Default**: `internal`
+- **Allowed Values**: `internal`, `internet-facing`
+- **Description**: Controls ALB accessibility. Use `internal` for private network access (recommended). Use `internet-facing` for public access.
+
+### ALBAllowedCIDRs
+
+- **Type**: String
+- **Default**: *(empty)*
+- **Description**: Comma-separated CIDR ranges allowed to access the ALB on port 443. When empty, the VPC CIDR is used automatically (recommended for internal ALBs). Specify explicit CIDRs to restrict access to specific networks.
+
+## How It Works
+
+### Conditional Resource Creation
+
+When `WebUIHosting=ALB`:
+
+- CloudFront distribution, Origin Access Identity, and security headers policy are **not created**
+- ALB nested stack is created with all ALB infrastructure
+- S3 WebUI bucket omits `WebsiteConfiguration` (ALB handles routing)
+- S3 bucket policy grants access via `aws:sourceVpce` condition instead of CloudFront OAI
+
+When `WebUIHosting=CloudFront` (default):
+
+- ALB nested stack is **not created**
+- Standard CloudFront distribution with OAI is created
+
+### Request Flow (ALB Mode)
+
+1. User sends HTTPS request to the ALB
+2. ALB listener rule matches the path pattern
+3. ALB applies **host-header rewrite** transform — sets the Host header to the S3 bucket's regional endpoint (`bucket.s3.region.amazonaws.com`)
+4. ALB applies **URL rewrite** transform for root path (`/` → `/index.html`) to support SPA routing
+5. Request is forwarded to the S3 VPC Interface Endpoint ENI IPs (registered as ALB targets)
+6. S3 serves the content through the VPC endpoint
+
+### Automatic Integration
+
+The following are automatically configured based on the `WebUIHosting` parameter — no manual configuration is needed:
+
+- **S3 CORS origins** — all bucket CORS `AllowedOrigins` resolve to the ALB URL
+- **Cognito callback/logout URLs** — OAuth redirect URLs point to the ALB URL
+- **UI build configuration** — the `VITE_CLOUDFRONT_DOMAIN` environment variable resolves to the ALB URL
+- **CodeBuild post-deploy** — CloudFront cache invalidation is skipped in ALB mode
+- **Stack outputs** — `ApplicationWebURL` returns the ALB URL
+
+## Accessing the UI
+
+### Internal ALB
+
+For internal ALBs, you need network connectivity to the VPC. Common approaches:
+
+**VPN or Direct Connect** (recommended for production): Access the ALB DNS name directly through your organization's private network connection.
+
+**SSM Port Forwarding** (recommended for testing):
+
+1. Launch a small EC2 instance (e.g., t3.micro) in the same VPC with an IAM role that includes `AmazonSSMManagedInstanceCore`
+2. Start a port forwarding session:
+   ```bash
+   aws ssm start-session \
+     --target INSTANCE_ID \
+     --document-name AWS-StartPortForwardingSessionToRemoteHost \
+     --parameters '{"host":["ALB_DNS_NAME"],"portNumber":["443"],"localPortNumber":["8443"]}'
+   ```
+3. Add a local hosts file entry so the browser sends the correct Host header:
+   ```bash
+   echo "127.0.0.1 ALB_DNS_NAME" | sudo tee -a /etc/hosts
+   ```
+4. Open `https://ALB_DNS_NAME:8443/` in your browser (accept the certificate warning for self-signed certs)
+5. Remove the hosts entry when done testing
+
+### Internet-Facing ALB
+
+Access the ALB DNS name directly from the stack outputs:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name my-idp-stack \
+  --query 'Stacks[0].Outputs[?OutputKey==`ApplicationWebURL`].OutputValue' \
+  --output text
+```
+
+## Security Considerations
+
+- ALB security group restricts ingress to port 443 from the VPC CIDR (or specified CIDRs)
+- ALB egress is restricted to the VPC endpoint security group on port 443 only
+- S3 bucket policy uses `aws:sourceVpce` condition — only requests through the VPC endpoint are allowed
+- S3 VPC endpoint policy is scoped to the WebUI bucket ARN only
+- ALB enforces TLS 1.3 (`ELBSecurityPolicy-TLS13-1-2-2021-06`)
+- ALB drops invalid HTTP header fields (`routing.http.drop_invalid_header_fields.enabled`)
+- ALB access logs are written to the stack's logging bucket under `alb-access-logs/` prefix
+- All traffic between ALB and S3 traverses the VPC endpoint (no internet path)
+
+## Troubleshooting
+
+### 403 Forbidden
+
+- Verify the ALB target group health checks are passing (expected HTTP codes: 200, 307, 405)
+- Check the S3 bucket policy includes the correct VPC endpoint ID in the `aws:sourceVpce` condition
+- Confirm the ALB listener rules have the host-header rewrite transform configured correctly
+
+### 404 Not Found
+
+- The ALB default action returns 404 for unmatched paths. Ensure your request path matches a listener rule (`/` or `/*`)
+- Verify the WebUI bucket contains `index.html` and assets — check the CodeBuild project logs for build errors
+
+### Target Group Unhealthy
+
+- The custom resource Lambda registers S3 VPC endpoint ENI private IPs as ALB targets. If the VPC endpoint was recreated, targets may reference stale IPs
+- Verify the VPC endpoint security group allows inbound HTTPS (port 443) from the ALB security group
+
+### UI Not Loading After Deploy
+
+- The UI is built and deployed to S3 by CodeBuild during stack creation/update. Check the CodeBuild project logs for errors
+- Verify the `VITE_CLOUDFRONT_DOMAIN` build environment variable resolves to the ALB URL (not a CloudFront domain)
+
+## Comparison: CloudFront vs ALB Hosting
+
+| Feature | CloudFront | ALB |
+|---------|-----------|-----|
+| Global edge caching | ✅ | ❌ |
+| VPC-only access | ❌ | ✅ |
+| Custom domain (Route53) | Via CloudFront alias | Via ALB alias record |
+| WAF integration | ✅ (CloudFront WAF) | ✅ (Regional WAF) |
+| Cost model | Data transfer per GB | Hourly + data transfer |
+| Geo restrictions | ✅ Built-in | ❌ (use security groups/NACLs) |
+| SPA routing | S3 error document | ALB URL rewrite transform |
+| TLS termination | CloudFront edge | ALB in VPC |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ SPDX-License-Identifier: MIT-0
 - **DynamoDB**: Tracking and concurrency management
 - **CloudWatch**: Comprehensive monitoring and logging
 - **Web UI**: Browser-based interface for document management and visualization
-  - CloudFront distribution for global availability
+  - CloudFront distribution for global availability (default), or ALB for VPC-based hosting (see [ALB Hosting](./alb-hosting.md))
   - Cognito user authentication
   - GraphQL API for UI-backend interactions
 - **Evaluation**: Document processing accuracy assessment system
@@ -69,7 +69,7 @@ The main template handles all pattern-agnostic resources and infrastructure:
 - CloudWatch Alarms and Dashboard
 - SNS Topics for Alerts
 - Web UI Infrastructure:
-  - CloudFront Distribution
+  - CloudFront Distribution (default) or Application Load Balancer ([ALB Hosting](./alb-hosting.md))
   - S3 Bucket for static web assets
   - CodeBuild project for UI deployment
 - Authentication:
@@ -149,8 +149,8 @@ For detailed information about the Web UI, its features, and usage, see [web-ui.
    - Optional self-signup can be enabled with domain restrictions
    - Identity pools provide secure, temporary AWS credentials
 
-2. **Content Delivery**: CloudFront distribution serves the static web assets
-   - Global availability and low latency
+- **Content Delivery**: CloudFront distribution serves the static web assets (default), or an Application Load Balancer for VPC-based hosting (see [ALB Hosting](./alb-hosting.md))
+   - Global availability and low latency (CloudFront) or private network access (ALB)
    - WAF integration for added security (optional)
    - Geographical restrictions can be applied
 

--- a/docs/aws-services-and-roles.md
+++ b/docs/aws-services-and-roles.md
@@ -21,7 +21,8 @@ This document outlines the AWS services used by the GenAI Intelligent Document P
 | **AWS Step Functions** | Orchestrates document processing workflows | ✓ | ✓ |
 | **Amazon SQS** | Queues documents for processing and handles throttling | ✓ | ✓ |
 | **Amazon EventBridge** | Triggers document processing workflows when files are uploaded | ✓ | ✓ |
-| **Amazon CloudFront** | Delivers the web UI with global distribution | ✓ | ✓ |
+| **Amazon CloudFront** | Delivers the web UI with global distribution (default hosting mode) | ✓ | ✓ |
+| **Elastic Load Balancing (ALB)** | Alternative web UI hosting via Application Load Balancer for VPC-based deployments (see [ALB Hosting](./alb-hosting.md)) | ✓ | ✓ |
 | **AWS CloudFormation** | Deploys and manages the solution infrastructure | ✓ | |
 | **AWS SAM** | Simplifies serverless application deployment | ✓ | |
 | **AWS CodeBuild** | Builds and packages the web UI assets | ✓ | |
@@ -208,7 +209,7 @@ When deploying this solution, consider the following security best practices:
    * Enable encryption for DynamoDB tables
 
 2. **Network Security**:
-   * Use CloudFront security features (geo-restrictions, HTTPS, etc.)
+   * Use CloudFront security features (geo-restrictions, HTTPS, etc.) or ALB security groups for [VPC-based hosting](./alb-hosting.md)
    * Configure AWS WAF to protect web interfaces
 
 3. **Authentication**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,8 +270,9 @@ Key parameters that can be configured during CloudFormation deployment:
 - `ExecutionTimeThresholdMs`: Maximum acceptable execution time before alerting (default: 30000 ms)
 - `LogLevel`: Set logging level (DEBUG, INFO, WARN, ERROR)
 - `WAFAllowedIPv4Ranges`: IP restrictions for web UI access (default: allow all)
-- `CloudFrontPriceClass`: Set CloudFront price class for UI distribution
-- `CloudFrontAllowedGeos`: Optional geographic restrictions for UI access
+- `CloudFrontPriceClass`: Set CloudFront price class for UI distribution (CloudFront hosting only)
+- `CloudFrontAllowedGeos`: Optional geographic restrictions for UI access (CloudFront hosting only)
+- `WebUIHosting`: Select hosting mode — `CloudFront` (default) or `ALB` for VPC-based hosting (see [ALB Hosting](./alb-hosting.md))
 - `CustomConfigPath`: Optional S3 URI to a custom configuration file that overrides pattern presets. Leave blank to use selected pattern configuration. Example: s3://my-bucket/custom-config/config.yaml
 
 ### Integration and Tracing Parameters

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -295,7 +295,7 @@ The web UI is automatically deployed as part of the CloudFormation stack. The de
 
 1. Creates required Cognito resources (User Pool, Identity Pool)
 2. Builds and deploys the React application to S3
-3. Sets up CloudFront distribution for content delivery
+3. Sets up CloudFront distribution for content delivery (or ALB for VPC-based hosting — see [ALB Hosting](./alb-hosting.md))
 4. Configures necessary IAM roles and permissions
 
 ## Accessing the Web UI
@@ -342,7 +342,7 @@ The web UI implementation includes several security features:
 - All communication is encrypted using HTTPS
 - Authentication tokens are automatically rotated
 - Session timeouts are enforced
-- CloudFront distribution uses secure configuration
+- CloudFront distribution uses secure configuration (or ALB with TLS 1.3 for VPC-based hosting)
 - S3 buckets are configured with appropriate security policies
 - API access is controlled through IAM and Cognito
 - Web Application Firewall (WAF) protection for AppSync API
@@ -371,7 +371,7 @@ The web UI includes built-in monitoring:
 
 - CloudWatch metrics for API and authentication activity
 - Access logs in CloudWatch Logs
-- CloudFront distribution logs
+- CloudFront distribution logs (or ALB access logs for VPC-based hosting)
 - Error tracking and reporting
 - Performance monitoring
 
@@ -379,6 +379,6 @@ To troubleshoot issues:
 
 1. Check CloudWatch Logs for application errors
 2. Verify Cognito user status in the AWS Console
-3. Check CloudFront distribution status
+3. Check CloudFront distribution status (or ALB target group health for VPC-based hosting)
 4. Verify API endpoints are accessible
 5. Review browser console for client-side errors

--- a/docs/well-architected.md
+++ b/docs/well-architected.md
@@ -51,14 +51,19 @@ The GenAI Intelligent Document Processing (GenAIIDP) Accelerator demonstrates st
   - For production environments, use `LogLevel: WARN` or `LogLevel: ERROR` in your CloudFormation deployment parameters
   - Implement log filtering and masking for any essential INFO-level logs that must be retained
   - Regularly audit CloudWatch log groups to ensure no sensitive information is being captured
-- **CloudFront Security Enhancement**: 
+- **CloudFront Security Enhancement** (CloudFront hosting mode): 
   - Create a custom domain with a custom ACM certificate for the CloudFront distribution
   - Enforce TLS 1.2 or greater protocol in the CloudFront security policy
   - Configure secure response headers (X-Content-Type-Options, X-Frame-Options, Content-Security-Policy)
   - Restrict viewer access using signed URLs or cookies for sensitive content
+- **ALB Hosting Security** (ALB hosting mode — see [ALB Hosting](./alb-hosting.md)):
+  - Use internal ALB scheme to restrict access to VPC-connected users
+  - Configure `ALBAllowedCIDRs` to limit ingress to specific network ranges
+  - Use a CA-signed or ACM-issued certificate (avoid self-signed in production)
+  - Enable VPC Flow Logs to monitor traffic to the ALB and S3 VPC endpoint
 - **Additional WAF Protection**: 
-  - Deploy a WAF WebACL with GLOBAL scope in the us-east-1 region
-  - Associate this WAF with the CloudFront distribution to protect the UI
+  - Deploy a WAF WebACL with GLOBAL scope in the us-east-1 region (CloudFront) or REGIONAL scope (ALB)
+  - Associate this WAF with the CloudFront distribution or ALB to protect the UI
   - Enable core rule sets (AWS Managed Rules) including protections against XSS and SQL injection
   - Create custom rules for specific application threats
 - Consider implementing VPC endpoints for enhanced network isolation of sensitive services.

--- a/lib/idp_cli_pkg/idp_cli/cli.py
+++ b/lib/idp_cli_pkg/idp_cli/cli.py
@@ -440,10 +440,18 @@ def deploy(
         # Parse additional parameters
         additional_params = {}
         if parameters:
-            for param in parameters.split(","):
-                if "=" in param:
-                    key, value = param.split("=", 1)
-                    additional_params[key.strip()] = value.strip()
+            # Parse key=value pairs separated by commas, but handle values
+            # that themselves contain commas (e.g., subnet lists).
+            # Strategy: split on commas that are followed by a key= pattern.
+            import re
+
+            for match in re.finditer(
+                r"([A-Za-z][A-Za-z0-9]*)=((?:(?![A-Za-z][A-Za-z0-9]*=).)*)",
+                parameters,
+            ):
+                key = match.group(1).strip()
+                value = match.group(2).strip().rstrip(",")
+                additional_params[key] = value
 
         # Deploy stack via SDK (build_parameters is called internally by client.stack.deploy)
         # Debug: show custom config path hint before deploy

--- a/nested/alb-hosting/template.yaml
+++ b/nested/alb-hosting/template.yaml
@@ -1,0 +1,469 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  ALB hosting nested stack for GenAI IDP Web UI.
+  Creates an Application Load Balancer with S3 VPC Interface Endpoint
+  to serve static web content without CloudFront.
+
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC ID for the ALB and S3 VPC endpoint
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Subnet IDs for the ALB (minimum 2 in different AZs)
+
+  CertificateArn:
+    Type: String
+    Description: ACM certificate ARN for the ALB HTTPS listener
+
+  ALBScheme:
+    Type: String
+    Default: internal
+    AllowedValues: [internal, internet-facing]
+    Description: ALB scheme
+
+  ALBAllowedCIDRs:
+    Type: String
+    Default: ""
+    Description: >-
+      Comma-separated CIDR ranges for ALB security group ingress.
+      Empty means use VPC CIDR.
+
+  WebUIBucketName:
+    Type: String
+    Description: S3 bucket name for static web content
+
+  WebUIBucketArn:
+    Type: String
+    Description: S3 bucket ARN
+
+  StackName:
+    Type: String
+    Description: Parent stack name for resource naming
+
+  PermissionsBoundaryArn:
+    Type: String
+    Default: ""
+    Description: Optional IAM permissions boundary ARN
+
+  LoggingBucketName:
+    Type: String
+    Description: S3 bucket name for ALB access logs
+
+Conditions:
+  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryArn, ""]]
+  UseVpcCidr: !Equals [!Ref ALBAllowedCIDRs, ""]
+
+Resources:
+  ##########################################################################
+  # VPC CIDR Lookup (when ALBAllowedCIDRs is empty)
+  ##########################################################################
+
+  VpcCidrLookupRole:
+    Type: AWS::IAM::Role
+    Condition: UseVpcCidr
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub "lambda.${AWS::URLSuffix}"
+            Action: sts:AssumeRole
+      PermissionsBoundary: !If
+        - HasPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: VpcCidrLookup
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeVpcs
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  VpcCidrLookupFunction:
+    Type: AWS::Lambda::Function
+    Condition: UseVpcCidr
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "Custom resource Lambda does not need VPC access"
+          - id: W92
+            reason: "Custom resource Lambda does not need reserved concurrency"
+    # checkov:skip=CKV_AWS_116: "DLQ not required for CloudFormation custom resource"
+    # checkov:skip=CKV_AWS_117: "Function does not need VPC access"
+    # checkov:skip=CKV_AWS_115: "Function does not need reserved concurrency"
+    Properties:
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 30
+      MemorySize: 128
+      Role: !GetAtt VpcCidrLookupRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          def handler(event, context):
+              if event["RequestType"] == "Delete":
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                  return
+              try:
+                  vpc_id = event["ResourceProperties"]["VpcId"]
+                  ec2 = boto3.client("ec2")
+                  resp = ec2.describe_vpcs(VpcIds=[vpc_id])
+                  cidr = resp["Vpcs"][0]["CidrBlock"]
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {"CidrBlock": cidr})
+              except Exception as e:
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
+
+  VpcCidrLookup:
+    Type: Custom::VpcCidrLookup
+    Condition: UseVpcCidr
+    Properties:
+      ServiceToken: !GetAtt VpcCidrLookupFunction.Arn
+      VpcId: !Ref VpcId
+
+  ##########################################################################
+  # Security Groups
+  ##########################################################################
+
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W5
+            reason: "Egress restricted to VPC endpoint security group on port 443"
+    Properties:
+      GroupDescription: !Sub "${StackName} ALB Security Group"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !If
+            - UseVpcCidr
+            - !GetAtt VpcCidrLookup.CidrBlock
+            - !Select [0, !Split [",", !Ref ALBAllowedCIDRs]]
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-alb-sg"
+
+  EndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "${StackName} S3 VPC Endpoint Security Group"
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref ALBSecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-s3-endpoint-sg"
+
+  ALBToEndpointEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref ALBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      DestinationSecurityGroupId: !Ref EndpointSecurityGroup
+
+  ##########################################################################
+  # S3 Interface VPC Endpoint
+  ##########################################################################
+
+  S3InterfaceEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcEndpointType: Interface
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.s3"
+      VpcId: !Ref VpcId
+      SubnetIds: !Ref SubnetIds
+      SecurityGroupIds:
+        - !Ref EndpointSecurityGroup
+      PrivateDnsEnabled: false
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowWebUIBucketOnly
+            Effect: Allow
+            Principal: "*"
+            Action:
+              - "s3:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}"
+              - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}/*"
+
+  ##########################################################################
+  # ALB Target Group & Target Registration
+  ##########################################################################
+
+  S3TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${StackName}-s3-tg"
+      TargetType: ip
+      Protocol: HTTPS
+      Port: 443
+      VpcId: !Ref VpcId
+      HealthCheckProtocol: HTTPS
+      HealthCheckPort: "443"
+      HealthCheckPath: /
+      Matcher:
+        HttpCode: "200,307,405"
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-s3-target-group"
+
+  RegisterTargetsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub "lambda.${AWS::URLSuffix}"
+            Action: sts:AssumeRole
+      PermissionsBoundary: !If
+        - HasPermissionsBoundary
+        - !Ref PermissionsBoundaryArn
+        - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: RegisterTargets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeVpcEndpoints
+                  - ec2:DescribeNetworkInterfaces
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - elasticloadbalancing:RegisterTargets
+                  - elasticloadbalancing:DeregisterTargets
+                Resource: !Sub "arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+
+  RegisterTargetsFunction:
+    Type: AWS::Lambda::Function
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "Custom resource Lambda does not need VPC access"
+          - id: W92
+            reason: "Custom resource Lambda does not need reserved concurrency"
+    # checkov:skip=CKV_AWS_116: "DLQ not required for CloudFormation custom resource"
+    # checkov:skip=CKV_AWS_117: "Function does not need VPC access"
+    # checkov:skip=CKV_AWS_115: "Function does not need reserved concurrency"
+    Properties:
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 60
+      MemorySize: 128
+      Role: !GetAtt RegisterTargetsRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          def handler(event, context):
+              try:
+                  ec2 = boto3.client("ec2")
+                  elbv2 = boto3.client("elbv2")
+                  vpce_id = event["ResourceProperties"]["VpcEndpointId"]
+                  tg_arn = event["ResourceProperties"]["TargetGroupArn"]
+
+                  # Get VPC endpoint ENI IDs
+                  vpce_resp = ec2.describe_vpc_endpoints(VpcEndpointIds=[vpce_id])
+                  eni_ids = vpce_resp["VpcEndpoints"][0]["NetworkInterfaceIds"]
+
+                  # Get private IPs from ENIs
+                  eni_resp = ec2.describe_network_interfaces(NetworkInterfaceIds=eni_ids)
+                  ips = [eni["PrivateIpAddress"] for eni in eni_resp["NetworkInterfaces"]]
+
+                  if event["RequestType"] == "Delete":
+                      # Deregister targets
+                      targets = [{"Id": ip, "Port": 443} for ip in ips]
+                      try:
+                          elbv2.deregister_targets(TargetGroupArn=tg_arn, Targets=targets)
+                      except Exception:
+                          pass  # Best effort on delete
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                      return
+
+                  # Register targets
+                  targets = [{"Id": ip, "Port": 443} for ip in ips]
+                  elbv2.register_targets(TargetGroupArn=tg_arn, Targets=targets)
+
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {
+                      "IpAddresses": ",".join(ips),
+                      "TargetCount": str(len(ips)),
+                  })
+              except Exception as e:
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
+
+  RegisterTargetsCustomResource:
+    Type: Custom::RegisterTargets
+    DependsOn:
+      - S3InterfaceEndpoint
+      - S3TargetGroup
+    Properties:
+      ServiceToken: !GetAtt RegisterTargetsFunction.Arn
+      VpcEndpointId: !Ref S3InterfaceEndpoint
+      TargetGroupArn: !Ref S3TargetGroup
+
+  ##########################################################################
+  # Application Load Balancer
+  ##########################################################################
+
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W52
+            reason: "ALB access logging is configured to the logging bucket"
+    Properties:
+      Name: !Sub "${StackName}-webui-alb"
+      Type: application
+      Scheme: !Ref ALBScheme
+      Subnets: !Ref SubnetIds
+      SecurityGroups:
+        - !Ref ALBSecurityGroup
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: "60"
+        - Key: routing.http2.enabled
+          Value: "true"
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: "true"
+        - Key: access_logs.s3.enabled
+          Value: "true"
+        - Key: access_logs.s3.bucket
+          Value: !Ref LoggingBucketName
+        - Key: access_logs.s3.prefix
+          Value: alb-access-logs
+      Tags:
+        - Key: Name
+          Value: !Sub "${StackName}-webui-alb"
+
+  ##########################################################################
+  # ALB Listener and Rules
+  ##########################################################################
+
+  ALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      DefaultActions:
+        - Type: fixed-response
+          FixedResponseConfig:
+            StatusCode: "404"
+            ContentType: text/plain
+            MessageBody: "Not Found"
+
+  # Rule 1: Root path - rewrite to /index.html for SPA entry point
+  ALBListenerRuleRoot:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn: RegisterTargetsCustomResource
+    Properties:
+      ListenerArn: !Ref ALBListener
+      Priority: 1
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/"
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref S3TargetGroup
+      Transforms:
+        - Type: host-header-rewrite
+          HostHeaderRewriteConfig:
+            Rewrites:
+              - Regex: ".*"
+                Replace: !Sub "${WebUIBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}"
+        - Type: url-rewrite
+          UrlRewriteConfig:
+            Rewrites:
+              - Regex: "^/$"
+                Replace: "/index.html"
+
+  # Rule 2: All other paths - serve static assets (JS, CSS, images, fonts, etc.)
+  ALBListenerRuleCatchAll:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn: RegisterTargetsCustomResource
+    Properties:
+      ListenerArn: !Ref ALBListener
+      Priority: 2
+      Conditions:
+        - Field: path-pattern
+          PathPatternConfig:
+            Values:
+              - "/*"
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref S3TargetGroup
+      Transforms:
+        - Type: host-header-rewrite
+          HostHeaderRewriteConfig:
+            Rewrites:
+              - Regex: ".*"
+                Replace: !Sub "${WebUIBucketName}.s3.${AWS::Region}.${AWS::URLSuffix}"
+
+Outputs:
+  WebUIURL:
+    Description: Web UI URL via ALB
+    Value: !Sub "https://${ALB.DNSName}"
+
+  ALBDNSName:
+    Description: ALB DNS name
+    Value: !GetAtt ALB.DNSName
+
+  ALBArn:
+    Description: ALB ARN
+    Value: !Ref ALB
+
+  S3VPCEndpointId:
+    Description: S3 VPC Interface Endpoint ID
+    Value: !Ref S3InterfaceEndpoint
+
+  ALBHostedZoneID:
+    Description: ALB Canonical Hosted Zone ID (for Route53 alias records)
+    Value: !GetAtt ALB.CanonicalHostedZoneID

--- a/nested/alb-hosting/template.yaml
+++ b/nested/alb-hosting/template.yaml
@@ -56,16 +56,14 @@ Parameters:
 
 Conditions:
   HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryArn, ""]]
-  UseVpcCidr: !Equals [!Ref ALBAllowedCIDRs, ""]
 
 Resources:
   ##########################################################################
-  # VPC CIDR Lookup (when ALBAllowedCIDRs is empty)
+  # Security Group Ingress Manager (handles single or multiple CIDRs)
   ##########################################################################
 
-  VpcCidrLookupRole:
+  SGIngressManagerRole:
     Type: AWS::IAM::Role
-    Condition: UseVpcCidr
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -79,14 +77,20 @@ Resources:
         - !Ref PermissionsBoundaryArn
         - !Ref AWS::NoValue
       Policies:
-        - PolicyName: VpcCidrLookup
+        - PolicyName: SGIngressManager
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - ec2:DescribeVpcs
+                  - ec2:DescribeSecurityGroupRules
                 Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ec2:AuthorizeSecurityGroupIngress
+                  - ec2:RevokeSecurityGroupIngress
+                Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*"
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
@@ -94,9 +98,8 @@ Resources:
                   - logs:PutLogEvents
                 Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
 
-  VpcCidrLookupFunction:
+  SGIngressManagerFunction:
     Type: AWS::Lambda::Function
-    Condition: UseVpcCidr
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -110,33 +113,94 @@ Resources:
     Properties:
       Runtime: python3.12
       Handler: index.handler
-      Timeout: 30
+      Timeout: 60
       MemorySize: 128
-      Role: !GetAtt VpcCidrLookupRole.Arn
+      Role: !GetAtt SGIngressManagerRole.Arn
       Code:
         ZipFile: |
           import boto3
           import cfnresponse
 
+          ec2 = boto3.client("ec2")
+
+          def get_cidrs(props):
+              """Resolve CIDR list: use provided CIDRs or look up VPC CIDR."""
+              cidr_str = props.get("AllowedCIDRs", "")
+              if cidr_str:
+                  return [c.strip() for c in cidr_str.split(",") if c.strip()]
+              # Fall back to VPC CIDR
+              vpc_id = props["VpcId"]
+              resp = ec2.describe_vpcs(VpcIds=[vpc_id])
+              return [resp["Vpcs"][0]["CidrBlock"]]
+
+          def get_existing_cidrs(sg_id):
+              """Get CIDRs from existing ingress rules tagged by this custom resource."""
+              resp = ec2.describe_security_group_rules(
+                  Filters=[{"Name": "group-id", "Values": [sg_id]}]
+              )
+              return [
+                  r["CidrIpv4"] for r in resp["SecurityGroupRules"]
+                  if not r["IsEgress"] and r.get("CidrIpv4")
+                  and r.get("FromPort") == 443 and r.get("ToPort") == 443
+              ]
+
+          def add_cidrs(sg_id, cidrs):
+              for cidr in cidrs:
+                  try:
+                      ec2.authorize_security_group_ingress(
+                          GroupId=sg_id,
+                          IpPermissions=[{
+                              "IpProtocol": "tcp", "FromPort": 443, "ToPort": 443,
+                              "IpRanges": [{"CidrIp": cidr, "Description": "ALB ingress"}]
+                          }]
+                      )
+                  except ec2.exceptions.ClientError as e:
+                      if "Duplicate" not in str(e):
+                          raise
+
+          def remove_cidrs(sg_id, cidrs):
+              for cidr in cidrs:
+                  try:
+                      ec2.revoke_security_group_ingress(
+                          GroupId=sg_id,
+                          IpPermissions=[{
+                              "IpProtocol": "tcp", "FromPort": 443, "ToPort": 443,
+                              "IpRanges": [{"CidrIp": cidr}]
+                          }]
+                      )
+                  except Exception:
+                      pass  # Best effort on removal
+
           def handler(event, context):
-              if event["RequestType"] == "Delete":
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-                  return
               try:
-                  vpc_id = event["ResourceProperties"]["VpcId"]
-                  ec2 = boto3.client("ec2")
-                  resp = ec2.describe_vpcs(VpcIds=[vpc_id])
-                  cidr = resp["Vpcs"][0]["CidrBlock"]
-                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {"CidrBlock": cidr})
+                  props = event["ResourceProperties"]
+                  sg_id = props["SecurityGroupId"]
+
+                  if event["RequestType"] == "Delete":
+                      existing = get_existing_cidrs(sg_id)
+                      remove_cidrs(sg_id, existing)
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                      return
+
+                  cidrs = get_cidrs(props)
+
+                  if event["RequestType"] == "Update":
+                      # Remove old rules, add new ones
+                      existing = get_existing_cidrs(sg_id)
+                      to_remove = set(existing) - set(cidrs)
+                      to_add = set(cidrs) - set(existing)
+                      remove_cidrs(sg_id, to_remove)
+                      add_cidrs(sg_id, to_add)
+                  else:
+                      # Create
+                      add_cidrs(sg_id, cidrs)
+
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {
+                      "CIDRs": ",".join(cidrs),
+                      "RuleCount": str(len(cidrs)),
+                  })
               except Exception as e:
                   cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
-
-  VpcCidrLookup:
-    Type: Custom::VpcCidrLookup
-    Condition: UseVpcCidr
-    Properties:
-      ServiceToken: !GetAtt VpcCidrLookupFunction.Arn
-      VpcId: !Ref VpcId
 
   ##########################################################################
   # Security Groups
@@ -149,20 +213,23 @@ Resources:
         rules_to_suppress:
           - id: W5
             reason: "Egress restricted to VPC endpoint security group on port 443"
+          - id: W9
+            reason: "Ingress rules managed by SGIngressManager custom resource"
     Properties:
       GroupDescription: !Sub "${StackName} ALB Security Group"
       VpcId: !Ref VpcId
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: !If
-            - UseVpcCidr
-            - !GetAtt VpcCidrLookup.CidrBlock
-            - !Select [0, !Split [",", !Ref ALBAllowedCIDRs]]
       Tags:
         - Key: Name
           Value: !Sub "${StackName}-alb-sg"
+
+  SGIngressManagerCustomResource:
+    Type: Custom::SGIngressManager
+    DependsOn: ALBSecurityGroup
+    Properties:
+      ServiceToken: !GetAtt SGIngressManagerFunction.Arn
+      SecurityGroupId: !Ref ALBSecurityGroup
+      VpcId: !Ref VpcId
+      AllowedCIDRs: !Ref ALBAllowedCIDRs
 
   EndpointSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -174,6 +241,13 @@ Resources:
           FromPort: 443
           ToPort: 443
           SourceSecurityGroupId: !Ref ALBSecurityGroup
+          Description: "Allow HTTPS from ALB security group"
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          DestinationSecurityGroupId: !Ref ALBSecurityGroup
+          Description: "Allow HTTPS responses back to ALB security group"
       Tags:
         - Key: Name
           Value: !Sub "${StackName}-s3-endpoint-sg"
@@ -186,6 +260,7 @@ Resources:
       FromPort: 443
       ToPort: 443
       DestinationSecurityGroupId: !Ref EndpointSecurityGroup
+      Description: "Allow HTTPS to S3 VPC endpoint security group"
 
   ##########################################################################
   # S3 Interface VPC Endpoint
@@ -204,14 +279,20 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: AllowWebUIBucketOnly
+          - Sid: AllowWebUIBucketRead
             Effect: Allow
             Principal: "*"
             Action:
-              - "s3:*"
+              - "s3:GetObject"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}/*"
+          - Sid: AllowWebUIBucketList
+            Effect: Allow
+            Principal: "*"
+            Action:
+              - "s3:ListBucket"
             Resource:
               - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}"
-              - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucketName}/*"
 
   ##########################################################################
   # ALB Target Group & Target Registration
@@ -313,7 +394,6 @@ Resources:
                   ips = [eni["PrivateIpAddress"] for eni in eni_resp["NetworkInterfaces"]]
 
                   if event["RequestType"] == "Delete":
-                      # Deregister targets
                       targets = [{"Id": ip, "Port": 443} for ip in ips]
                       try:
                           elbv2.deregister_targets(TargetGroupArn=tg_arn, Targets=targets)
@@ -322,7 +402,21 @@ Resources:
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
                       return
 
-                  # Register targets
+                  if event["RequestType"] == "Update":
+                      # Deregister old targets from previous endpoint (if changed)
+                      old_vpce_id = event.get("OldResourceProperties", {}).get("VpcEndpointId", "")
+                      if old_vpce_id and old_vpce_id != vpce_id:
+                          try:
+                              old_resp = ec2.describe_vpc_endpoints(VpcEndpointIds=[old_vpce_id])
+                              old_eni_ids = old_resp["VpcEndpoints"][0]["NetworkInterfaceIds"]
+                              old_eni_resp = ec2.describe_network_interfaces(NetworkInterfaceIds=old_eni_ids)
+                              old_ips = [eni["PrivateIpAddress"] for eni in old_eni_resp["NetworkInterfaces"]]
+                              old_targets = [{"Id": ip, "Port": 443} for ip in old_ips]
+                              elbv2.deregister_targets(TargetGroupArn=tg_arn, Targets=old_targets)
+                          except Exception:
+                              pass  # Old endpoint may no longer exist
+
+                  # Register current targets (Create or Update)
                   targets = [{"Id": ip, "Port": 443} for ip in ips]
                   elbv2.register_targets(TargetGroupArn=tg_arn, Targets=targets)
 
@@ -342,6 +436,9 @@ Resources:
       ServiceToken: !GetAtt RegisterTargetsFunction.Arn
       VpcEndpointId: !Ref S3InterfaceEndpoint
       TargetGroupArn: !Ref S3TargetGroup
+      # UpdateToken changes when the VPC endpoint is replaced, forcing
+      # the custom resource to re-register targets with new ENI IPs
+      UpdateToken: !Sub "${S3InterfaceEndpoint}"
 
   ##########################################################################
   # Application Load Balancer

--- a/publish.py
+++ b/publish.py
@@ -1768,6 +1768,9 @@ STDERR:
                 "nested/bedrockkb/src",
                 "nested/bedrockkb/template.yaml",
             ],
+            "nested/alb-hosting": [
+                "nested/alb-hosting/template.yaml",
+            ],
             # Unified pattern (combines BDA + Pipeline)
             "patterns/unified": [
                 LIB_DEPENDENCY,

--- a/scripts/generate_self_signed_cert.sh
+++ b/scripts/generate_self_signed_cert.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Generates a self-signed TLS certificate and imports it to AWS Certificate Manager (ACM).
+# Use this for demo/testing with the ALB hosting option.
+#
+# Usage:
+#   ./scripts/generate_self_signed_cert.sh [--region REGION] [--domain DOMAIN] [--days DAYS]
+#
+# Options:
+#   --region  AWS region for ACM import (default: from AWS_DEFAULT_REGION or aws configure)
+#   --domain  Domain name for the certificate CN/SAN (default: self-signed.internal)
+#   --days    Certificate validity in days (default: 365)
+#
+# Output:
+#   Prints the ACM certificate ARN to stdout (last line).
+#
+# Example:
+#   CERT_ARN=$(./scripts/generate_self_signed_cert.sh --region us-gov-west-1 --domain myapp.internal)
+#   echo "Use this ARN for ALBCertificateArn parameter: $CERT_ARN"
+
+set -euo pipefail
+
+REGION=""
+DOMAIN="self-signed.internal"
+DAYS=365
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
+        --domain)
+            DOMAIN="$2"
+            shift 2
+            ;;
+        --days)
+            DAYS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -20 "$0" | grep '^#' | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate dependencies
+for cmd in openssl aws; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is required but not installed." >&2
+        exit 1
+    fi
+done
+
+# Build region flag
+REGION_FLAG=""
+if [[ -n "$REGION" ]]; then
+    REGION_FLAG="--region $REGION"
+fi
+
+# Create temporary directory for certificate files
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+KEY_FILE="$TMPDIR/private.key"
+CERT_FILE="$TMPDIR/certificate.pem"
+
+echo "Generating self-signed certificate for domain: $DOMAIN (valid for $DAYS days)" >&2
+
+# Generate private key and self-signed certificate
+openssl req -x509 -nodes \
+    -days "$DAYS" \
+    -newkey rsa:2048 \
+    -keyout "$KEY_FILE" \
+    -out "$CERT_FILE" \
+    -subj "/CN=$DOMAIN" \
+    -addext "subjectAltName=DNS:$DOMAIN" \
+    2>/dev/null
+
+echo "Importing certificate to ACM..." >&2
+
+# Import certificate to ACM
+# shellcheck disable=SC2086
+CERT_ARN=$(aws acm import-certificate \
+    --certificate fileb://"$CERT_FILE" \
+    --private-key fileb://"$KEY_FILE" \
+    --query 'CertificateArn' \
+    --output text \
+    $REGION_FLAG)
+
+echo "" >&2
+echo "Certificate imported successfully." >&2
+echo "ACM Certificate ARN: $CERT_ARN" >&2
+echo "" >&2
+echo "Use this value for the ALBCertificateArn CloudFormation parameter." >&2
+echo "" >&2
+echo "NOTE: This is a self-signed certificate. Browsers will show a security warning." >&2
+echo "For production use, use a certificate issued by a trusted CA or AWS ACM." >&2
+
+# Print just the ARN to stdout for scripting
+echo "$CERT_ARN"

--- a/template.yaml
+++ b/template.yaml
@@ -312,13 +312,63 @@ Parameters:
         3653,
       ]
 
+  WebUIHosting:
+    Type: String
+    Default: CloudFront
+    AllowedValues:
+      - CloudFront
+      - ALB
+    Description: >-
+      Frontend hosting method. Use CloudFront for public/standard deployments.
+      Use ALB for GovCloud or private network deployments that require
+      VPC-based hosting.
+
+  ALBVpcId:
+    Type: String
+    Default: ""
+    Description: >-
+      (Required when WebUIHosting=ALB) VPC ID for the ALB and S3 VPC endpoint.
+
+  ALBSubnetIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >-
+      (Required when WebUIHosting=ALB) Comma-separated subnet IDs for the ALB
+      (minimum 2 subnets in different AZs).
+
+  ALBCertificateArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Required when WebUIHosting=ALB) ACM certificate ARN for the ALB HTTPS
+      listener. Can be ACM-issued or imported (including self-signed). Use
+      scripts/generate_self_signed_cert.sh for demo/testing.
+
+  ALBScheme:
+    Type: String
+    Default: internal
+    AllowedValues:
+      - internal
+      - internet-facing
+    Description: >-
+      (ALB hosting only) ALB scheme. Use 'internal' for private network access,
+      'internet-facing' for public access.
+
+  ALBAllowedCIDRs:
+    Type: String
+    Default: ""
+    Description: >-
+      (ALB hosting only) Comma-separated CIDR ranges allowed to access the ALB.
+      Leave empty to automatically use the VPC CIDR range (recommended for
+      internal ALBs). Specify explicit CIDRs to override.
+
   CloudFrontPriceClass:
     Type: String
     Default: PriceClass_100
     Description: >-
-      Specify the CloudFront price class. See https://aws.amazon.com/cloudfront/pricing/
-      for a
-      description of each price class.
+      (CloudFront hosting only) Specify the CloudFront price class. See
+      https://aws.amazon.com/cloudfront/pricing/ for a description of each
+      price class.
     AllowedValues:
       - PriceClass_100
       - PriceClass_200
@@ -376,6 +426,8 @@ Conditions:
   IsS3VectorsVectorStore: !Equals [ !Ref KnowledgeBaseVectorStore, "S3_VECTORS" ]
   CreateAgentCoreLambda: !Equals [ !Ref EnableMCP, "true" ]
   CreateExternalAppClient: !Equals [ !Ref EnableMCP, "true" ]
+  UseCloudFrontHosting: !Equals [ !Ref WebUIHosting, "CloudFront" ]
+  UseALBHosting: !Equals [ !Ref WebUIHosting, "ALB" ]
 
 Metadata:
   cfn-lint:
@@ -430,6 +482,20 @@ Metadata:
         Parameters:
           - EnableMCP
       - Label:
+          default: "Web UI Hosting"
+        Parameters:
+          - WebUIHosting
+          - CloudFrontPriceClass
+          - CloudFrontAllowedGeos
+      - Label:
+          default: "ALB Hosting (when WebUIHosting=ALB)"
+        Parameters:
+          - ALBVpcId
+          - ALBSubnetIds
+          - ALBCertificateArn
+          - ALBScheme
+          - ALBAllowedCIDRs
+      - Label:
           default: "General Configuration"
         Parameters:
           - MaxConcurrentWorkflows
@@ -438,8 +504,6 @@ Metadata:
           - ExecutionTimeThresholdMs
           - LogLevel
           - LogRetentionDays
-          - CloudFrontPriceClass
-          - CloudFrontAllowedGeos
 
     ParameterLabels:
       AdminEmail:
@@ -490,6 +554,18 @@ Metadata:
         default: "WAF Allowed IPv4 Ranges"
       EnableMCP:
         default: "Enable MCP Integration"
+      WebUIHosting:
+        default: "Web UI Hosting Method"
+      ALBVpcId:
+        default: "ALB - VPC ID"
+      ALBSubnetIds:
+        default: "ALB - Subnet IDs"
+      ALBCertificateArn:
+        default: "ALB - ACM Certificate ARN"
+      ALBScheme:
+        default: "ALB - Scheme (internal/internet-facing)"
+      ALBAllowedCIDRs:
+        default: "ALB - Allowed CIDR Ranges"
 
 Resources:
   # Custom resource to enforce max length of StackName - prevent downstream failures
@@ -1545,6 +1621,32 @@ Resources:
             Condition:
               StringEquals:
                 "AWS:SourceAccount": !Ref "AWS::AccountId"
+          - !If
+            - UseALBHosting
+            - Sid: AllowALBAccessLogs
+              Effect: Allow
+              Principal:
+                Service: !Sub "logdelivery.elasticloadbalancing.${AWS::URLSuffix}"
+              Action:
+                - s3:PutObject
+              Resource: !Sub "${LoggingBucket.Arn}/alb-access-logs/*"
+              Condition:
+                StringEquals:
+                  "aws:SourceAccount": !Ref "AWS::AccountId"
+            - !Ref AWS::NoValue
+          - !If
+            - UseALBHosting
+            - Sid: AllowALBAccessLogsBucketACL
+              Effect: Allow
+              Principal:
+                Service: !Sub "logdelivery.elasticloadbalancing.${AWS::URLSuffix}"
+              Action:
+                - s3:GetBucketAcl
+              Resource: !Sub "${LoggingBucket.Arn}"
+              Condition:
+                StringEquals:
+                  "aws:SourceAccount": !Ref "AWS::AccountId"
+            - !Ref AWS::NoValue
           - Sid: EnforceSSLOnly
             Effect: Deny
             Principal: "*"
@@ -1576,7 +1678,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1645,7 +1750,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1710,7 +1818,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2156,7 +2267,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2268,7 +2382,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2334,7 +2451,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2785,7 +2905,10 @@ Resources:
               - PUT
               - POST
             AllowedOrigins:
-              - !Sub "https://${CloudFrontDistribution.DomainName}"
+              - !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2850,9 +2973,11 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
-      WebsiteConfiguration:
-        IndexDocument: index.html
-        ErrorDocument: index.html
+      WebsiteConfiguration: !If
+        - UseCloudFrontHosting
+        - IndexDocument: index.html
+          ErrorDocument: index.html
+        - !Ref AWS::NoValue
       LoggingConfiguration:
         DestinationBucketName: !Ref LoggingBucket
         LogFilePrefix: webapp-bucket-logs/
@@ -2864,11 +2989,24 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
-            Principal:
-              CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
-            Action: s3:GetObject
-            Resource: !Sub "${WebUIBucket.Arn}/*"
+          - !If
+            - UseCloudFrontHosting
+            - Effect: Allow
+              Principal:
+                CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+              Action: s3:GetObject
+              Resource: !Sub "${WebUIBucket.Arn}/*"
+            - !Ref AWS::NoValue
+          - !If
+            - UseALBHosting
+            - Effect: Allow
+              Principal: "*"
+              Action: s3:GetObject
+              Resource: !Sub "${WebUIBucket.Arn}/*"
+              Condition:
+                StringEquals:
+                  "aws:sourceVpce": !GetAtt ALBHostingStack.Outputs.S3VPCEndpointId
+            - !Ref AWS::NoValue
           - Effect: "Deny"
             Action:
               - "s3:*"
@@ -5288,7 +5426,10 @@ Resources:
         - profile
       CallbackURLs:
         - !Sub "https://${GetDomain.OutputString}.auth.${AWS::Region}.amazoncognito.com"
-        - !Sub "https://${CloudFrontDistribution.DomainName}/"
+        - !If
+          - UseCloudFrontHosting
+          - !Sub "https://${CloudFrontDistribution.DomainName}/"
+          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5296,7 +5437,10 @@ Resources:
         - https://ap-southeast-2.quicksight.aws.amazon.com/sn/oauthcallback
       LogoutURLs:
         - !Sub "https://${GetDomain.OutputString}.auth.${AWS::Region}.amazoncognito.com"
-        - !Sub "https://${CloudFrontDistribution.DomainName}/"
+        - !If
+          - UseCloudFrontHosting
+          - !Sub "https://${CloudFrontDistribution.DomainName}/"
+          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5323,16 +5467,21 @@ Resources:
           - true
         InviteMessageTemplate:
           EmailSubject: Welcome to GenAI-IDP!
-          EmailMessage: !Sub |-
-            <p>Hello {username},</p>
-            <p>Welcome to the AWS GenAIIDP Solution! Your temporary password is: <strong>{####}</strong></p>
-            <p>When the CloudFormation stack is COMPLETE, use the link below to log in and set your permanent password.
-            <p>     https://${CloudFrontDistribution.DomainName}/
-            <p>
-            <p>Thanks,</p>
-            <p>AWS GenAIIDP Team</p>
-            <p>
-            <p><em>Stack: ${AWS::StackName}, v<VERSION>, <BUILD_DATE_TIME></em>
+          EmailMessage: !Sub
+            - |-
+              <p>Hello {username},</p>
+              <p>Welcome to the AWS GenAIIDP Solution! Your temporary password is: <strong>{####}</strong></p>
+              <p>When the CloudFormation stack is COMPLETE, use the link below to log in and set your permanent password.
+              <p>     ${WebUIURL}
+              <p>
+              <p>Thanks,</p>
+              <p>AWS GenAIIDP Team</p>
+              <p>
+              <p><em>Stack: ${AWS::StackName}, v<VERSION>, <BUILD_DATE_TIME></em>
+            - WebUIURL: !If
+                - UseCloudFrontHosting
+                - !Sub "https://${CloudFrontDistribution.DomainName}/"
+                - !GetAtt ALBHostingStack.Outputs.WebUIURL
       AutoVerifiedAttributes:
         - email
       EmailConfiguration:
@@ -5375,7 +5524,10 @@ Resources:
         - phone
         - profile
       CallbackURLs:
-        - !Sub "https://${CloudFrontDistribution.DomainName}"
+        - !If
+          - UseCloudFrontHosting
+          - !Sub "https://${CloudFrontDistribution.DomainName}"
+          - !GetAtt ALBHostingStack.Outputs.WebUIURL
       AccessTokenValidity: 1
       EnableTokenRevocation: true
       ExplicitAuthFlows:
@@ -6402,6 +6554,7 @@ Resources:
 
   CloudFrontOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Condition: UseCloudFrontHosting
     Properties:
       CloudFrontOriginAccessIdentityConfig:
         Comment: !Sub "${AWS::StackName} CloudFront OAI for ${WebUIBucket}"
@@ -6409,6 +6562,7 @@ Resources:
   # Define a custom response headers policy for security headers
   SecurityHeadersPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
+    Condition: UseCloudFrontHosting
     Properties:
       ResponseHeadersPolicyConfig:
         Name: !Sub "${AWS::StackName}-security-headers-policy"
@@ -6433,6 +6587,7 @@ Resources:
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
+    Condition: UseCloudFrontHosting
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -6494,6 +6649,27 @@ Resources:
           - GeoRestriction:
               RestrictionType: none
 
+  ##########################################################################
+  # ALB Hosting (alternative to CloudFront for GovCloud / private networks)
+  ##########################################################################
+
+  ALBHostingStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: UseALBHosting
+    Properties:
+      TemplateURL: ./nested/alb-hosting/.aws-sam/packaged.yaml
+      Parameters:
+        VpcId: !Ref ALBVpcId
+        SubnetIds: !Join [",", !Ref ALBSubnetIds]
+        CertificateArn: !Ref ALBCertificateArn
+        ALBScheme: !Ref ALBScheme
+        ALBAllowedCIDRs: !Ref ALBAllowedCIDRs
+        WebUIBucketName: !Ref WebUIBucket
+        WebUIBucketArn: !GetAtt WebUIBucket.Arn
+        StackName: !Ref AWS::StackName
+        PermissionsBoundaryArn: !Ref PermissionsBoundaryArn
+        LoggingBucketName: !Ref LoggingBucket
+
   UICodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -6541,11 +6717,14 @@ Resources:
                   - s3:DeleteObject
                 Resource:
                   - !Sub "arn:${AWS::Partition}:s3:::${WebUIBucket}/*"
-              - Effect: Allow
-                Action:
-                  - cloudfront:CreateInvalidation
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}"
+              - !If
+                - UseCloudFrontHosting
+                - Effect: Allow
+                  Action:
+                    - cloudfront:CreateInvalidation
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}"
+                - !Ref AWS::NoValue
 
   UICodeBuildProject:
     Type: AWS::CodeBuild::Project
@@ -6589,10 +6768,13 @@ Resources:
                 - echo Copying Web UI
                 - find build -ls
                 - aws s3 cp --recursive build s3://${WEBAPP_BUCKET}/
-                - echo Invalidating CloudFront Distribution
-                - >
-                  aws cloudfront create-invalidation
-                  --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths '/*'
+                - |
+                  if [ "$WEB_UI_HOSTING" = "CloudFront" ]; then
+                    echo "Invalidating CloudFront Distribution"
+                    aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths '/*'
+                  else
+                    echo "ALB hosting mode - skipping CloudFront invalidation"
+                  fi
           artifacts:
             files:
               - build.json
@@ -6610,8 +6792,13 @@ Resources:
             Value: !Sub "<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>"
           - Name: WEBAPP_BUCKET
             Value: !Ref WebUIBucket
+          - Name: WEB_UI_HOSTING
+            Value: !Ref WebUIHosting
           - Name: CLOUDFRONT_DISTRIBUTION_ID
-            Value: !Ref CloudFrontDistribution
+            Value: !If
+              - UseCloudFrontHosting
+              - !Ref CloudFrontDistribution
+              - ""
             # These VITE variables are used by the web ui in the
             # aws-exports.js Amplify config. The values are embedded in the
             # code at build time.
@@ -6633,7 +6820,10 @@ Resources:
               - "false"
               - "true"
           - Name: VITE_CLOUDFRONT_DOMAIN
-            Value: !Sub "https://${CloudFrontDistribution.DomainName}/"
+            Value: !If
+              - UseCloudFrontHosting
+              - !Sub "https://${CloudFrontDistribution.DomainName}/"
+              - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
           - Name: VITE_TEST_SET_BUCKET_NAME
             Value: !Ref TestSetBucket
           - Name: VITE_INPUT_BUCKET_NAME
@@ -7059,7 +7249,10 @@ Outputs:
     Value: !GetAtt CustomerManagedEncryptionKey.Arn
   ApplicationWebURL:
     Description: Application Web URL
-    Value: !Sub "https://${CloudFrontDistribution.DomainName}/"
+    Value: !If
+      - UseCloudFrontHosting
+      - !Sub "https://${CloudFrontDistribution.DomainName}/"
+      - !GetAtt ALBHostingStack.Outputs.WebUIURL
   S3InstallBucket:
     Description: Install S3 bucket name
     Value: !Ref InputBucket

--- a/template.yaml
+++ b/template.yaml
@@ -1681,7 +1681,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1753,7 +1753,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -1821,7 +1821,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2270,7 +2270,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2385,7 +2385,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2454,7 +2454,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2908,7 +2908,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -3005,7 +3005,7 @@ Resources:
               Resource: !Sub "${WebUIBucket.Arn}/*"
               Condition:
                 StringEquals:
-                  "aws:sourceVpce": !GetAtt ALBHostingStack.Outputs.S3VPCEndpointId
+                  "aws:sourceVpce": !GetAtt ALBHOSTINGSTACK.Outputs.S3VPCEndpointId
             - !Ref AWS::NoValue
           - Effect: "Deny"
             Action:
@@ -5429,7 +5429,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
+          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5440,7 +5440,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
+          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -5481,7 +5481,7 @@ Resources:
             - WebUIURL: !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}/"
-                - !GetAtt ALBHostingStack.Outputs.WebUIURL
+                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
       AutoVerifiedAttributes:
         - email
       EmailConfiguration:
@@ -5527,7 +5527,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}"
-          - !GetAtt ALBHostingStack.Outputs.WebUIURL
+          - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
       AccessTokenValidity: 1
       EnableTokenRevocation: true
       ExplicitAuthFlows:
@@ -6653,7 +6653,7 @@ Resources:
   # ALB Hosting (alternative to CloudFront for GovCloud / private networks)
   ##########################################################################
 
-  ALBHostingStack:
+  ALBHOSTINGSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: UseALBHosting
     Properties:
@@ -6823,7 +6823,7 @@ Resources:
             Value: !If
               - UseCloudFrontHosting
               - !Sub "https://${CloudFrontDistribution.DomainName}/"
-              - !Sub "${ALBHostingStack.Outputs.WebUIURL}/"
+              - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
           - Name: VITE_TEST_SET_BUCKET_NAME
             Value: !Ref TestSetBucket
           - Name: VITE_INPUT_BUCKET_NAME
@@ -7252,7 +7252,7 @@ Outputs:
     Value: !If
       - UseCloudFrontHosting
       - !Sub "https://${CloudFrontDistribution.DomainName}/"
-      - !GetAtt ALBHostingStack.Outputs.WebUIURL
+      - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
   S3InstallBucket:
     Description: Install S3 bucket name
     Value: !Ref InputBucket


### PR DESCRIPTION
Adds an alternative web UI hosting mode using Application Load Balancer (ALB) with S3 VPC Interface Endpoint for environments that require VPC-based hosting (private networks, regulated environments, corporate networks without internet-facing CDN access).

## Changes

### ALB Hosting Infrastructure (`nested/alb-hosting/template.yaml`)
- New nested CloudFormation stack with ALB, S3 Interface VPC Endpoint, security groups, and target registration
- ALB listener rules with host-header rewrite and URL rewrite transforms for serving S3 static content
- Custom resource Lambdas for VPC CIDR lookup and VPC endpoint ENI target registration
- TLS 1.3 enforcement, access logging, and scoped VPC endpoint policy

### Main Template (`template.yaml`)
- `WebUIHosting` parameter (`CloudFront` | `ALB`) with conditional resource creation
- `UseCloudFrontHosting` / `UseALBHosting` conditions gating CloudFront and ALB resources
- All S3 CORS origins, Cognito callback/logout URLs, CodeBuild env vars, and stack outputs resolve conditionally based on hosting mode
- S3 bucket policy uses `aws:sourceVpce` condition for ALB mode instead of CloudFront OAI
- Renamed nested stack logical ID to `ALBHOSTINGSTACK` to match existing convention (`PATTERNSTACK`, `APPSYNCSTACK`, etc.)

### CLI Fix (`lib/idp_cli_pkg/idp_cli/cli.py`)
- Fixed `--parameters` parsing to handle comma-delimited values (e.g., `ALBSubnetIds=subnet-a,subnet-b`) — previously the naive `split(",")` broke values containing commas

### Helper Script (`scripts/generate_self_signed_cert.sh`)
- New script to generate and import self-signed TLS certificates to ACM for demo/testing with ALB hosting

### Publish Script (`publish.py`)
- Added `nested/alb-hosting` as a build component

### Documentation
- New `docs/alb-hosting.md` — when/why to use ALB hosting, VPC prerequisites, deployment steps, security considerations, troubleshooting, CloudFront vs ALB comparison
- Updated `docs/architecture.md`, `docs/aws-services-and-roles.md`, `docs/configuration.md`, `docs/web-ui.md`, `docs/well-architected.md` with ALB hosting references alongside existing CloudFront content
- Updated `docs/README.md` with link to new doc

## Testing

- Deployed fresh stack with `WebUIHosting=ALB` using `idp-cli deploy --from-code` against `customer-vpc` (private subnets, self-signed cert, internal ALB scheme)
- Stack created successfully (`CREATE_COMPLETE`) with ALB serving the web UI
- Verified ALB returns 200 with full HTML content from within the VPC
- All lint checks pass (`make check-arn-partitions`, `make ruff-lint`, `make format`, `make validate-buildspec`)
- All CLI tests pass (108/108)