### PR TITLE
fix(pricing): populate missing Claude Sonnet 4.6 unit prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ are migrated automatically on read — no manual edit is required.** See the
 
 - **Model output-token limits corrected for Claude Sonnet 4.6 / Opus 4.6 (128K, not 64K).** A generic pattern in `model_config_limits.yaml` mis-capped these models at 64,000 output tokens, causing config validation to reject valid `max_tokens` up to their true 128,000 limit. Only Haiku 4.5 and Sonnet/Opus 4.0–4.5 cap at 64K.
 
+- **Claude Sonnet 4.6 pricing was missing (empty `units`).** The `bedrock/*.anthropic.claude-sonnet-4-6` entries (all regions, base + `:1m`) in `pricing.yaml` had no unit prices, so cost reports showed $0 for the **default extraction model** and — more critically — config validation rejected the pricing block (`units: Input should be a valid list`), which could deadlock a stack update/rollback via the `UpdateDefaultConfig` custom resource. Populated with the correct Sonnet-tier rates.
+
 - **Advanced (agentic) extraction cost is reported correctly.** The Assessment step's "intelligent skip" discarded the Extraction step's Bedrock/lambda metering, making advanced modes look nearly free in cost reports; the incoming metering is now preserved.
 
 - **Extraction prompts respect per-field date/number formats from the Document Schema** (previously a hardcoded MM/DD/YYYY instruction overrode per-field formats), and **every list/nested-list cell gets its own confidence + bounding box** (previously a single score could apply to a whole row).

--- a/config_library/pricing.yaml
+++ b/config_library/pricing.yaml
@@ -208,6 +208,14 @@ pricing:
   
   - name: bedrock/us.anthropic.claude-sonnet-4-6
     units:
+      - name: inputTokens
+        price: "3.3E-6"
+      - name: outputTokens
+        price: "1.65E-5"
+      - name: cacheReadInputTokens
+        price: "3.3E-7"
+      - name: cacheWriteInputTokens
+        price: "4.125E-6"
 
   - name: bedrock/us.anthropic.claude-sonnet-5
     units:
@@ -222,6 +230,14 @@ pricing:
 
   - name: bedrock/us.anthropic.claude-sonnet-4-6:1m
     units:
+      - name: inputTokens
+        price: "6.6E-6"
+      - name: outputTokens
+        price: "2.475E-5"
+      - name: cacheReadInputTokens
+        price: "6.6E-7"
+      - name: cacheWriteInputTokens
+        price: "8.25E-6"
 
   - name: bedrock/us.anthropic.claude-sonnet-5:1m
     units:
@@ -465,6 +481,14 @@ pricing:
   
   - name: bedrock/eu.anthropic.claude-sonnet-4-6
     units:
+      - name: inputTokens
+        price: "3.3E-6"
+      - name: outputTokens
+        price: "1.65E-5"
+      - name: cacheReadInputTokens
+        price: "3.3E-7"
+      - name: cacheWriteInputTokens
+        price: "4.125E-6"
 
   - name: bedrock/eu.anthropic.claude-sonnet-5
     units:
@@ -479,6 +503,14 @@ pricing:
 
   - name: bedrock/eu.anthropic.claude-sonnet-4-6:1m
     units:
+      - name: inputTokens
+        price: "6.6E-6"
+      - name: outputTokens
+        price: "2.475E-5"
+      - name: cacheReadInputTokens
+        price: "6.6E-7"
+      - name: cacheWriteInputTokens
+        price: "8.25E-6"
 
   - name: bedrock/eu.anthropic.claude-sonnet-5:1m
     units:
@@ -628,6 +660,14 @@ pricing:
   
   - name: bedrock/global.anthropic.claude-sonnet-4-6
     units:
+      - name: inputTokens
+        price: "3.0E-6"
+      - name: outputTokens
+        price: "1.5E-5"
+      - name: cacheReadInputTokens
+        price: "3.0E-7"
+      - name: cacheWriteInputTokens
+        price: "3.75E-6"
 
   - name: bedrock/global.anthropic.claude-sonnet-5
     units:
@@ -642,6 +682,14 @@ pricing:
 
   - name: bedrock/global.anthropic.claude-sonnet-4-6:1m
     units:
+      - name: inputTokens
+        price: "6.0E-6"
+      - name: outputTokens
+        price: "2.25E-5"
+      - name: cacheReadInputTokens
+        price: "6.0E-7"
+      - name: cacheWriteInputTokens
+        price: "7.5E-6"
 
   - name: bedrock/global.anthropic.claude-sonnet-5:1m
     units:


### PR DESCRIPTION
## Summary

The `bedrock/*.anthropic.claude-sonnet-4-6` pricing entries (us/eu/global, base + `:1m`) in `config_library/pricing.yaml` had an **empty `units:` list** — a latent bug present since Sonnet 4.6 was first added.

## Impact

1. Cost reports showed **$0 for the default extraction model** (Sonnet 4.6).
2. **More critically:** `PricingConfig` validation rejects `units: None` (`units: Input should be a valid list`). The `UpdateDefaultConfig` custom resource re-validates `pricing.yaml` (read from the config S3 bucket) on **every** stack create/update — **and on rollback**. Because the pre-existing template also had the empty units, a nested-stack (`PATTERNSTACK`) update that touched config could fail *and then fail its own rollback*, deadlocking the stack in `UPDATE_ROLLBACK_FAILED`. (Encountered live; recovered by uploading the corrected `pricing.yaml` to the config bucket and re-running `continue-update-rollback`.)

## Fix

Populated all six entries with the correct Sonnet-tier rates, mirroring the same-region Sonnet 5 base prices:
- us/eu: input `3.3E-6`, output `1.65E-5`, cacheRead `3.3E-7`, cacheWrite `4.125E-6`
- global: input `3.0E-6`, output `1.5E-5`, cacheRead `3.0E-7`, cacheWrite `3.75E-6`
- `:1m`: doubles input + cacheRead

## Verification

- `PricingConfig(**yaml)` validates (80 entries, zero empty-units)
- No other pricing entries have empty units

🤖 Generated with [Claude Code](https://claude.com/claude-code)