### PR TITLE
fix(evaluation): don't fail whole doc when a required field is correctly null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ are migrated automatically on read — no manual edit is required.** See the
 
 ### Fixed
 
+- **Evaluation no longer fails a whole document when a `required` field is correctly null.** If an explicit config marked a field `required` (e.g. RealKIE Invoice: `required: [Agency, Advertiser, LineItems]`) and a document genuinely had no value for it, the Stickler/Pydantic model raised `Field required [type=missing]` after null-stripping, producing an `__EVALUATION_FAILURE__` that zero-scored **every** attribute in the section (deflating reported accuracy and inflating failure counts). Evaluation now clears `required` arrays on all objects (matching the auto-generated-schema path), so a missing/null field is scored as a normal miss on that one attribute. Model-agnostic; affected any config with `required` fields.
+
 - **Config v0.6 import/upgrade no longer silently reverts customizations to defaults.** A v0.5-shaped config was deep-merged onto the v0.6 defaults *before* migration ran, so v0.6 default values could beat the user's migrated customizations (e.g. a pinned model or batch size reverted) — silent data loss on in-place stack update and on importing older config files. Both paths now migrate the incoming config to v0.6 *first*, then merge. Regression tests added.
 
 - **Model output-token limits corrected for Claude Sonnet 4.6 / Opus 4.6 (128K, not 64K).** A generic pattern in `model_config_limits.yaml` mis-capped these models at 64,000 output tokens, causing config validation to reject valid `max_tokens` up to their true 128,000 limit. Only Haiku 4.5 and Sonnet/Opus 4.0–4.5 cap at 64K.

--- a/lib/idp_common_pkg/idp_common/evaluation/stickler_mapper.py
+++ b/lib/idp_common_pkg/idp_common/evaluation/stickler_mapper.py
@@ -711,11 +711,17 @@ class SticklerConfigMapper:
         # Coerce types FIRST, before any other processing
         cls._coerce_json_schema_types(schema, field_path)
 
-        # If this is an object with properties but no required array, add empty one
-        # This makes all fields optional, allowing None values
+        # Force all fields optional for evaluation by clearing any 'required' array.
+        # For evaluation a field that is present in the baseline but correctly
+        # extracted as null (or vice versa) is a scored MISS, not a hard schema
+        # failure. If an explicit config marks a field required (e.g. RealKIE
+        # Invoice: required: [Agency, Advertiser, LineItems]) and a document
+        # genuinely has no value for it, Stickler/Pydantic would otherwise raise
+        # "Field required [type=missing]" after None-stripping and fail-score the
+        # WHOLE document. Overwriting (not just adding-when-missing) makes explicit
+        # configs behave like the genson auto-schema path (_strip_required).
         if schema.get(SCHEMA_TYPE) == TYPE_OBJECT and SCHEMA_PROPERTIES in schema:
-            if "required" not in schema:
-                schema["required"] = []
+            schema["required"] = []
 
         # Check if this is an array with structured items
         is_structured_array = False

--- a/lib/idp_common_pkg/tests/unit/evaluation/test_stickler_mapper.py
+++ b/lib/idp_common_pkg/tests/unit/evaluation/test_stickler_mapper.py
@@ -395,3 +395,53 @@ class TestUSPatentTableSchema:
         assert "DataType" in tables_items["properties"]
         # TableData should have been removed because its items are free-form objects
         assert "TableData" not in tables_items["properties"]
+
+
+class TestRequiredFieldsClearedForEvaluation:
+    """Explicit-config `required` arrays must be cleared so a correctly-null field
+    is scored as a miss, not a whole-document schema failure.
+
+    Regression: RealKIE Invoice marks `required: [Agency, Advertiser, LineItems]`.
+    A document where Agency is genuinely absent (extracted null) previously crashed
+    the entire doc with 'Field required [type=missing]' -> __EVALUATION_FAILURE__ and
+    a 0 score. All fields must be optional during evaluation.
+    """
+
+    def test_top_level_required_cleared(self):
+        schema = {
+            "$id": "Invoice",
+            "x-aws-idp-document-type": "Invoice",
+            "type": "object",
+            "required": ["Agency", "Advertiser", "LineItems"],
+            "properties": {
+                "Agency": {
+                    "type": "string",
+                    "x-aws-idp-evaluation-method": "LEVENSHTEIN",
+                },
+                "Advertiser": {
+                    "type": "string",
+                    "x-aws-idp-evaluation-method": "FUZZY",
+                },
+                "LineItems": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["LineItemRate"],
+                        "properties": {
+                            "LineItemRate": {
+                                "type": "number",
+                                "x-aws-idp-evaluation-method": "NUMERIC_EXACT",
+                            }
+                        },
+                    },
+                },
+            },
+        }
+        config = SticklerConfigMapper.build_stickler_model_config(schema)
+        result = config["schema"]
+
+        # Top-level required must be emptied (not left as the original 3 fields).
+        assert result.get("required") == []
+        # Nested object inside the list items must also be emptied.
+        nested = result["properties"]["LineItems"]["items"]
+        assert nested.get("required") == []


### PR DESCRIPTION
## Problem

When an **explicit** config marks a field `required` (e.g. RealKIE Invoice: `required: [Agency, Advertiser, LineItems]`) and a document genuinely has **no value** for it, evaluation produced an `__EVALUATION_FAILURE__` that **zero-scored every attribute** in the section — deflating reported accuracy and inflating failure counts.

Observed on 2/20 RealKIE docs (`26372a56…`, `52f1588f…`): extraction correctly returned `Agency: null`, the baseline had a value, but instead of scoring that one field as a miss, eval crashed the whole doc with:
```
Schema configuration error for document class 'Invoice': Field required [type=missing] — Agency
```

## Root cause

The eval flow strips `None` values from the prediction, then constructs a Stickler/Pydantic model. `_make_model_fields_nullable` widens field **types** to `Optional[...]` (Stickler bug #149 workaround) but doesn't clear **required** status — so a stripped null on a required field raises `Field required [type=missing]`.

`_strip_required()` already prevents this for **genson auto-generated** schemas, but the **explicit-config** path (`_translate_extensions_in_schema` in `stickler_mapper.py`) only *added* an empty `required: []` when one was **missing** — it left an existing `required` array intact.

## Fix

`_translate_extensions_in_schema` now **always clears `required` to `[]`** on every object (top-level and nested), making all fields optional for evaluation. A missing/null field is scored as a normal miss on that one attribute, matching the auto-generated-schema path. Model-agnostic — affects any config with `required` fields; unrelated to extraction quality.

## Testing
- New regression test `TestRequiredFieldsClearedForEvaluation` (top-level + nested required cleared).
- Full `tests/unit/evaluation` suite: 64 passed, 0 failures. ruff + typecheck-pr clean.
- Live re-verification of the 2 affected RealKIE docs after deploy (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)