### PR TITLE
fix(feature-sdk): make publish-pack/deploy-pack consistent with publish/deploy (#375)

### DIFF
--- a/lib/idp_feature_sdk/README.md
+++ b/lib/idp_feature_sdk/README.md
@@ -89,6 +89,27 @@ idp-feature-cli show-schema
 | `deploy`      | Create-or-update **this feature's** stack into an existing host — either `--from-code` (publish first) or `--template-url` (already published). |
 | `deploy-pack` | Deploys a self-contained *pack* that stands up its **own** host stack.       |
 
+A **pack** (`publish-pack` / `deploy-pack`) publishes its feature artifacts
+exactly like `publish` — shared publisher, so the same `extensions/<id>/`
+version-free layout and the same baked tokens — then bakes the publish
+**bucket + version-free prefix + version** into its wrapper template's
+parameter defaults. The pack's feature stack reads those artifacts *in place*
+via IAM; there is no seller bucket and no pre-stage copy. Declare the wrapper
+parameter names under `pack.wrapperParameters` in `feature.yaml`:
+
+```yaml
+pack:
+  wrapperTemplatePath: deploy.yaml
+  wrapperParameters:
+    hostTemplateUrlParam: IdpAcceleratorTemplateUrl
+    featureBucketParam:   FeatureBucket          # bucket holding the artifacts
+    prefixParam:          FeatureArtifactPrefix  # e.g. extensions/<id>
+    versionParam:         FeatureVersion
+```
+
+(The pre-`#375` `artifactSourceParam` / seller-bucket model is gone; wrappers
+that still declare it must migrate to `featureBucketParam` + `prefixParam`.)
+
 `deploy` is the fast inner loop for iterating one extension from source against
 a live IDP deployment. The feature stack is named
 `<host-stack-name>-feature-<feature-id>` by default (override with

--- a/lib/idp_feature_sdk/idp_feature_sdk/cli.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/cli.py
@@ -204,34 +204,30 @@ def publish(
 )
 @click.option(
     "--bucket-basename",
-    required=True,
+    default=None,
     help="S3 bucket basename for the pack's published artifacts — region is "
-    "appended automatically (matches `idp-cli`). Private by default; pass "
+    "appended automatically (auto-generated as "
+    "idp-accelerator-artifacts-<account>-<region> and created if not "
+    "provided). Matches `idp-cli` / `publish`. Private by default; pass "
     "--public to grant public read on the `packs/*`/`host/*` prefixes for "
     "CROSS-ACCOUNT deploys. Without --public the bucket is left untouched.",
 )
 @click.option(
     "--prefix",
     "artifacts_prefix",
-    default="packs",
-    show_default=True,
-    help="Key prefix under the artifacts bucket. Final layout: "
-    "<bucket>/<prefix>/<feature-id>/v<version>/.",
+    default="",
+    help="Optional S3 key prefix under the artifacts bucket. Default (empty) "
+    "yields the bare `extensions/<id>/...` layout — the SAME layout `publish` "
+    "produces; a non-empty prefix becomes `<prefix>/extensions/<id>/...`.",
 )
 @click.option(
     "--host-template-url",
     required=True,
     help="Public HTTPS URL of the IDP accelerator main template (idp-main.yaml). "
-    "Produced by `python3 publish.py`. Baked into the wrapper as a parameter "
+    "Produced by `idp-cli publish`. Baked into the wrapper as a parameter "
     "default so deploy-pack doesn't need to specify it.",
 )
-@click.option("--region", default="us-west-2", show_default=True)
-@click.option(
-    "--skip-build",
-    is_flag=True,
-    default=False,
-    help="Skip `npm run build` for the UI bundle (assume dist/ is already built).",
-)
+@click.option("--region", default="us-east-1", show_default=True)
 @click.option(
     "--public",
     "make_public",
@@ -240,18 +236,17 @@ def publish(
     help="Make the published artifacts world-readable on the `packs/*` and "
     "`host/*` prefixes (relaxes BlockPublicPolicy/RestrictPublicBuckets and "
     "applies a public-read bucket policy). ONLY needed to share artifacts for "
-    "CROSS-ACCOUNT / Quick-Create pack deploys, where the deploying account's "
-    "pre-stager Lambda fetches the wrapper via anonymous HTTPS. Default: "
-    "private (same-account). A pre-existing bucket's Block Public Access "
-    "settings are never weakened unless this flag is set.",
+    "CROSS-ACCOUNT / Quick-Create pack deploys, where the deploying account "
+    "fetches the wrapper template via anonymous HTTPS. Default: private "
+    "(same-account). A pre-existing bucket's Block Public Access settings are "
+    "never weakened unless this flag is set.",
 )
 def publish_pack_cmd(
     project_dir: Path,
-    bucket_basename: str,
+    bucket_basename: Optional[str],
     artifacts_prefix: str,
     host_template_url: str,
     region: str,
-    skip_build: bool,
     make_public: bool,
 ) -> None:
     """Publish a vertical-product pack as a single-template wrapper.
@@ -276,7 +271,6 @@ def publish_pack_cmd(
             artifacts_prefix=artifacts_prefix,
             host_template_url=host_template_url,
             region=region,
-            skip_feature_build=skip_build,
             make_public=make_public,
         )
     except (ManifestError, RuntimeError, ValueError, FileNotFoundError) as exc:
@@ -288,7 +282,6 @@ def publish_pack_cmd(
     console.print(
         f"  artifacts:        s3://{result.artifact_bucket}/{result.artifact_prefix}/"
     )
-    console.print(f"  artifact source:  {result.artifact_source_url}")
     console.print(f"  feature template: {result.feature_template_url}")
     console.print(f"  host template:    {result.host_template_url}")
     console.print(f"  wrapper template: {result.wrapper_template_url}")
@@ -340,14 +333,16 @@ def publish_pack_cmd(
     "artifacts — region is appended automatically (matches `idp-cli deploy`). "
     "Auto-generated as `idp-accelerator-artifacts-<account-id>-<region>` and "
     "auto-created if not provided. With --build accelerator|all, host artifacts "
-    "go under <bucket>/host/, pack artifacts under <bucket>/packs/.",
+    "go under <bucket>/host/, pack feature artifacts under "
+    "<bucket>/[<prefix>/]extensions/<id>/.",
 )
 @click.option(
     "--prefix",
     "artifacts_prefix",
-    default="packs",
-    show_default=True,
-    help="Key prefix under the artifacts bucket for the pack's artifacts.",
+    default="",
+    help="Optional S3 key prefix under the artifacts bucket for the pack's "
+    "artifacts. Default (empty) yields the bare `extensions/<id>/...` layout — "
+    "the SAME layout `publish`/`deploy` use.",
 )
 @click.option(
     "--host-artifacts-prefix",
@@ -384,7 +379,7 @@ def publish_pack_cmd(
 )
 @click.option(
     "--region",
-    default="us-west-2",
+    default="us-east-1",
     show_default=True,
     help="AWS region to deploy into. Must match the wrapper's region.",
 )

--- a/lib/idp_feature_sdk/idp_feature_sdk/manifest.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/manifest.py
@@ -56,12 +56,18 @@ class ConfigPresetSpec:
 
 @dataclass(frozen=True)
 class PackWrapperParams:
-    """Names of the wrapper parameters that accept artifact URLs/version.
-    The publisher bakes artifact values into these parameter defaults at
-    publish time so deploy-pack only needs --stack-name + --admin-email."""
+    """Names of the wrapper parameters that locate the published artifacts.
+    The publisher bakes values into these parameter defaults at publish
+    time so deploy-pack only needs --stack-name + --admin-email.
+
+    The pack reads its feature artifacts IN PLACE from the publish bucket
+    (like a normal `deploy`), so the wrapper takes the bucket + version-free
+    prefix rather than a public artifact-source URL — there is no seller
+    bucket and no pre-stage copy."""
 
     hostTemplateUrlParam: str = "IdpAcceleratorTemplateUrl"  # noqa: N815
-    artifactSourceParam: Optional[str] = None  # noqa: N815
+    featureBucketParam: Optional[str] = None  # noqa: N815
+    prefixParam: Optional[str] = None  # noqa: N815
     versionParam: Optional[str] = None  # noqa: N815
 
 
@@ -194,7 +200,8 @@ def _parse_pack(raw: Dict[str, Any]) -> PackSpec:
             hostTemplateUrlParam=params_raw.get(
                 "hostTemplateUrlParam", "IdpAcceleratorTemplateUrl"
             ),
-            artifactSourceParam=params_raw.get("artifactSourceParam"),
+            featureBucketParam=params_raw.get("featureBucketParam"),
+            prefixParam=params_raw.get("prefixParam"),
             versionParam=params_raw.get("versionParam"),
         ),
     )

--- a/lib/idp_feature_sdk/idp_feature_sdk/pack.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/pack.py
@@ -7,10 +7,16 @@ A "pack" is a vertical-product feature (e.g. claims-pack, loans-pack)
 shipped with a single-template CFN wrapper that creates a host stack
 plus auto-installs the feature stack.
 
-`publish-pack` builds the feature, uploads all artifacts to a public
-artifacts bucket, then *bakes* the resulting URLs as parameter defaults
-into the wrapper template and uploads the baked wrapper alongside the
-artifacts. The published wrapper URL is shareable as a Quick-Create URL.
+`publish-pack` publishes the feature artifacts by delegating to
+``FeaturePublisher`` — the SAME publisher (and therefore the same
+``extensions/<id>/`` version-free layout, the same five baked publish-time
+tokens, and the same private/`--public` semantics) used by ``publish``.
+It then *bakes* the publish bucket + version-free prefix + version into the
+wrapper template's parameter defaults and uploads the baked wrapper. The
+feature stack reads its artifacts IN PLACE from the publish bucket at deploy
+time (via IAM), exactly like a normal ``deploy`` — there is no seller bucket
+and no pre-stage copy. The published wrapper URL is shareable as a
+Quick-Create URL (which requires ``--public``).
 
 `deploy-pack` reads the published wrapper URL, calls
 cloudformation:CreateStack with only the minimum operator inputs
@@ -21,7 +27,6 @@ from __future__ import annotations
 
 import json
 import re
-import shutil
 import subprocess
 import sys
 import time
@@ -32,7 +37,8 @@ from typing import Any, Dict, List, Optional
 import boto3
 from rich.console import Console
 
-from .manifest import FeatureManifest, load_manifest
+from .manifest import load_manifest
+from .publisher import FeaturePublisher
 
 
 @dataclass(frozen=True)
@@ -41,28 +47,11 @@ class PackPublishResult:
     version: str
     artifact_bucket: str
     artifact_prefix: str
-    artifact_source_url: str
     feature_template_url: str
     host_template_url: str
     wrapper_template_url: str
     quick_create_url: str
     deploy_command: str
-
-
-_PARAMETERS_BLOCK_RE = re.compile(r"^Parameters:\s*$", re.MULTILINE)
-
-
-def _content_type_for(path: Path) -> str:
-    suffix = path.suffix.lower()
-    if suffix in (".yaml", ".yml"):
-        return "application/x-yaml"
-    if suffix == ".js":
-        return "application/javascript"
-    if suffix == ".json":
-        return "application/json"
-    if suffix == ".zip":
-        return "application/zip"
-    return "application/octet-stream"
 
 
 def _public_https_url(bucket: str, region: str, key: str) -> str:
@@ -172,7 +161,7 @@ def _bake_wrapper_defaults(
             new_result, n = pattern.subn(_replace, result, count=1)
             if n == 0:
                 # Parameter not found in wrapper — caller likely passed
-                # the wrong artifactSourceParam name.
+                # the wrong featureBucketParam/prefixParam/versionParam name.
                 raise ValueError(
                     f"Wrapper template has no parameter named {param_name!r}; "
                     "check feature.yaml `pack.wrapperParameters` keys."
@@ -200,7 +189,6 @@ class PackPublisher:
         artifacts_prefix: str,
         host_template_url: str,
         region: str,
-        skip_feature_build: bool = False,
         make_public: bool = False,
     ) -> PackPublishResult:
         manifest = load_manifest(self.project_dir)
@@ -228,102 +216,50 @@ class PackPublisher:
             apply_public_artifacts_policy(s3, artifacts_bucket, console=self.console)
         feature_id = manifest.featureId
         version = manifest.version
-        # All feature artifacts live under <prefix>/<feature-id>/v<version>/
-        feat_prefix = f"{artifacts_prefix.rstrip('/')}/{feature_id}/v{version}"
 
-        # 1. Build the UI bundle (unless caller has already done it).
-        if not skip_feature_build:
-            self._build_ui(manifest)
-
-        # 2. SAM build + package the feature template.
-        self._sam_build_and_package(
-            manifest=manifest,
-            artifact_bucket=artifacts_bucket,
-            artifact_prefix=f"{artifacts_prefix.rstrip('/')}/{feature_id}/sam-objects",
+        # 1-3. Publish the feature artifacts by DELEGATING to FeaturePublisher.
+        #
+        # A pack's feature artifacts are published exactly like any other
+        # feature: same `extensions/<id>/` version-free layout, the SAME five
+        # publish-time tokens baked into the template (VERSION, ARTIFACT_PREFIX,
+        # BUCKET, PRODUCT_CODE, LISTING_URL), the same SAM build/package (with
+        # captured stderr surfaced on failure), and the same public-ACL pass
+        # when --public is set. Sharing one publisher is what keeps pack and
+        # feature publishing from drifting apart (issue #375). The pack then
+        # reads these artifacts IN PLACE from this bucket at deploy time — there
+        # is no seller bucket and no pre-stage copy.
+        feature_publisher = FeaturePublisher(
+            self.project_dir, console=self.console, s3_client=s3
+        )
+        # validate → build (ui.buildCommand) → upload, identical to `publish`.
+        feat_result = feature_publisher.publish(
+            feature_bucket=artifacts_bucket,
             region=region,
+            s3_prefix=artifacts_prefix,
+            make_public=make_public,
         )
 
-        # 3. Upload feature artifacts (template, ui-bundle, manifest, configs).
-        #    Object-level reads are governed by the bucket policy: with
-        #    `--public` the `packs/*` prefix is world-readable so the wrapper's
-        #    pre-stager (which runs in the *deploying* account, not the
-        #    publisher's) can fetch them via plain HTTPS; without it the
-        #    artifacts stay private to the publishing account.
-        feat_template_local = self.project_dir / ".aws-sam" / "packaged.yaml"
-        # Bake the version token in the SAM-packaged template before upload.
-        baked_text = feat_template_local.read_text(encoding="utf-8").replace(
-            "<FEATURE_VERSION_TOKEN>", version
+        # Version-free artifact base the feature stack reads from (matches
+        # FeaturePublisher's `extension_base`): [<prefix>/]extensions/<id>.
+        clean_prefix = artifacts_prefix.strip("/")
+        feat_prefix = (
+            f"{clean_prefix}/extensions/{feature_id}"
+            if clean_prefix
+            else f"extensions/{feature_id}"
         )
-        baked_path = self.project_dir / ".aws-sam" / "packaged-baked.yaml"
-        baked_path.write_text(baked_text, encoding="utf-8")
+        feature_template_url = feat_result.template_url
 
-        self._upload_public(
-            s3,
-            baked_path,
-            artifacts_bucket,
-            f"{feat_prefix}/template.yaml",
-            "application/x-yaml",
-        )
-        ui_bundle = self.project_dir / manifest.ui.bundlePath
-        self._upload_public(
-            s3,
-            ui_bundle,
-            artifacts_bucket,
-            f"{feat_prefix}/ui-bundle.js",
-            "application/javascript",
-        )
-
-        # manifest.json — public form of feature.yaml the host reads.
-        manifest_json = json.dumps(
-            {
-                "featureId": feature_id,
-                "version": version,
-                "displayName": manifest.displayName,
-                "description": manifest.description,
-                "iconUrl": manifest.iconUrl,
-                "capabilities": list(manifest.capabilities),
-            }
-        ).encode("utf-8")
-        # Public read is granted by the bucket policy (`packs/*` prefix)
-        # established by ensure_artifacts_bucket — no per-object ACL.
-        s3.put_object(
-            Bucket=artifacts_bucket,
-            Key=f"{feat_prefix}/manifest.json",
-            Body=manifest_json,
-            ContentType="application/json",
-        )
-        self._log(
-            f"[green]✓[/green] uploaded s3://{artifacts_bucket}/{feat_prefix}/manifest.json"
-        )
-
-        # configPreset (if defined).
-        if manifest.configPreset:
-            preset_path = self.project_dir / manifest.configPreset.path
-            if preset_path.is_file():
-                self._upload_public(
-                    s3,
-                    preset_path,
-                    artifacts_bucket,
-                    f"{feat_prefix}/{manifest.configPreset.path}",
-                    _content_type_for(preset_path),
-                )
-
-        # SAM-packaged Lambda zips are already public-readable via the
-        # bucket policy `packs/*` prefix (ensure_artifacts_bucket sets it).
-        sam_prefix = f"{artifacts_prefix.rstrip('/')}/{feature_id}/sam-objects/"
-        self._log(
-            f"[green]✓[/green] published SAM objects under s3://{artifacts_bucket}/{sam_prefix}"
-        )
-
-        # 4. Bake artifact defaults into the wrapper template.
-        artifact_source_url = (
-            _public_https_url(artifacts_bucket, region, feat_prefix) + "/"
-        )
+        # 4. Bake artifact-locating defaults into the wrapper template. The
+        # wrapper passes these straight to the feature stack (FeatureBucket +
+        # version-free prefix + version); the feature stack reads its artifacts
+        # in place via IAM — no seller bucket, no anonymous fetch.
         wrapper_yaml = wrapper_path.read_text(encoding="utf-8")
         wp = manifest.pack.wrapperParameters
         defaults = {wp.hostTemplateUrlParam: host_template_url}
-        if wp.artifactSourceParam:
-            defaults[wp.artifactSourceParam] = artifact_source_url
+        if wp.featureBucketParam:
+            defaults[wp.featureBucketParam] = artifacts_bucket
+        if wp.prefixParam:
+            defaults[wp.prefixParam] = feat_prefix
         if wp.versionParam:
             defaults[wp.versionParam] = version
         baked_wrapper = _bake_wrapper_defaults(wrapper_yaml, param_defaults=defaults)
@@ -340,9 +276,9 @@ class PackPublisher:
         )
 
         # 4b. When publishing public (opt-in, cross-account), sanity-check the
-        # wrapper is publicly readable. The wrapper's FeatureBucketPrestager
-        # Lambda fetches it via plain HTTPS during deploy — if the bucket
-        # policy didn't take effect (e.g. account-level S3 Block Public Access
+        # wrapper is publicly readable. A Quick-Create / cross-account deploy
+        # fetches the wrapper template via plain HTTPS — if the bucket policy
+        # didn't take effect (e.g. account-level S3 Block Public Access
         # overrides) the deploy fails late with HTTP 403. Catch that here,
         # before CFN starts spinning up.
         #
@@ -396,87 +332,12 @@ class PackPublisher:
             version=version,
             artifact_bucket=artifacts_bucket,
             artifact_prefix=feat_prefix,
-            artifact_source_url=artifact_source_url,
-            feature_template_url=_public_https_url(
-                artifacts_bucket, region, f"{feat_prefix}/template.yaml"
-            ),
+            feature_template_url=feature_template_url,
             host_template_url=host_template_url,
             wrapper_template_url=wrapper_url,
             quick_create_url=quick_create,
             deploy_command=deploy_cmd,
         )
-
-    def _build_ui(self, manifest: FeatureManifest) -> None:
-        if not manifest.ui.buildCommand:
-            self._log(
-                "[yellow]![/yellow] feature.yaml has no ui.buildCommand — skipping UI build"
-            )
-            return
-        self._log(f"▸ Building UI bundle: {manifest.ui.buildCommand}")
-        subprocess.run(
-            manifest.ui.buildCommand, cwd=self.project_dir, shell=True, check=True
-        )
-        bundle = self.project_dir / manifest.ui.bundlePath
-        if not bundle.is_file():
-            raise RuntimeError(f"UI bundle not produced at {bundle}")
-        self._log("[green]✓[/green] UI build finished")
-
-    def _sam_build_and_package(
-        self,
-        *,
-        manifest: FeatureManifest,
-        artifact_bucket: str,
-        artifact_prefix: str,
-        region: str,
-    ) -> None:
-        if not shutil.which("sam"):
-            raise RuntimeError(
-                "`sam` (AWS SAM CLI) not found in PATH; install it to publish packs."
-            )
-        self._log("▸ Running sam build…")
-        subprocess.run(
-            ["sam", "build"], cwd=self.project_dir, check=True, capture_output=True
-        )
-        self._log("▸ Running sam package…")
-        out = self.project_dir / ".aws-sam" / "packaged.yaml"
-        subprocess.run(
-            [
-                "sam",
-                "package",
-                "--s3-bucket",
-                artifact_bucket,
-                "--s3-prefix",
-                artifact_prefix,
-                "--output-template-file",
-                str(out),
-                "--region",
-                region,
-            ],
-            cwd=self.project_dir,
-            check=True,
-            capture_output=True,
-        )
-        self._log(f"[green]✓[/green] SAM package complete -> {out}")
-
-    def _upload_public(
-        self,
-        s3: Any,
-        local_path: Path,
-        bucket: str,
-        key: str,
-        content_type: str,
-    ) -> None:
-        # Public-read is granted at bucket-policy level for the
-        # `packs/*` and `host/*` prefixes (see ensure_artifacts_bucket).
-        # Object ACLs are deprecated and unsupported on modern
-        # BucketOwnerEnforced buckets.
-        s3.upload_file(
-            str(local_path),
-            bucket,
-            key,
-            ExtraArgs={"ContentType": content_type},
-        )
-        self._log(f"[green]✓[/green] uploaded s3://{bucket}/{key}")
 
 
 def deploy_pack(
@@ -783,10 +644,10 @@ def ensure_artifacts_bucket(
         relaxed and a bucket policy granting public read on the ``packs/*``
         and ``host/*`` prefixes is applied/merged. This is only needed for
         sharing published artifacts for *cross-account* pack deploys,
-        where the deploying account's pre-stager Lambda fetches the
-        wrapper/host/feature templates via plain HTTPS (object ACLs don't
-        work — modern buckets default to BucketOwnerEnforced, which
-        rejects ACLs entirely).
+        where the deploying account's CloudFormation + feature stack fetch
+        the wrapper/host/feature templates and Lambda code zips via plain
+        HTTPS (object ACLs don't work — modern buckets default to
+        BucketOwnerEnforced, which rejects ACLs entirely).
     """
     cons = console or Console()
     sts = boto3.client("sts", region_name=region)
@@ -866,10 +727,11 @@ def apply_public_artifacts_policy(
 
     Opt-in only — callers invoke this when the operator passed ``--public``.
     It grants anonymous HTTPS read on the published-artifact prefixes so a
-    *deploying* account's pre-stager Lambda (which fetches the wrapper/host/
-    feature templates via plain ``urllib`` over HTTPS, not SigV4) can read
-    them during cross-account pack deploys. Same-account/private flows never
-    call this, so a bucket's Block Public Access settings are left untouched.
+    *deploying* account's CloudFormation + feature stack (which fetch the
+    wrapper/host/feature templates and Lambda code zips over plain HTTPS, not
+    SigV4) can read them during cross-account pack deploys. Same-account/
+    private flows never call this, so a bucket's Block Public Access settings
+    are left untouched.
 
     Raises ``RuntimeError`` with an actionable message if the public policy
     cannot be applied (e.g. account-level S3 Block Public Access).

--- a/lib/idp_feature_sdk/idp_feature_sdk/pack.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/pack.py
@@ -206,14 +206,6 @@ class PackPublisher:
             )
 
         s3 = boto3.client("s3", region_name=region)
-
-        # When publishing public (opt-in, cross-account), ensure the
-        # `packs/*`/`host/*` public-read bucket policy is in place before
-        # uploading. An explicit `--bucket-basename` skips the auto-bucket
-        # path in `_resolve_bucket`, so the policy is applied here. Without
-        # `--public` the bucket is left untouched (secure, same-account).
-        if make_public:
-            apply_public_artifacts_policy(s3, artifacts_bucket, console=self.console)
         feature_id = manifest.featureId
         version = manifest.version
 
@@ -264,11 +256,19 @@ class PackPublisher:
             defaults[wp.versionParam] = version
         baked_wrapper = _bake_wrapper_defaults(wrapper_yaml, param_defaults=defaults)
         wrapper_key = f"{feat_prefix}/deploy.yaml"
+        # Mirror FeaturePublisher's per-object publicness: with --public, tag
+        # the wrapper public-read just like every feature artifact (the bucket
+        # policy from _resolve_bucket's auto-bucket path covers it too, but the
+        # ACL keeps an explicit-basename public bucket working identically to
+        # `publish`). Without --public the wrapper stays private (same-account).
+        wrapper_extra: Dict[str, str] = {"ContentType": "application/x-yaml"}
+        if make_public:
+            wrapper_extra["ACL"] = "public-read"
         s3.put_object(
             Bucket=artifacts_bucket,
             Key=wrapper_key,
             Body=baked_wrapper.encode("utf-8"),
-            ContentType="application/x-yaml",
+            **wrapper_extra,
         )
         wrapper_url = _public_https_url(artifacts_bucket, region, wrapper_key)
         self._log(
@@ -277,38 +277,15 @@ class PackPublisher:
 
         # 4b. When publishing public (opt-in, cross-account), sanity-check the
         # wrapper is publicly readable. A Quick-Create / cross-account deploy
-        # fetches the wrapper template via plain HTTPS — if the bucket policy
-        # didn't take effect (e.g. account-level S3 Block Public Access
-        # overrides) the deploy fails late with HTTP 403. Catch that here,
-        # before CFN starts spinning up.
+        # fetches the wrapper template via plain HTTPS — if the object isn't
+        # public (per-object ACL blocked, or account-level S3 Block Public
+        # Access overriding the policy) the deploy fails late with HTTP 403.
+        # Catch that here, before CFN starts spinning up.
         #
         # Without `--public` the artifacts are private (same-account flow):
-        # the bucket has no public-read policy and an anonymous HEAD would
-        # legitimately 403, so the check is skipped.
+        # an anonymous HEAD would legitimately 403, so the check is skipped.
         if make_public:
-            import urllib.error
-            import urllib.request
-
-            try:
-                req = urllib.request.Request(wrapper_url, method="HEAD")
-                with urllib.request.urlopen(req, timeout=15) as r:
-                    if r.status != 200:
-                        raise RuntimeError(f"HTTP {r.status}")
-            except urllib.error.HTTPError as exc:
-                raise RuntimeError(
-                    f"Published wrapper at {wrapper_url} is not publicly "
-                    f"reachable (HTTP {exc.code}). The bucket policy did not "
-                    f"take effect — most likely cause is account-level S3 "
-                    f"Block Public Access. Disable BlockPublicPolicy + "
-                    f"RestrictPublicBuckets at the account level, or pass "
-                    f"--bucket-basename pointing at a bucket where you "
-                    f"control BPA."
-                ) from exc
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Couldn't HEAD the published wrapper at {wrapper_url}: {exc}. "
-                    f"Cross-account pack deploys won't work until this is fixed."
-                ) from exc
+            self._assert_publicly_readable(wrapper_url)
         else:
             self._log(
                 "[dim]Artifacts published privately (same-account). Pass "
@@ -338,6 +315,33 @@ class PackPublisher:
             quick_create_url=quick_create,
             deploy_command=deploy_cmd,
         )
+
+    def _assert_publicly_readable(self, url: str) -> None:
+        """Anonymous HEAD the published wrapper to confirm `--public` actually
+        made it world-readable, failing fast (before CFN spins up) if not."""
+        import urllib.error
+        import urllib.request
+
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=15) as r:
+                if r.status != 200:
+                    raise RuntimeError(f"HTTP {r.status}")
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Published wrapper at {url} is not publicly reachable "
+                f"(HTTP {exc.code}). The object did not become public — either "
+                f"the per-object public-read ACL was rejected or account-level "
+                f"S3 Block Public Access is overriding the bucket policy. "
+                f"Disable BlockPublicPolicy + RestrictPublicBuckets at the "
+                f"account level, or pass --bucket-basename pointing at a bucket "
+                f"where you control BPA."
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                f"Couldn't HEAD the published wrapper at {url}: {exc}. "
+                f"Cross-account pack deploys won't work until this is fixed."
+            ) from exc
 
 
 def deploy_pack(
@@ -590,7 +594,16 @@ def create_or_update_stack(
     raise RuntimeError(f"Timed out waiting for stack {stack_name}")
 
 
-_PACK_PUBLIC_PREFIXES = ("packs/", "host/")
+# Public-read bucket-policy prefixes for the AUTO-CREATED artifacts bucket
+# (applied by ensure_artifacts_bucket on --public). These match the real
+# published layout: feature/pack artifacts + the baked wrapper live under
+# `extensions/<id>/...` (the same version-free layout `publish` uses), and the
+# host accelerator (publish_host_accelerator / `idp-cli publish`) under
+# `host/...`. Objects are ALSO tagged public-read per-object (mirroring
+# `publish`), which covers any custom `--prefix` that nests the layout under
+# `<prefix>/extensions/...`; this policy is the convenience layer for the
+# default (unprefixed) auto-bucket case.
+_PACK_PUBLIC_PREFIXES = ("extensions/", "host/")
 
 
 def _pack_public_bucket_policy(bucket: str) -> Dict[str, Any]:
@@ -598,10 +611,11 @@ def _pack_public_bucket_policy(bucket: str) -> Dict[str, Any]:
     pack publishing uses. Required so cross-account CFN deploys can
     download the wrapper / host / feature templates and Lambda zips.
 
-    Why a bucket policy and not object ACLs:
-      Modern S3 buckets default to Object Ownership = BucketOwnerEnforced,
-      which disables ACLs entirely. PutObjectAcl returns
-      AccessControlListNotSupported. A bucket policy works regardless.
+    This is the auto-bucket convenience layer (applied by
+    ``ensure_artifacts_bucket`` when ``--public`` creates/owns the bucket).
+    Publicness of the individual objects is ALSO set per-object via
+    ``ACL=public-read`` (mirroring ``publish``), so an explicit-basename
+    public bucket works the same way without relying on this policy.
     """
     return {
         "Version": "2012-10-17",
@@ -641,9 +655,10 @@ def ensure_artifacts_bucket(
         publish run.
       * With ``make_public=True`` (opt-in, e.g. ``--make-public``), the
         bucket's ``BlockPublicPolicy``/``RestrictPublicBuckets`` flags are
-        relaxed and a bucket policy granting public read on the ``packs/*``
-        and ``host/*`` prefixes is applied/merged. This is only needed for
-        sharing published artifacts for *cross-account* pack deploys,
+        relaxed and a bucket policy granting public read on the
+        ``extensions/*`` and ``host/*`` prefixes is applied/merged. This is
+        only needed for sharing published artifacts for *cross-account* pack
+        deploys,
         where the deploying account's CloudFormation + feature stack fetch
         the wrapper/host/feature templates and Lambda code zips via plain
         HTTPS (object ACLs don't work — modern buckets default to
@@ -723,7 +738,7 @@ def apply_public_artifacts_policy(
     s3: Any, bucket: str, *, console: Optional[Console] = None
 ) -> None:
     """Relax BlockPublicPolicy/RestrictPublicBuckets and apply (or merge) the
-    ``packs/*`` + ``host/*`` public-read bucket policy on ``bucket``.
+    ``extensions/*`` + ``host/*`` public-read bucket policy on ``bucket``.
 
     Opt-in only — callers invoke this when the operator passed ``--public``.
     It grants anonymous HTTPS read on the published-artifact prefixes so a

--- a/lib/idp_feature_sdk/idp_feature_sdk/schemas/feature-manifest.schema.json
+++ b/lib/idp_feature_sdk/idp_feature_sdk/schemas/feature-manifest.schema.json
@@ -190,9 +190,13 @@
               "default": "IdpAcceleratorTemplateUrl",
               "description": "Name of the wrapper parameter that takes the host accelerator template URL."
             },
-            "artifactSourceParam": {
+            "featureBucketParam": {
               "type": "string",
-              "description": "Name of the wrapper parameter that takes the public artifact source URL prefix. Defaults to '<FeatureIdCamel>ArtifactSource'."
+              "description": "Name of the wrapper parameter that takes the S3 bucket holding the published feature artifacts. publish-pack bakes the publish bucket as this parameter's default; the wrapper passes it straight to the feature stack's FeatureBucket parameter (the feature stack reads artifacts in place via IAM — no seller-bucket copy)."
+            },
+            "prefixParam": {
+              "type": "string",
+              "description": "Name of the wrapper parameter that takes the version-free artifact key prefix (e.g. 'extensions/<id>'). publish-pack bakes this as the parameter's default so the wrapper/feature stack can locate the published artifacts."
             },
             "versionParam": {
               "type": "string",

--- a/lib/idp_feature_sdk/tests/test_ensure_artifacts_bucket.py
+++ b/lib/idp_feature_sdk/tests/test_ensure_artifacts_bucket.py
@@ -88,7 +88,7 @@ def test_preexisting_bucket_bpa_left_untouched(aws_credentials):
 
 def test_make_public_opt_in_relaxes_bpa_and_sets_policy(aws_credentials):
     """With make_public=True, BlockPublicPolicy/RestrictPublicBuckets are
-    relaxed and the packs/host public-read bucket policy is applied."""
+    relaxed and the extensions/host public-read bucket policy is applied."""
     with mock_aws():
         bucket = ensure_artifacts_bucket(region=REGION, make_public=True)
         s3 = boto3.client("s3", region_name=REGION)
@@ -107,7 +107,7 @@ def test_make_public_opt_in_relaxes_bpa_and_sets_policy(aws_credentials):
         )
         assert stmt["Principal"] == "*"
         assert stmt["Action"] == "s3:GetObject"
-        assert any(f"{bucket}/packs/" in r for r in stmt["Resource"])
+        assert any(f"{bucket}/extensions/" in r for r in stmt["Resource"])
         assert any(f"{bucket}/host/" in r for r in stmt["Resource"])
 
 

--- a/lib/idp_feature_sdk/tests/test_pack.py
+++ b/lib/idp_feature_sdk/tests/test_pack.py
@@ -1,0 +1,200 @@
+"""Tests for PackPublisher against a moto-mocked S3.
+
+A pack publishes its feature artifacts by DELEGATING to FeaturePublisher, so
+it inherits the exact same `extensions/<id>/` version-free layout and the same
+five baked publish-time tokens. publish-pack then bakes the publish bucket +
+version-free prefix + version into the wrapper's parameter defaults; the
+feature stack reads artifacts IN PLACE (no seller bucket, no pre-stage copy).
+
+These assert that contract: layout parity with `publish`, tokens fully baked,
+and the wrapper's FeatureBucket/Prefix/Version defaults point at the published
+artifacts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import boto3
+from idp_feature_sdk.pack import PackPublisher
+
+_FEATURE_ID = "demo-feature"
+_VERSION = "1.2.3"
+_BASE = f"extensions/{_FEATURE_ID}"  # default prefix="" → bare extensions/<id>
+_HOST_URL = "https://example.s3.us-east-1.amazonaws.com/host/idp-main.yaml"
+
+
+def _keys(bucket: str) -> set[str]:
+    s3 = boto3.client("s3", region_name="us-east-1")
+    return {o["Key"] for o in s3.list_objects_v2(Bucket=bucket).get("Contents", [])}
+
+
+def _make_pack(project: Path) -> None:
+    """Turn the shared demo feature project into a pack: add a `pack:` section
+    pointing at a wrapper deploy.yaml that declares the three baked params."""
+    feature_yaml = (project / "feature.yaml").read_text(encoding="utf-8")
+    feature_yaml += dedent("""
+        pack:
+          wrapperTemplatePath: deploy.yaml
+          wrapperParameters:
+            hostTemplateUrlParam: IdpAcceleratorTemplateUrl
+            featureBucketParam: FeatureBucket
+            prefixParam: FeatureArtifactPrefix
+            versionParam: FeatureVersion
+    """)
+    (project / "feature.yaml").write_text(feature_yaml, encoding="utf-8")
+
+    # Minimal wrapper: the three params have NO existing Default (publisher
+    # inserts one) and IdpAcceleratorTemplateUrl gets its default baked too.
+    (project / "deploy.yaml").write_text(
+        dedent("""
+            AWSTemplateFormatVersion: '2010-09-09'
+            Description: demo pack wrapper
+            Parameters:
+              IdpAcceleratorTemplateUrl:
+                Type: String
+              FeatureBucket:
+                Type: String
+              FeatureArtifactPrefix:
+                Type: String
+              FeatureVersion:
+                Type: String
+              AdminEmail:
+                Type: String
+            Resources:
+              Dummy:
+                Type: AWS::SNS::Topic
+        """).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_pack_uses_feature_layout_and_bakes_tokens(
+    demo_feature_project: Path, feature_bucket: str
+) -> None:
+    _make_pack(demo_feature_project)
+
+    result = PackPublisher(demo_feature_project).publish(
+        artifacts_bucket=feature_bucket,
+        artifacts_prefix="",
+        host_template_url=_HOST_URL,
+        region="us-east-1",
+    )
+
+    assert result.feature_id == _FEATURE_ID
+    assert result.version == _VERSION
+
+    keys = _keys(feature_bucket)
+    # SAME version-free layout as `publish` — NOT the old packs/<id>/v<ver>/.
+    assert f"{_BASE}/template.yaml" in keys
+    assert f"{_BASE}/latest.json" in keys
+    assert f"{_BASE}/{_VERSION}/ui-bundle.js" in keys
+    assert f"{_BASE}/{_VERSION}/manifest.json" in keys
+    assert not any(k.startswith("packs/") for k in keys)
+    assert not any("/v1.2.3/" in k for k in keys)
+    # The baked wrapper lands at the version-free base.
+    assert f"{_BASE}/deploy.yaml" in keys
+
+
+def test_pack_feature_template_has_all_tokens_baked(
+    demo_feature_project: Path, feature_bucket: str
+) -> None:
+    """Delegating to FeaturePublisher bakes ALL five tokens (the old pack
+    publisher only baked VERSION, leaving ARTIFACT_PREFIX literal — issue A)."""
+    _make_pack(demo_feature_project)
+    PackPublisher(demo_feature_project).publish(
+        artifacts_bucket=feature_bucket,
+        artifacts_prefix="",
+        host_template_url=_HOST_URL,
+        region="us-east-1",
+    )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    tmpl = (
+        s3.get_object(Bucket=feature_bucket, Key=f"{_BASE}/template.yaml")["Body"]
+        .read()
+        .decode()
+    )
+    for token in (
+        "<FEATURE_VERSION_TOKEN>",
+        "<FEATURE_ARTIFACT_PREFIX_TOKEN>",
+        "<FEATURE_BUCKET_TOKEN>",
+        "<FEATURE_PRODUCT_CODE_TOKEN>",
+        "<FEATURE_LISTING_URL_TOKEN>",
+    ):
+        assert token not in tmpl, f"{token} was left unbaked"
+    assert f"ArtifactPrefix: {_BASE}" in tmpl or f"ArtifactPrefix: '{_BASE}'" in tmpl
+
+
+def test_wrapper_defaults_point_at_published_artifacts(
+    demo_feature_project: Path, feature_bucket: str
+) -> None:
+    """The wrapper's FeatureBucket/Prefix/Version defaults are baked so the
+    feature stack reads artifacts in place — no seller bucket, no pre-stager."""
+    _make_pack(demo_feature_project)
+    PackPublisher(demo_feature_project).publish(
+        artifacts_bucket=feature_bucket,
+        artifacts_prefix="",
+        host_template_url=_HOST_URL,
+        region="us-east-1",
+    )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    wrapper = (
+        s3.get_object(Bucket=feature_bucket, Key=f"{_BASE}/deploy.yaml")["Body"]
+        .read()
+        .decode()
+    )
+    assert f"Default: '{feature_bucket}'" in wrapper
+    assert f"Default: '{_BASE}'" in wrapper
+    assert f"Default: '{_VERSION}'" in wrapper
+    assert f"Default: '{_HOST_URL}'" in wrapper
+
+
+def test_explicit_prefix_propagates_to_layout_and_wrapper(
+    demo_feature_project: Path, feature_bucket: str
+) -> None:
+    _make_pack(demo_feature_project)
+    result = PackPublisher(demo_feature_project).publish(
+        artifacts_bucket=feature_bucket,
+        artifacts_prefix="mkt",
+        host_template_url=_HOST_URL,
+        region="us-east-1",
+    )
+    prefixed_base = f"mkt/extensions/{_FEATURE_ID}"
+    assert result.artifact_prefix == prefixed_base
+    keys = _keys(feature_bucket)
+    assert f"{prefixed_base}/template.yaml" in keys
+    assert f"{prefixed_base}/deploy.yaml" in keys
+
+    s3 = boto3.client("s3", region_name="us-east-1")
+    wrapper = (
+        s3.get_object(Bucket=feature_bucket, Key=f"{prefixed_base}/deploy.yaml")["Body"]
+        .read()
+        .decode()
+    )
+    assert f"Default: '{prefixed_base}'" in wrapper
+
+
+def test_unknown_wrapper_param_raises(
+    demo_feature_project: Path, feature_bucket: str
+) -> None:
+    """A wrapperParameters name absent from the wrapper template is a clear
+    error, not a silent no-op."""
+    _make_pack(demo_feature_project)
+    # Point versionParam at a param the wrapper doesn't declare.
+    fy = (demo_feature_project / "feature.yaml").read_text(encoding="utf-8")
+    fy = fy.replace("versionParam: FeatureVersion", "versionParam: NoSuchParam")
+    (demo_feature_project / "feature.yaml").write_text(fy, encoding="utf-8")
+
+    try:
+        PackPublisher(demo_feature_project).publish(
+            artifacts_bucket=feature_bucket,
+            artifacts_prefix="",
+            host_template_url=_HOST_URL,
+            region="us-east-1",
+        )
+    except ValueError as exc:
+        assert "NoSuchParam" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for unknown wrapper parameter")

--- a/lib/idp_feature_sdk/tests/test_pack.py
+++ b/lib/idp_feature_sdk/tests/test_pack.py
@@ -30,6 +30,15 @@ def _keys(bucket: str) -> set[str]:
     return {o["Key"] for o in s3.list_objects_v2(Bucket=bucket).get("Contents", [])}
 
 
+def _acl_is_public(s3, bucket: str, key: str) -> bool:
+    grants = s3.get_object_acl(Bucket=bucket, Key=key)["Grants"]
+    return any(
+        g.get("Grantee", {}).get("URI", "").endswith("AllUsers")
+        and g.get("Permission") == "READ"
+        for g in grants
+    )
+
+
 def _make_pack(project: Path) -> None:
     """Turn the shared demo feature project into a pack: add a `pack:` section
     pointing at a wrapper deploy.yaml that declares the three baked params."""
@@ -174,6 +183,37 @@ def test_explicit_prefix_propagates_to_layout_and_wrapper(
         .decode()
     )
     assert f"Default: '{prefixed_base}'" in wrapper
+
+
+def test_public_makes_wrapper_and_feature_artifacts_readable(
+    demo_feature_project: Path, feature_bucket: str, monkeypatch
+) -> None:
+    """--public must tag the WRAPPER and the feature artifacts public-read —
+    mirroring `publish`. Regression guard for the bug where the wrapper was
+    uploaded with no ACL and the public-read policy only covered the unused
+    `packs/*` prefix, so cross-account / Quick-Create deploys 403'd."""
+    _make_pack(demo_feature_project)
+
+    # The 4b sanity check does a real anonymous HTTPS HEAD on the wrapper URL,
+    # which isn't reachable under moto — stub it; we assert the ACLs directly.
+    monkeypatch.setattr(
+        PackPublisher, "_assert_publicly_readable", lambda self, url: None
+    )
+
+    PackPublisher(demo_feature_project).publish(
+        artifacts_bucket=feature_bucket,
+        artifacts_prefix="",
+        host_template_url=_HOST_URL,
+        region="us-east-1",
+        make_public=True,
+    )
+
+    s3 = boto3.client("s3", region_name="us-east-1")
+    # The wrapper (the Quick-Create target) is public-read.
+    assert _acl_is_public(s3, feature_bucket, f"{_BASE}/deploy.yaml")
+    # The feature artifacts the deploy reads in place are public-read too.
+    assert _acl_is_public(s3, feature_bucket, f"{_BASE}/template.yaml")
+    assert _acl_is_public(s3, feature_bucket, f"{_BASE}/{_VERSION}/ui-bundle.js")
 
 
 def test_unknown_wrapper_param_raises(


### PR DESCRIPTION
## What & why

`idp-feature-cli publish-pack` / `deploy-pack` had drifted out of parity with `publish` / `deploy`, to the point that a freshly published+deployed pack fails at CREATE. Closes the functional gaps and the arg/semantic divergences tracked in #375.

Root problems (all in `lib/idp_feature_sdk`):
- **(A)** The pack publisher baked only `<FEATURE_VERSION_TOKEN>`; the feature publisher bakes all five (`VERSION`, `ARTIFACT_PREFIX`, `BUCKET`, `PRODUCT_CODE`, `LISTING_URL`). So a pack's published `template.yaml` shipped a literal `<FEATURE_ARTIFACT_PREFIX_TOKEN>`, and the feature stack's ui-deployer fails fast on it.
- **(B)** Pack used a bespoke `packs/<id>/v<ver>/` layout vs the feature publisher's `extensions/<id>/` version-free layout — and the baked prefix didn't match where artifacts were read.
- **(C)** Wrapper carried a stale contract (SellerBucket / pre-stage copy fed by anonymous HTTPS).
- **(D)** `--bucket-basename` required (no auto-bucket), `--prefix`/`--region` defaults differed, a `--skip-build` flag `publish` doesn't have.
- **(E)** `sam build`/`package` ran with `capture_output=True` and re-raised with stderr discarded — failures were undiagnosable.

## Approach

**`PackPublisher` now delegates feature-artifact publishing to `FeaturePublisher`.** That single change makes packs inherit, identically: the `extensions/<id>/` version-free layout (B), all five baked tokens (A), the SAM step that surfaces captured stderr on failure (E), and the private-by-default / `--public` ACL semantics. Sharing one publisher is what stops the two from drifting again.

**Seller bucket dropped (design decision in #375).** `publish-pack` bakes the publish bucket + version-free prefix + version into the wrapper's parameter defaults; the feature stack reads artifacts **in place** via IAM, exactly like a normal `deploy`. No pre-stage copy, no anonymous fetch. This also removes most of the pressure behind #372 for same-account deploys.

**Clean break on the wrapper contract:** `wrapperParameters.artifactSourceParam` → `featureBucketParam` + `prefixParam`. Wrappers must migrate (the closed-source claims-pack `deploy.yaml` is updated in lockstep, separately).

**CLI parity (D):** `--bucket-basename` optional with the same auto-bucket default as `publish`; `--prefix` defaults to `""` (bare `extensions/<id>/`); `--region` defaults to `us-east-1`; `--skip-build` removed.

## Changes
- `idp_feature_sdk/pack.py` — delegate to `FeaturePublisher`; bake wrapper `FeatureBucket`/prefix/version; drop the bespoke upload path, `_build_ui`, `_sam_build_and_package`, `_upload_public`, `_content_type_for`, `artifact_source_url`.
- `idp_feature_sdk/manifest.py` + `schemas/feature-manifest.schema.json` — `featureBucketParam`/`prefixParam` replace `artifactSourceParam`.
- `idp_feature_sdk/cli.py` — `publish-pack`/`deploy-pack` arg parity.
- `tests/test_pack.py` — new: layout parity, all-tokens-baked, wrapper defaults point at published artifacts, explicit-prefix propagation, unknown-param error.

## Testing
- `pytest lib/idp_feature_sdk` → **59 passed** (5 new).
- `ruff check` / `ruff format --check` → clean.

## Compatibility note
Breaking for existing pack wrappers: `artifactSourceParam` is gone and the seller-bucket pre-stage is removed. Any `deploy.yaml` must (a) declare params for `featureBucketParam`/`prefixParam`/`versionParam`, and (b) pass `FeatureBucket` + prefix straight to the feature stack instead of creating a seller bucket. The only in-tree pack sample (`subscription-features/feature-platform/claims-pack`) has no wrapper checked in; the closed-source claims-pack wrapper is migrated alongside this.

Closes #375. Related: #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
