### PR TITLE
fix(cors): lowercase ALB URL for CORS, OAuth redirects, and ALB rewrite

### DIFF
--- a/nested/alb-hosting/template.yaml
+++ b/nested/alb-hosting/template.yaml
@@ -528,7 +528,12 @@ Resources:
         - Type: url-rewrite
           UrlRewriteConfig:
             Rewrites:
-              - Regex: "^/$"
+              # The url-rewrite regex matches against path + query string.
+              # Matching only the leading "/" leaves the query string intact,
+              # which is required for OAuth callbacks ("/?code=...&state=...").
+              # "^/$" does not match when a query string is present, causing
+              # S3 to see a bare "GET /" (ListBucket) and return AccessDenied.
+              - Regex: "^/"
                 Replace: "/index.html"
 
   # Rule 2: All other paths - serve static assets (JS, CSS, images, fonts, etc.)

--- a/src/ui/src/aws-exports.js
+++ b/src/ui/src/aws-exports.js
@@ -17,14 +17,20 @@ const {
   VITE_CLOUDFRONT_DOMAIN,
 } = import.meta.env;
 
-// Build OAuth config only when an external IdP is configured
+// Build OAuth config only when an external IdP is configured.
+// Cognito matches redirect_uri case-sensitively against its registered
+// callback/logout URLs, but browsers normalize the host portion of a URL
+// to lowercase. Lowercasing the full URL keeps Amplify's request aligned
+// with what the browser actually presents (ALB DNS names embed the stack
+// name and can otherwise be mixed-case).
+const redirectUrl = (VITE_CLOUDFRONT_DOMAIN || window.location.origin + '/').toLowerCase();
 const oauthConfig =
   VITE_EXTERNAL_IDP_NAME && VITE_COGNITO_DOMAIN
     ? {
         domain: VITE_COGNITO_DOMAIN,
         scope: ['openid', 'email', 'phone', 'profile'],
-        redirectSignIn: VITE_CLOUDFRONT_DOMAIN || window.location.origin + '/',
-        redirectSignOut: VITE_CLOUDFRONT_DOMAIN || window.location.origin + '/',
+        redirectSignIn: redirectUrl,
+        redirectSignOut: redirectUrl,
         responseType: 'code',
       }
     : {};

--- a/template.yaml
+++ b/template.yaml
@@ -2623,7 +2623,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2700,7 +2700,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -2819,7 +2819,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -3296,7 +3296,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -3417,7 +3417,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -3486,7 +3486,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -3540,6 +3540,13 @@ Resources:
     Properties:
       ServiceToken: !GetAtt GetDomainLambda.Arn
       InputString: !Ref AWS::StackName
+
+  GetLowercaseAlbUrl:
+    Type: Custom::GetLowercaseAlbUrl
+    Condition: UseALBHosting
+    Properties:
+      ServiceToken: !GetAtt GetDomainLambda.Arn
+      InputString: !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
 
   ReportingDatabase:
     Type: AWS::Glue::Database
@@ -3954,7 +3961,7 @@ Resources:
               - !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
               # For local development only
               - "http://localhost:3000"
             ExposedHeaders:
@@ -6869,7 +6876,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
+          - !Sub "${GetLowercaseAlbUrl.Lowercase}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -6880,7 +6887,7 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
+          - !Sub "${GetLowercaseAlbUrl.Lowercase}/"
         - !Sub "https://${AWS::Region}.quicksight.aws.amazon.com/sn/oauthcallback"
         - https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback
         - https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback
@@ -6948,7 +6955,7 @@ Resources:
             - WebUIURL: !If
                 - UseCloudFrontHosting
                 - !Sub "https://${CloudFrontDistribution.DomainName}/"
-                - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+                - !GetAtt GetLowercaseAlbUrl.Lowercase
       AutoVerifiedAttributes:
         - email
       EmailConfiguration:
@@ -7013,21 +7020,21 @@ Resources:
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}"
-          - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+          - !GetAtt GetLowercaseAlbUrl.Lowercase
         - !If
           - UseCloudFrontHosting
           - !Sub "https://${CloudFrontDistribution.DomainName}/"
-          - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
+          - !Sub "${GetLowercaseAlbUrl.Lowercase}/"
       LogoutURLs: !If
         - HasExternalIdP
         - - !If
             - UseCloudFrontHosting
             - !Sub "https://${CloudFrontDistribution.DomainName}"
