### PR TITLE
fix(ui): restrict Discovery upload to PDF/image formats only

### DIFF
--- a/src/ui/src/components/common/constants.ts
+++ b/src/ui/src/components/common/constants.ts
@@ -5,10 +5,13 @@
 
 export const SYSTEM = 'System' as const;
 
-/** File extensions accepted for document upload across the UI. */
+/** File extensions accepted for document processing upload (supports backend conversion). */
 export const SUPPORTED_UPLOAD_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls,.csv,.doc,.docx' as const;
 
-/** Human-readable label for supported upload formats. */
+/** File extensions accepted for Discovery upload (PDF and images only — no backend conversion). */
+export const SUPPORTED_DISCOVERY_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif' as const;
+
+/** Human-readable label for supported processing upload formats. */
 export const SUPPORTED_UPLOAD_FORMATS_LABEL =
   'Supported formats: PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS), CSV, and Word (DOC/DOCX). PDF and image files are processed with Textract; spreadsheet and Word files are supported through backend conversion.' as const;
 

--- a/src/ui/src/components/discovery/DiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/DiscoveryPanel.tsx
@@ -39,7 +39,7 @@ import { formatConfigVersionLink } from '../test-studio/utils/configVersionUtils
 import type { ConfigVersion } from '../test-studio/utils/configVersionUtils';
 import { useNavigate } from 'react-router-dom';
 import { DISCOVERY_JOB_PATH } from '../../routes/constants';
-import { SUPPORTED_UPLOAD_EXTENSIONS } from '../common/constants';
+import { SUPPORTED_DISCOVERY_EXTENSIONS } from '../common/constants';
 import PdfPageSelector from './PdfPageSelector';
 import type { PageRange } from './PdfPageSelector';
 
@@ -850,7 +850,7 @@ const DiscoveryPanel = (): React.JSX.Element => {
                 type="file"
                 onChange={handleDocumentFileChange}
                 disabled={isUploading}
-                accept={SUPPORTED_UPLOAD_EXTENSIONS}
+                accept={SUPPORTED_DISCOVERY_EXTENSIONS}
               />
               {documentFile && (
                 <Box margin={{ top: 'xs' }}>


### PR DESCRIPTION
## Summary
- Discovery pipeline sends documents directly to Bedrock's multimodal API, which only accepts PDF and images — it lacks the backend conversion layer that the main processing pipeline has for Excel/CSV/Word
- Adds a separate `SUPPORTED_DISCOVERY_EXTENSIONS` constant (`.pdf,.png,.jpg,.jpeg,.tiff,.tif`) and uses it in `DiscoveryPanel` instead of the full `SUPPORTED_UPLOAD_EXTENSIONS` list
- Follows up on #267 feedback that Discovery shouldn't advertise formats it can't process

## Test plan
- [ ] Verify Discovery panel file picker only shows PDF/image files
- [ ] Verify main Upload Documents panel still accepts Excel, CSV, and Word files