### PR TITLE
Added restrictions to the Class Name input according to requirements …

### DIFF
--- a/src/ui/src/components/json-schema-builder/SchemaBuilder.tsx
+++ b/src/ui/src/components/json-schema-builder/SchemaBuilder.tsx
@@ -99,6 +99,13 @@ const SchemaBuilder = ({
   const [classToDelete, setClassToDelete] = useState<SchemaClass | null>(null);
   const [showWipeAllModal, setShowWipeAllModal] = useState(false);
   const [aggregatedValidationErrors, setAggregatedValidationErrors] = useState<ValidationError[]>([]);
+
+  const CLASS_NAME_PATTERN = /^[a-zA-Z0-9\-_]+$/;
+  const isClassNameValid = (name: string): boolean => name.trim().length > 0 && CLASS_NAME_PATTERN.test(name.trim());
+  const classNameErrorText = newClassName.trim() && !CLASS_NAME_PATTERN.test(newClassName.trim())
+    ? 'Class name can only contain letters, numbers, hyphens, and underscores'
+    : '';
+    
   const lastExportedSchemaRef = useRef<string | null>(null);
   const lastValidationResultRef = useRef<string | null>(null);
 
@@ -656,7 +663,7 @@ const SchemaBuilder = ({
                   >
                     {isRuleSchema ? 'Cancel' : 'Back'}
                   </Button>
-                  <Button variant="primary" onClick={handleConfirmAddClass} disabled={!newClassName.trim()}>
+                  <Button variant="primary" onClick={handleConfirmAddClass} disabled={!isClassNameValid(newClassName)}>
                     {isRuleSchema ? 'Add Rule Class' : 'Add Class'}
                   </Button>
                 </SpaceBetween>
@@ -757,6 +764,7 @@ const SchemaBuilder = ({
               <FormField
                 label={isRuleSchema ? 'Rule Class Name' : 'Class Name'}
                 description={`A unique name for this ${isRuleSchema ? 'rule' : 'extraction'} class`}
+                errorText={classNameErrorText}
               >
                 <Input
                   value={newClassName}
@@ -919,7 +927,7 @@ const SchemaBuilder = ({
                 >
                   Cancel
                 </Button>
-                <Button variant="primary" onClick={handleConfirmEditClass} disabled={!newClassName.trim()}>
+                <Button variant="primary" onClick={handleConfirmEditClass} disabled={!isClassNameValid(newClassName)}>
                   Save Changes
                 </Button>
               </SpaceBetween>
@@ -927,7 +935,7 @@ const SchemaBuilder = ({
           }
         >
           <SpaceBetween size="m">
-            <FormField label="Class Name" description="A unique name for this extraction class">
+            <FormField label="Class Name" description="A unique name for this extraction class" errorText={classNameErrorText}>
               <Input
                 value={newClassName}
                 onChange={({ detail }) => setNewClassName(detail.value)}


### PR DESCRIPTION
…from BDA

*Issue #, if available:*

*Description of changes:*
All class names need to follow [a-zA-Z0-9-_]+ pattern to sync to BDA. Added a function which checks whether the class name is valid in Schema Builder. If not, it will spring an error to notify the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
