### PR TITLE
docs: document model-max output + Claude reasoning-effort

### DIFF
--- a/docs/extraction-and-confidence.md
+++ b/docs/extraction-and-confidence.md
@@ -49,8 +49,23 @@ extraction:
     enabled: false            # Simple mode (default)
   model: anthropic.claude-3-haiku-20240307-v1:0
   temperature: 0.0
-  max_tokens: 4096
+  reasoning_effort: low       # reasoning-capable models only (see note below)
 ```
+
+> **Output tokens:** extraction and the confidence pass always request the
+> selected model's **maximum** output — there is no `max_tokens` config knob for
+> them. Bedrock's default-when-omitted truncates, so the client sets it
+> explicitly from `config_library/model_config_limits.yaml`; completeness matters
+> more than an output cap here. (`classification` / `summarization` keep their
+> `max_tokens` knob.)
+>
+> **Reasoning effort:** for reasoning-capable models — Claude Sonnet 5 / Sonnet
+> 4.6 / Opus 4.5–4.8 / Fable 5 (`low`|`medium`|`high`|`xhigh`|`max`) and OpenAI
+> GPT-5.x (`minimal`|`low`|`medium`|`high`) — `reasoning_effort` controls how much
+> the model reasons before answering. Extraction **defaults to `low`**: a full
+> effort sweep found higher effort adds output-token cost with negligible
+> extraction-accuracy gain. Raise it per-config for reasoning-heavy documents.
+> Ignored by Nova, Sonnet 4.5, and Haiku 4.5.
 
 ### Advanced (agentic) extraction
 
@@ -333,7 +348,7 @@ extraction:
   temperature: 0.0           # Keep low for consistency
   top_p: 0.1
   top_k: 5
-  max_tokens: 4096
+  reasoning_effort: low      # reasoning-capable models only; output is always model-max
 
   system_prompt: |
     You are an expert in extracting structured information from documents.
@@ -435,11 +450,11 @@ extraction:
   confidence:
     enabled: true             # false disables confidence entirely (zero LLM cost)
     mode: separate            # off | separate (default) | integrated
-    model: us.anthropic.claude-haiku-4-5-20251001-v1:0
+    model: us.amazon.nova-lite-v1:0   # default; far cheaper for the confidence pass
     temperature: 0.0
     top_k: 5
     top_p: 0.1
-    max_tokens: 4096
+    reasoning_effort: low     # only used if a reasoning-capable model is selected here
     list_batch_size: 25       # rows per assessment batch for large lists
     system_prompt: |
       You are an expert document analyst specializing in assessing the confidence

--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -75,14 +75,34 @@ the model IDs carry no region prefix.
 GPT-5.x are reasoning models — they reject `temperature` / `top_p` / `top_k` and
 are instead tuned with **reasoning effort**. Each model-selectable service (OCR,
 classification, extraction, assessment, summarization, evaluation, and
-Chat-with-Document) exposes a `reasoning_effort` config field. Allowed values:
-`minimal`, `low`, `medium`, `high` (default `medium`). It is an **OpenAI-only**
-parameter — ignored by Anthropic / Nova and other model families.
+Chat-with-Document) exposes a `reasoning_effort` config field.
+
+`reasoning_effort` applies to **any reasoning-capable model**, not just OpenAI:
+
+| Model family | Allowed values | Mechanism |
+|---|---|---|
+| OpenAI GPT-5.x | `minimal`, `low`, `medium`, `high` | Responses API `reasoning.effort` |
+| Claude Sonnet 5 / Sonnet 4.6 / Opus 4.5–4.8 / Fable 5 | `low`, `medium`, `high`, `xhigh`, `max` | Bedrock Converse `output_config.effort` |
+
+It is **ignored** by models without an effort control — Amazon Nova, Claude
+Sonnet 4.5, and Claude Haiku 4.5. In the config UI, the **Reasoning effort**
+selector appears only when the section's selected model supports it.
+
+**Extraction defaults to `low`.** A full effort sweep (5 extraction methods ×
+{low, medium, high, xhigh} × 2 datasets × 20 docs) found higher effort adds
+output-token cost with negligible extraction-accuracy gain, so `low` keeps the
+Claude Sonnet 5 default affordable. Raise it per-config for genuinely
+reasoning-heavy documents. Other services default to `medium`.
 
 ```yaml
 extraction:
   model: "openai.gpt-5.4"