-            - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+            - !GetAtt GetLowercaseAlbUrl.Lowercase
           - !If
             - UseCloudFrontHosting
             - !Sub "https://${CloudFrontDistribution.DomainName}/"
-            - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
+            - !Sub "${GetLowercaseAlbUrl.Lowercase}/"
         - !Ref AWS::NoValue
       AccessTokenValidity: 1
       EnableTokenRevocation: true
@@ -8956,7 +8963,7 @@ Resources:
             Value: !If
               - UseCloudFrontHosting
               - !Sub "https://${CloudFrontDistribution.DomainName}/"
-              - !Sub "${ALBHOSTINGSTACK.Outputs.WebUIURL}/"
+              - !Sub "${GetLowercaseAlbUrl.Lowercase}/"
           - Name: VITE_TEST_SET_BUCKET_NAME
             Value: !Ref TestSetBucket
           - Name: VITE_INPUT_BUCKET_NAME
@@ -10083,7 +10090,7 @@ Outputs:
     Value: !If
       - UseCloudFrontHosting
       - !Sub "https://${CloudFrontDistribution.DomainName}/"
-      - !GetAtt ALBHOSTINGSTACK.Outputs.WebUIURL
+      - !GetAtt GetLowercaseAlbUrl.Lowercase
   S3InstallBucket:
     Description: Install S3 bucket name
     Value: !Ref InputBucket


### PR DESCRIPTION
## fix(cors): Lowercase ALB URL for CORS, OAuth redirects, and ALB rewrite

Fixes #303

Resolves case-sensitivity failures in Private ALB deployments when the stack name contains uppercase characters. The ALB DNS name includes the mixed-case stack name (e.g., `internal-IDP-PRIVATE-webui-alb-...`), which breaks S3 CORS, Cognito OAuth redirects, and ALB path rewriting.

All changes are scoped to Private ALB hosting mode — CloudFront deployments are unaffected.

### What's included

**Infrastructure (template.yaml)**

- `GetLowercaseAlbUrl` custom resource that lowercases the ALB URL (reuses existing `GetDomainLambda` — no new Lambda functions or IAM roles)
- 7 S3 bucket `CorsConfiguration.AllowedOrigins` swapped to use lowercase ALB URL
- 9 additional references updated: Cognito `CallbackURLs`, `LogoutURLs`, `VITE_*` environment variables, QuickSight email-template URL, and `ApplicationWebURL` stack output

**Frontend (src/ui/src/aws-exports.js)**

- `redirectSignIn` and `redirectSignOut` apply `.toLowerCase()` to ensure Cognito's case-sensitive `redirect_uri` matching succeeds regardless of ALB DNS casing

**ALB Hosting (nested/alb-hosting/template.yaml)**

- URL rewrite regex changed from `^/$` to `^/` — the original regex failed to match OAuth callback paths with query strings (`/?code=...&state=...`), causing S3 to return AccessDenied on the authentication round-trip

### Root cause

When a stack name contains uppercase characters (e.g., `IDP-PRIVATE`), three failures cascade:

1. **S3 CORS rejection** — browsers send the `Origin` header lowercased per RFC 6454, but `AllowedOrigins` contained the mixed-case ALB URL → preflight rejected
2. **Cognito OAuth redirect_uri mismatch** — Cognito matches `redirect_uri` case-sensitively against registered `CallbackURLs`, but the browser lowercases the host → callback rejected
3. **ALB url-rewrite miss** — regex `^/$` doesn't match when `?code=...&state=...` query string is present on the OAuth callback → request forwarded to S3 without the `/index.html` rewrite → S3 returns AccessDenied (bare `GET /` = `ListBucket`)

### Testing

- Deployed with `WebUIHosting=ALB`, `ALBScheme=internal`, `ExternalIdPType=OIDC` — verified CORS preflight, OAuth callback, and full authentication flow with Okta
- Deployed with `ExternalIdPType=SAML` — verified SAML redirect and assertion flow
- Deployed without federation (Cognito-only) — verified no behavioral changes
- Verified S3 CORS headers match browser `Origin` on document upload
- `make check-arn-partitions`, `make validate-buildspec`, `make ruff-lint`, `npm run lint` — all pass
- Security scan: zero findings related to these changes (no new IAM, compute, endpoints, or trust boundaries introduced)

Co-authored-by: VamsiGudi <gudivt@amazon.com>


