### PR TITLE
fix(config): remove duplicate max_images_per_agent field (develop CI red)

### DIFF
--- a/lib/idp_common_pkg/idp_common/config/models.py
+++ b/lib/idp_common_pkg/idp_common/config/models.py
@@ -288,19 +288,6 @@ class AgenticConfig(BaseModel):
         "(legacy behavior). Per-shard sharding already bounds this; the cap is the "
         "backstop for the single-agent path.",
     )
-    max_images_per_agent: int = Field(
-        default=20,
-        ge=0,
-        description="Safety cap on how many page images are attached to a single "
-        "agent invocation when the task prompt uses {DOCUMENT_IMAGE}. Sending many "
-        "large images in one request can cause Bedrock read timeouts / oversized "
-        "first turns (a long doc with 25+ page images is the classic case). When "
-        "the section (or a shard) has more images than this, only the first N are "
-        "attached and a warning is logged; the agent still has the full OCR text "
-        "and can fetch specific pages with the view_image tool. 0 = unlimited "
-        "(legacy behavior). Per-shard sharding already bounds this; the cap is the "
-        "backstop for the single-agent path.",
-    )
     table_parsing: TableParsingConfig = Field(
         default_factory=TableParsingConfig,
         description="Configuration for deterministic table parsing tool. "


### PR DESCRIPTION
## Summary

**Fixes a red `develop` CI typecheck.** The squash-merges of the stacked extraction PRs left `AgenticConfig` (`idp_common/config/models.py`) with **two identical `max_images_per_agent` field declarations** — #396 added the field, and #397's merge-conflict resolution re-added an identical copy. basedpyright flagged it as `reportRedeclaration`, failing the develop CI typecheck (the failure landed *after* #397 auto-merged on its earlier-green check).

## Fix
Remove the duplicate declaration (the two blocks were byte-identical, so runtime behavior is unchanged — `max_images_per_agent` still defaults to 20).

## Verification
- `basedpyright lib/idp_common_pkg/idp_common/config/models.py`: **0 errors** (was 1: reportRedeclaration). Only the long-standing unrelated `RuleValidationConfig` warning remains.
- `pytest tests/unit/config tests/unit/extraction`: 371 passed; the 6 failures are the pre-existing `configuration_sync` baseline (unrelated). ruff clean.
- `IDPConfig()` constructs; `extraction.agentic.max_images_per_agent == 20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)