### PR TITLE
feat(feature-sdk): bake publish-time tokens into the pack wrapper template

### DIFF
--- a/lib/idp_feature_sdk/idp_feature_sdk/pack.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/pack.py
@@ -37,7 +37,7 @@ from typing import Any, Dict, List, Optional
 import boto3
 from rich.console import Console
 
-from .manifest import load_manifest
+from .manifest import FeatureManifest, load_manifest
 from .publisher import FeaturePublisher
 
 
@@ -56,6 +56,29 @@ class PackPublishResult:
 
 def _public_https_url(bucket: str, region: str, key: str) -> str:
     return f"https://{bucket}.s3.{region}.amazonaws.com/{key}"
+
+
+def _bake_wrapper_tokens(
+    wrapper_yaml: str,
+    *,
+    manifest: FeatureManifest,
+    artifact_bucket: str,
+    artifact_prefix: str,
+) -> str:
+    """Substitute the publish-time ``<FEATURE_*_TOKEN>`` placeholders in the
+    wrapper text, mirroring how FeaturePublisher bakes the SAME tokens into the
+    feature template (publisher.py). Lets the wrapper use the version (etc.) in
+    places CloudFormation forbids intrinsics — most notably the top-level
+    ``Description``. All tokens are OPTIONAL: a placeholder that isn't present
+    is simply a no-op, so wrappers that don't use them are unaffected.
+    """
+    return (
+        wrapper_yaml.replace("<FEATURE_VERSION_TOKEN>", manifest.version)
+        .replace("<FEATURE_ARTIFACT_PREFIX_TOKEN>", artifact_prefix)
+        .replace("<FEATURE_BUCKET_TOKEN>", artifact_bucket)
+        .replace("<FEATURE_PRODUCT_CODE_TOKEN>", manifest.marketplace.productCode or "")
+        .replace("<FEATURE_LISTING_URL_TOKEN>", manifest.marketplace.listingUrl or "")
+    )
 
 
 def _bake_wrapper_defaults(
@@ -254,7 +277,20 @@ class PackPublisher:
             defaults[wp.prefixParam] = feat_prefix
         if wp.versionParam:
             defaults[wp.versionParam] = version
-        baked_wrapper = _bake_wrapper_defaults(wrapper_yaml, param_defaults=defaults)
+        # Also bake the publish-time tokens into the wrapper text, the SAME way
+        # FeaturePublisher bakes them into the feature template. The wrapper
+        # parameter Defaults above cover values referenced via !Ref/!Sub, but
+        # CloudFormation forbids intrinsics in a few places (e.g. the top-level
+        # `Description`), so a wrapper that wants the version in such a field
+        # uses `<FEATURE_VERSION_TOKEN>` and relies on this substitution. Tokens
+        # are optional — absent placeholders are simply left untouched.
+        baked_wrapper = _bake_wrapper_tokens(
+            wrapper_yaml,
+            manifest=manifest,
+            artifact_bucket=artifacts_bucket,
+            artifact_prefix=feat_prefix,
+        )
+        baked_wrapper = _bake_wrapper_defaults(baked_wrapper, param_defaults=defaults)
         wrapper_key = f"{feat_prefix}/deploy.yaml"
         # Mirror FeaturePublisher's per-object publicness: with --public, tag
         # the wrapper public-read just like every feature artifact (the bucket

--- a/lib/idp_feature_sdk/tests/test_pack.py
+++ b/lib/idp_feature_sdk/tests/test_pack.py
@@ -59,7 +59,7 @@ def _make_pack(project: Path) -> None:
     (project / "deploy.yaml").write_text(
         dedent("""
             AWSTemplateFormatVersion: '2010-09-09'
-            Description: demo pack wrapper
+            Description: demo pack wrapper v<FEATURE_VERSION_TOKEN>
             Parameters:
               IdpAcceleratorTemplateUrl:
                 Type: String
@@ -214,6 +214,29 @@ def test_public_makes_wrapper_and_feature_artifacts_readable(
     # The feature artifacts the deploy reads in place are public-read too.
     assert _acl_is_public(s3, feature_bucket, f"{_BASE}/template.yaml")
     assert _acl_is_public(s3, feature_bucket, f"{_BASE}/{_VERSION}/ui-bundle.js")
+
+
+def test_wrapper_version_token_is_baked(
+    demo_feature_project: Path, feature_bucket: str
+) -> None:
+    """`<FEATURE_VERSION_TOKEN>` in the wrapper (e.g. in the top-level
+    Description, where CloudFormation forbids !Ref/!Sub) is substituted at
+    publish time — same baking the feature template gets."""
+    _make_pack(demo_feature_project)
+    PackPublisher(demo_feature_project).publish(
+        artifacts_bucket=feature_bucket,
+        artifacts_prefix="",
+        host_template_url=_HOST_URL,
+        region="us-east-1",
+    )
+    s3 = boto3.client("s3", region_name="us-east-1")
+    wrapper = (
+        s3.get_object(Bucket=feature_bucket, Key=f"{_BASE}/deploy.yaml")["Body"]
+        .read()
+        .decode()
+    )
+    assert "<FEATURE_VERSION_TOKEN>" not in wrapper
+    assert f"demo pack wrapper v{_VERSION}" in wrapper
 
 
 def test_unknown_wrapper_param_raises(


### PR DESCRIPTION
## What & why

`publish-pack` bakes the five `<FEATURE_*_TOKEN>` placeholders into the **feature** template (via `FeaturePublisher`), but for the **wrapper** (`deploy.yaml`) it only set parameter `Default:` values — it never substituted tokens in the wrapper body.

That gap matters because a wrapper can't always use a parameter where it wants a value. The clearest case: the CloudFormation top-level **`Description`** must be a literal string — `!Ref`/`!Sub` are not allowed there. So a pack author who wants the version in the stack Description (e.g. `Description: Claims Processing — v<FEATURE_VERSION_TOKEN>`) had no way to get it; the literal token would publish verbatim.

## Change

Add `_bake_wrapper_tokens`, applied to the wrapper text **before** `_bake_wrapper_defaults`, substituting the **same** token set the feature template already gets:

- `<FEATURE_VERSION_TOKEN>` → `manifest.version`
- `<FEATURE_ARTIFACT_PREFIX_TOKEN>` → the version-free prefix (`extensions/<id>`)
- `<FEATURE_BUCKET_TOKEN>` → the publish bucket
- `<FEATURE_PRODUCT_CODE_TOKEN>` / `<FEATURE_LISTING_URL_TOKEN>` → marketplace identity

All tokens are **optional** — an absent placeholder is a no-op, so existing wrappers are unaffected. Parameter-`Default:` baking is unchanged (the two are complementary: defaults for `!Ref`-able params, token substitution for places intrinsics can't go).

## Testing
- New `test_wrapper_version_token_is_baked`: the wrapper fixture's `Description: demo pack wrapper v<FEATURE_VERSION_TOKEN>` is substituted to the real version at publish.
- Full suite: **61 passed**; ruff check + format clean.

Follows #376 (the pack/feature parity refactor). No behavior change for wrappers that don't use the tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