-  reasoning_effort: "high"   # minimal | low | medium | high
+  reasoning_effort: "high"   # OpenAI: minimal | low | medium | high
+
+# or, for a reasoning-capable Claude model:
+extraction:
+  model: "us.anthropic.claude-sonnet-5"
+  reasoning_effort: "low"    # Claude: low | medium | high | xhigh | max
 ```
 
 ## Regional availability and routing

--- a/lib/idp_common_pkg/idp_common/assessment/README.md
+++ b/lib/idp_common_pkg/idp_common/assessment/README.md
@@ -106,8 +106,11 @@ extraction:
     temperature: 0
     top_k: 5
     top_p: 0.1
-    max_tokens: 4096
+    reasoning_effort: low               # only if a reasoning-capable model is selected
     list_batch_size: 25                 # rows per assessment batch for large lists
+    # NOTE: no max_tokens knob — the confidence pass always requests the model's
+    # maximum output (resolved from config_library/model_config_limits.yaml) so
+    # long list assessments are never truncated.
     system_prompt: "You are an expert document analyst..."
     task_prompt: |
       Assess the confidence of extraction results for this {DOCUMENT_CLASS} document.
@@ -780,7 +783,8 @@ def lambda_handler(event, context):
 
 ### Configuration
 - Set appropriate temperature (0 for deterministic assessment)
-- Configure max_tokens based on expected response length
+- Output tokens are not configurable — the confidence pass always requests the
+  model maximum (so long list assessments aren't truncated)
 - Use system prompts to establish assessment criteria
 
 ### Performance

--- a/lib/idp_common_pkg/idp_common/bedrock/README.md
+++ b/lib/idp_common_pkg/idp_common/bedrock/README.md
@@ -354,6 +354,17 @@ Different Bedrock models implement these parameters with varying defaults, namin
   - Default values: temperature=1.0, top_p=0.999, top_k=250 (wide open)
   - Parameters use snake_case: `temperature`, `top_p`, `top_k`
   - Implementation: `top_k` is placed in `additionalModelRequestFields`
+  - **Reasoning effort** (Sonnet 5, Sonnet 4.6, Opus 4.5–4.8, Fable 5 — see
+    `is_claude_effort_model()`): `reasoning_effort` (`low`/`medium`/`high`/
+    `xhigh`/`max`) maps to `additionalModelRequestFields.output_config.effort`.
+    Ignored for Sonnet 4.5 / Haiku 4.5 (they 400 on it). `budget_tokens` is
+    rejected — use effort. Verified live: effort changes output-token spend.
+  - **max_tokens**: extraction/confidence pass `max_tokens=None`, so the client
+    resolves the model maximum from `get_model_max_output_tokens()`
+    (`config_library/model_config_limits.yaml`, bundled in-package). Omitting
+    `maxTokens` would let Bedrock apply a small truncating default. If a request
+    still exceeds the model cap, the client parses the true limit from the
+    `ValidationException` and retries once.
 
 - **Nova models**:
   - Default values: temperature=0.7, topP=0.9, topK≈50 (moderately constrained)


### PR DESCRIPTION
Documentation follow-up for the two merged PRs (#434 model-max output / `max_tokens` knob removal; #436 configurable reasoning effort for Claude, default `low`).

## User docs
- **`docs/extraction-and-confidence.md`** — config examples no longer show the removed `extraction`/`confidence` `max_tokens`; added a note that these passes always request the model **maximum** output (Bedrock's omit-default truncates), and that `reasoning_effort` applies to reasoning-capable models with extraction defaulting to `low`.
- **`docs/openai-models.md`** — `reasoning_effort` is no longer "OpenAI-only": added a cross-model table (GPT-5.x `minimal|low|medium|high` via Responses API; Claude Sonnet 5 / Sonnet 4.6 / Opus 4.5–4.8 / Fable 5 `low|medium|high|xhigh|max` via Converse `output_config.effort`), the capability gate, and the `low` default rationale from the effort sweep.

## Developer docs
- **`bedrock/README.md`** — documents `output_config.effort` for effort-capable Claude (`budget_tokens` rejected), and the model-max resolution + over-limit `ValidationException` retry.
- **`assessment/README.md`** — drops the `max_tokens` knob from the confidence config example and the tuning note.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)