### PR TITLE
fix(ui): refresh document detail content when processing completes

### DIFF
--- a/src/ui/src/components/document-panel/DocumentPanel.tsx
+++ b/src/ui/src/components/document-panel/DocumentPanel.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Box,
   ButtonDropdown,
@@ -685,8 +685,8 @@ export const DocumentPanel = ({
   // subscription pushed live Sections/Pages updates into the open document.
   // With the HTTP API there are no subscriptions, so while the open document is
   // still processing we re-fetch its rich detail (getDocument via the parent's
-  // getDocumentDetailsFromIds, which merges into list state and flows back as
-  // the `item` prop). Stops once the document reaches a terminal status.
+  // getDocumentDetailsFromIds, which merges into shared list state and flows back
+  // as the `item` prop). Stops once the document reaches a terminal status.
   const detailStatus = (localItem?.objectStatus || '').toUpperCase();
   const isTerminalStatus = ['COMPLETED', 'FAILED', 'ABORTED'].includes(detailStatus);
   const pollDetail = useCallback(() => {
@@ -699,6 +699,19 @@ export const DocumentPanel = ({
     enabled: USE_POLLING && !!localItem?.objectKey && !isTerminalStatus,
     intervalMs: DOCUMENT_DETAIL_POLL_INTERVAL_MS,
   });
+
+  // When the open document transitions to a terminal status (typically detected
+  // by the lightweight list poll, which carries no Sections/Pages/Metering), the
+  // detail poll above stops firing. Do one final rich getDocument fetch on that
+  // transition so the completed sections, pages, and estimated cost are pulled in.
+  const objectKey = localItem?.objectKey;
+  const wasTerminalRef = useRef(isTerminalStatus);
+  useEffect(() => {
+    if (isTerminalStatus && !wasTerminalRef.current && objectKey && getDocumentDetailsFromIds) {
+      void getDocumentDetailsFromIds([objectKey]);
+    }
+    wasTerminalRef.current = isTerminalStatus;
+  }, [isTerminalStatus, objectKey, getDocumentDetailsFromIds]);
 
   // Fetch active configuration for dynamic confidence threshold (used by sections panel, etc.)
   const { mergedConfig } = useConfiguration();

--- a/src/ui/src/hooks/use-graphql-api.ts
+++ b/src/ui/src/hooks/use-graphql-api.ts
@@ -145,7 +145,11 @@ const useGraphQlApi = ({ initialPeriodsToLoad = DOCUMENT_LIST_SHARDS_PER_DAY * 2
 
   /**
    * Fetch full document details for specific documents by ObjectKey.
-   * Used only when navigating to document detail view, NOT for list loading.
+   * Used both when navigating to the document detail view and by the detail-view
+   * poll (which refreshes an open, still-processing document). The rich getDocument
+   * responses (including Sections/Pages/Metering) are merged into shared list state
+   * via setDocumentsDeduped so the fresh data flows back through the `item` prop and
+   * re-renders the detail view — not just returned to the caller.
    */
   const getDocumentDetailsFromIds = useCallback(
     async (objectKeys: string[]): Promise<Document[]> => {
@@ -160,9 +164,16 @@ const useGraphQlApi = ({ initialPeriodsToLoad = DOCUMENT_LIST_SHARDS_PER_DAY * 2
         .map((r) => (r as PromiseFulfilledResult<GetDocumentResolved>).value?.data?.getDocument)
         .filter((doc): doc is NonNullable<typeof doc> => doc != null) as Document[];
 
+      // Merge the rich detail into shared list state so the open detail view picks
+      // up the latest Sections/Pages/Metering (e.g. when a document finishes
+      // processing while its detail page is open).
+      if (documentValues.length > 0) {
+        setDocumentsDeduped(documentValues);
+      }
+
       return documentValues;
     },
-    [setErrorMessage],
+    [setDocumentsDeduped, setErrorMessage],
   );
 
   // ── Subscriptions ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When a document's detail page is open while the document is still processing, the UI polling correctly detects the status flip to **COMPLETED**, but the page content — sections, pages, estimated cost, and other metering — does **not** update to reflect the finished document. Content only appears correctly after a full reload / re-navigation.

## Root cause

Two compounding bugs:

1. **The detail poll fetched the rich data and threw it away.** `DocumentPanel.pollDetail` re-fetches the full `getDocument` payload every 4s via `getDocumentDetailsFromIds`, but that function only *returned* the data — it never merged it into shared state. The fresh `Sections`/`Pages`/`Metering` were fetched and discarded. (The list poll uses the lightweight `listDocuments` query, whose selection set has no `Sections`/`Pages`/`Metering`, and the merge logic intentionally preserves stale rich fields when it sees lightweight data.)

2. **The detail poll stops at the moment it matters.** The poll is disabled once status is terminal. Because the `listDocuments` poll is what flips the status to `COMPLETED`, the detail poll shut off before any rich fetch captured the completed content.

## Fix

1. `getDocumentDetailsFromIds` now calls `setDocumentsDeduped(documentValues)` so the rich detail (already the "rich data" path, since it includes `Sections`) merges into shared list state and flows back through the `item` prop, re-rendering the detail view.

2. `DocumentPanel` now performs **one final** `getDocument` fetch on the transition into a terminal status, so the completed sections/pages/estimated cost are pulled in even though the poll then goes quiet.

No backend/GraphQL changes — the `getDocument` query already selects `Sections`, `Pages`, and `Metering`.

## Files changed

- `src/ui/src/hooks/use-graphql-api.ts`
- `src/ui/src/components/document-panel/DocumentPanel.tsx`

## Testing

- `eslint` clean on both changed files
- `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)