### PR TITLE
fix(ui): allow .txt upload in Web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ SPDX-License-Identifier: MIT-0
 
 - **Global split panel ("documents selected")** — Removed the persistent bottom split panel from the global Web UI layout and deleted the related split-panel components and `use-split-panel` hook. The split-panel was noisy on non-document-list pages and only provided full details for single-document selection; reintroduce as an opt-in, per-page component if needed (recommendation: enable only on `DocumentList`).
 
+### Fixed
+
+- **Web UI blocked `.txt` uploads despite backend support (#373)** — The Web UI file picker's upload allow-list (`SUPPORTED_UPLOAD_EXTENSIONS`) omitted `.txt`, so users with plain-text corpora had to bypass the UI and upload directly to S3. The backend OCR service already processes plain text (`_process_non_pdf_document()` → `DocumentConverter.convert_text_to_pages()`), so this was a UI-only gap. Added `.txt` to the allow-list and updated the supported-formats label. Discovery upload remains intentionally PDF/image-only.
+
 ### Changed
 
 - **Web UI CloudFront origin access: OAI → OAC (#369)** — The CloudFront-hosted Web UI now reads its S3 origin (`WebUIBucket`) using **Origin Access Control (OAC)** instead of the legacy **Origin Access Identity (OAI)**. The distribution origin references a new `AWS::CloudFront::OriginAccessControl` resource (SigV4, `SigningBehavior: always`), and the `WebUIBucketPolicy` now grants `s3:GetObject` to the `cloudfront.amazonaws.com` service principal scoped by an `AWS:SourceArn` condition matching this distribution — strictly tighter than the previous shared canonical-user grant. This fixes a **403 / Access Denied** loading the Web UI in accounts whose org-level SCP or data-perimeter guardrails silently deny legacy OAI requests to S3 (OAI requests carry no `aws:SourceAccount`/`aws:SourceArn` and are blocked). OAC is the AWS-recommended successor to OAI. **Upgrade is in-place and non-disruptive:** the CloudFront distribution keeps the same domain name (existing Web UI URLs and the welcome-email link continue to work), and `WebUIBucket` is unaffected. GovCloud and ALB-hosted deployments are unchanged — the resource is gated on `WebUIHosting=CloudFront`.

--- a/src/ui/src/components/common/constants.ts
+++ b/src/ui/src/components/common/constants.ts
@@ -6,14 +6,14 @@
 export const SYSTEM = 'System' as const;
 
 /** File extensions accepted for document processing upload (supports backend conversion). */
-export const SUPPORTED_UPLOAD_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls,.csv,.doc,.docx' as const;
+export const SUPPORTED_UPLOAD_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif,.xlsx,.xls,.csv,.doc,.docx,.txt' as const;
 
 /** File extensions accepted for Discovery upload (PDF and images only — no backend conversion). */
 export const SUPPORTED_DISCOVERY_EXTENSIONS = '.pdf,.png,.jpg,.jpeg,.tiff,.tif' as const;
 
 /** Human-readable label for supported processing upload formats. */
 export const SUPPORTED_UPLOAD_FORMATS_LABEL =
-  'Supported formats: PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS), CSV, and Word (DOC/DOCX). PDF and image files are processed with Textract; spreadsheet and Word files are supported through backend conversion.' as const;
+  'Supported formats: PDF, PNG, JPEG, TIFF, Excel (XLSX/XLS), CSV, Word (DOC/DOCX), and plain text (TXT). PDF and image files are processed with Textract; spreadsheet, Word, and text files are supported through backend conversion.' as const;
 
 export const LANGUAGE_CODES = [
   { value: '', label: 'Choose a Language' },

--- a/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
+++ b/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
@@ -207,7 +207,7 @@ const UploadDocumentPanel = (): React.JSX.Element => {
           />
         </FormField>
 
-        <FormField label="Select files to upload" constraintText="Multiple files allowed. Excel files are converted on the backend.">
+        <FormField label="Select files to upload" constraintText="Multiple files allowed. Spreadsheet, Word, and text files are converted on the backend.">
           <FileUpload
             onChange={({ detail }) => handleFileChange(detail.value)}
             value={selectedFiles}


### PR DESCRIPTION
## Summary
Adds `.txt` (plain text) to the Web UI upload allow-list to align the UI with existing backend support.

Closes #373.

## Why
The backend OCR service already processes `.txt` (`_process_non_pdf_document()` → `DocumentConverter.convert_text_to_pages()`), but the UI file picker blocked it because `.txt` was missing from `SUPPORTED_UPLOAD_EXTENSIONS`. Users with plain-text corpora had to bypass the UI by uploading directly to S3.

## Changes
- `src/ui/src/components/common/constants.ts`
  - Added `.txt` to `SUPPORTED_UPLOAD_EXTENSIONS`
  - Updated `SUPPORTED_UPLOAD_FORMATS_LABEL` to mention plain text

## Not changed
- `SUPPORTED_DISCOVERY_EXTENSIONS` — Discovery remains intentionally PDF/image-only
- No backend changes — the `.txt` processing path already exists and is in use

## Testing
- `npm run typecheck` and `eslint` pass; full UI test suite (`vitest`) passes.
- Built the UI with the change and deployed to a live v0.5.9 stack (WebUI bundle + CloudFront invalidation). Confirmed `.txt` files upload through the UI and process end-to-end (classification → extraction → assessment → summarization → KB indexing). No backend changes were needed.
