### PR TITLE
feat(ui): add Excel file upload support (XLSX/XLS)

### DIFF
--- a/src/ui/src/components/common/constants.ts
+++ b/src/ui/src/components/common/constants.ts
@@ -5,6 +5,13 @@
 
 export const SYSTEM = 'System' as const;
 
+/** File extensions accepted for document upload across the UI. */
+export const SUPPORTED_UPLOAD_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls' as const;
+
+/** Human-readable label for supported upload formats. */
+export const SUPPORTED_UPLOAD_FORMATS_LABEL =
+  'Supported formats: PDF, PNG, JPEG, TIFF, and Excel (XLSX/XLS). PDF and image files are processed with Textract; Excel files are supported through backend conversion.' as const;
+
 export const LANGUAGE_CODES = [
   { value: '', label: 'Choose a Language' },
   { value: 'af', label: 'Afrikaans' },

--- a/src/ui/src/components/common/constants.ts
+++ b/src/ui/src/components/common/constants.ts
@@ -6,11 +6,11 @@
 export const SYSTEM = 'System' as const;
 
 /** File extensions accepted for document upload across the UI. */
-export const SUPPORTED_UPLOAD_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls' as const;
+export const SUPPORTED_UPLOAD_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls,.csv,.doc,.docx' as const;
 
 /** Human-readable label for supported upload formats. */
 export const SUPPORTED_UPLOAD_FORMATS_LABEL =
-  'Supported formats: PDF, PNG, JPEG, TIFF, and Excel (XLSX/XLS). PDF and image files are processed with Textract; Excel files are supported through backend conversion.' as const;
+  'Supported formats: PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS), CSV, and Word (DOC/DOCX). PDF and image files are processed with Textract; spreadsheet and Word files are supported through backend conversion.' as const;
 
 export const LANGUAGE_CODES = [
   { value: '', label: 'Choose a Language' },

--- a/src/ui/src/components/discovery/DiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/DiscoveryPanel.tsx
@@ -39,6 +39,7 @@ import { formatConfigVersionLink } from '../test-studio/utils/configVersionUtils
 import type { ConfigVersion } from '../test-studio/utils/configVersionUtils';
 import { useNavigate } from 'react-router-dom';
 import { DISCOVERY_JOB_PATH } from '../../routes/constants';
+import { SUPPORTED_UPLOAD_EXTENSIONS } from '../common/constants';
 import PdfPageSelector from './PdfPageSelector';
 import type { PageRange } from './PdfPageSelector';
 
@@ -849,7 +850,7 @@ const DiscoveryPanel = (): React.JSX.Element => {
                 type="file"
                 onChange={handleDocumentFileChange}
                 disabled={isUploading}
-                accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls"
+                accept={SUPPORTED_UPLOAD_EXTENSIONS}
               />
               {documentFile && (
                 <Box margin={{ top: 'xs' }}>

--- a/src/ui/src/components/discovery/DiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/DiscoveryPanel.tsx
@@ -849,7 +849,7 @@ const DiscoveryPanel = (): React.JSX.Element => {
                 type="file"
                 onChange={handleDocumentFileChange}
                 disabled={isUploading}
-                accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif"
+                accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls"
               />
               {documentFile && (
                 <Box margin={{ top: 'xs' }}>

--- a/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
+++ b/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
@@ -206,7 +206,10 @@ const UploadDocumentPanel = (): React.JSX.Element => {
           />
         </FormField>
 
-        <FormField label="Select files to upload" constraintText="Supported formats: PDF, PNG, JPEG, TIFF. Multiple files allowed.">
+        <FormField
+          label="Select files to upload"
+          constraintText="Supported formats: PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS). Multiple files allowed."
+        >
           <FileUpload
             onChange={({ detail }) => handleFileChange(detail.value)}
             value={selectedFiles}
@@ -217,7 +220,7 @@ const UploadDocumentPanel = (): React.JSX.Element => {
               errorIconAriaLabel: 'Error',
               warningIconAriaLabel: 'Warning',
             }}
-            accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif"
+            accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls"
             multiple
             showFileSize
             showFileLastModified

--- a/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
+++ b/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
@@ -23,6 +23,7 @@ import { uploadDocument } from '../../graphql/generated';
 import useConfigurationVersions from '../../hooks/use-configuration-versions';
 
 import useSettingsContext from '../../contexts/settings';
+import { SUPPORTED_UPLOAD_EXTENSIONS } from '../common/constants';
 
 const client = generateClient();
 
@@ -206,10 +207,7 @@ const UploadDocumentPanel = (): React.JSX.Element => {
           />
         </FormField>
 
-        <FormField
-          label="Select files to upload"
-          constraintText="Supported formats: PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS). Multiple files allowed."
-        >
+        <FormField label="Select files to upload" constraintText="Multiple files allowed. Excel files are converted on the backend.">
           <FileUpload
             onChange={({ detail }) => handleFileChange(detail.value)}
             value={selectedFiles}
@@ -220,7 +218,7 @@ const UploadDocumentPanel = (): React.JSX.Element => {
               errorIconAriaLabel: 'Error',
               warningIconAriaLabel: 'Warning',
             }}
-            accept=".pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls"
+            accept={SUPPORTED_UPLOAD_EXTENSIONS}
             multiple
             showFileSize
             showFileLastModified

--- a/src/ui/src/components/upload-document/tools-panel.tsx
+++ b/src/ui/src/components/upload-document/tools-panel.tsx
@@ -8,7 +8,7 @@ const content = (
   <>
     <p>Upload documents to be processed by the GenAI IDP system.</p>
     <p>
-      <strong>Supported formats:</strong> PDF, PNG, JPEG, TIFF, and other document formats supported by Textract.
+      <strong>Supported formats:</strong> PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS), and other document formats supported by Textract.
     </p>
     <p>
       <strong>Prefix:</strong> Optionally add a prefix to organize your documents (e.g., &quot;invoices/&quot;, &quot;forms/2023/&quot;).

--- a/src/ui/src/components/upload-document/tools-panel.tsx
+++ b/src/ui/src/components/upload-document/tools-panel.tsx
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { HelpPanel } from '@cloudscape-design/components';
+import { SUPPORTED_UPLOAD_FORMATS_LABEL } from '../common/constants';
 
 const header = <h2>Upload Documents</h2>;
 const content = (
   <>
     <p>Upload documents to be processed by the GenAI IDP system.</p>
-    <p>
-      <strong>Supported formats:</strong> PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS), and other document formats supported by Textract.
-    </p>
+    <p>{SUPPORTED_UPLOAD_FORMATS_LABEL}</p>
     <p>
       <strong>Prefix:</strong> Optionally add a prefix to organize your documents (e.g., &quot;invoices/&quot;, &quot;forms/2023/&quot;).
     </p>


### PR DESCRIPTION
## Summary
- Add `.xlsx` and `.xls` to the file upload accept filters in `UploadDocumentPanel`, `DiscoveryPanel`, and `tools-panel`
- Update user-facing constraint/help text to explicitly mention Excel format support
- The backend already supports Excel via `document_converter.convert_excel_to_pages()` — this unblocks the UI side

## Test plan
- [x] `make lint` passes (0 errors)
- [x] `make ui-build` succeeds
- [x] TypeScript typecheck passes
- [ ] Manually verify file picker accepts `.xlsx`/`.xls` files in Upload and Discovery panels