### PR TITLE
fix(ui): repair Discovery page blank render + stuck job status after AppSync removal

### DIFF
--- a/src/ui/src/api/rest-client.ts
+++ b/src/ui/src/api/rest-client.ts
@@ -118,12 +118,8 @@ const inertSubscription = (field: string) => ({
   },
 });
 
-const doGraphql = async ({ query, variables }: GraphqlRequest): Promise<GraphqlResult> => {
-  const { kind, field, argMap } = parseOperation(query);
-
-  if (kind === 'subscription') {
-    return inertSubscription(field) as unknown as GraphqlResult;
-  }
+const doGraphqlRequest = async ({ query, variables }: GraphqlRequest): Promise<GraphqlResult> => {
+  const { field, argMap } = parseOperation(query);
 
   if (!apiBaseUrl) {
     throw new Error('restClient: VITE_API_BASE_URL is not configured');
@@ -169,6 +165,20 @@ const doGraphql = async ({ query, variables }: GraphqlRequest): Promise<GraphqlR
 
   // Success: wrap under the field name to match Amplify's res.data.<field>.
   return { data: { [field]: body } };
+};
+
+// Synchronous dispatcher. Amplify's client.graphql() returns an Observable
+// (with .subscribe()) *synchronously* for subscription ops and a Promise for
+// queries/mutations. Subscription call sites do `client.graphql(...).subscribe(...)`
+// with no await, so we MUST return the inert subscription synchronously here —
+// returning a Promise (e.g. from an async function) would make `.subscribe`
+// undefined and throw "subscribe is not a function", crashing the page render.
+const doGraphql = (req: GraphqlRequest): Promise<GraphqlResult> | ReturnType<typeof inertSubscription> => {
+  const { kind, field } = parseOperation(req.query);
+  if (kind === 'subscription') {
+    return inertSubscription(field);
+  }
+  return doGraphqlRequest(req);
 };
 
 // Brand types emitted by the codegen for each operation. We extract the result

--- a/src/ui/src/components/discovery/DiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/DiscoveryPanel.tsx
@@ -32,7 +32,7 @@ import {
 import type { SelectProps } from '@cloudscape-design/components';
 import { generateClient } from '../../api/client-shim';
 
-import { uploadDiscoveryDocument, listDiscoveryJobs, onDiscoveryJobStatusChange, deleteDiscoveryJob, autoDetectSections } from '../../graphql/generated';
+import { uploadDiscoveryDocument, listDiscoveryJobs, deleteDiscoveryJob, autoDetectSections } from '../../graphql/generated';
 import useSettingsContext from '../../contexts/settings';
 import useConfigurationVersions from '../../hooks/use-configuration-versions';
 import { getJsonValidationError } from '../common/utilities';
@@ -174,8 +174,10 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
     }, 50);
   }, []);
 
-  const loadDiscoveryJobs = async () => {
-    setIsLoadingJobs(true);
+  // `silent` skips the loading spinner so the 5s status poll doesn't flicker
+  // the table / refresh button on every tick.
+  const loadDiscoveryJobs = async (silent = false) => {
+    if (!silent) setIsLoadingJobs(true);
     try {
       const response = await client.graphql({ query: listDiscoveryJobs });
       type ListJobsResp = Record<string, Record<string, Record<string, DiscoveryJob[]>>>;
@@ -185,9 +187,9 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
       setDiscoveryJobs(singleDocJobs);
     } catch (err) {
       console.error('Error loading discovery jobs:', err);
-      setError(`Failed to load discovery jobs: ${(err as Error).message}`);
+      if (!silent) setError(`Failed to load discovery jobs: ${(err as Error).message}`);
     } finally {
-      setIsLoadingJobs(false);
+      if (!silent) setIsLoadingJobs(false);
     }
   };
 
@@ -233,12 +235,16 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
     loadDiscoveryJobs();
   }, []);
 
-  // Timer for elapsed time display on active jobs (subscriptions handle status updates)
+  // Poll for status updates + refresh the elapsed-time display while any job is
+  // active. Real-time GraphQL subscriptions were removed with AppSync (the REST
+  // transport has no push channel), so polling is the only way active jobs
+  // advance past PENDING here.
   useEffect(() => {
     const hasActiveJobs = discoveryJobs.some((j) => j.status === 'PENDING' || j.status === 'IN_PROGRESS' || j.status === 'OPTIMIZATION_IN_PROGRESS');
     if (hasActiveJobs && !tickRef.current) {
       tickRef.current = setInterval(() => {
         setTick((t) => t + 1);
+        loadDiscoveryJobs(true);
       }, 5000);
     } else if (!hasActiveJobs && tickRef.current) {
       clearInterval(tickRef.current);
@@ -252,91 +258,6 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
     };
   }, [discoveryJobs]);
 
-  // Update a specific job in the list — FIX: spread ALL fields from the update, not just status
-  const updateDiscoveryJob = useCallback((updatedJob: DiscoveryJob) => {
-    console.log('Updating discovery job status:', updatedJob);
-    setDiscoveryJobs((currentJobs) => {
-      const jobIndex = currentJobs.findIndex((job) => job.jobId === updatedJob.jobId);
-      if (jobIndex >= 0) {
-        const newJobs = [...currentJobs];
-        const oldJob = newJobs[jobIndex];
-        // Merge ALL updated fields from subscription (not just status)
-        // Set updatedAt to now when terminal status arrives via subscription
-        // (subscription doesn't include updatedAt, so we capture it client-side)
-        const merged = { ...oldJob, ...updatedJob };
-        if (updatedJob.status === 'COMPLETED' || updatedJob.status === 'FAILED' || updatedJob.status === 'OPTIMIZATION_COMPLETED' || updatedJob.status === 'OPTIMIZATION_FAILED') {
-          merged.updatedAt = new Date().toISOString();
-        }
-        newJobs[jobIndex] = merged;
-        console.log(`Updated job ${updatedJob.jobId}: ${oldJob.status} -> ${updatedJob.status}`);
-
-        return newJobs;
-      }
-      console.warn(`Job ${updatedJob.jobId} not found in current jobs list, adding it`);
-      return [...currentJobs, updatedJob];
-    });
-  }, []);
-
-  // Set up subscriptions for active discovery jobs
-  // Use a ref to track active subscriptions and avoid teardown/recreation on status changes
-  const subscriptionsRef = useRef(new Map<string, { unsubscribe: () => void }>());
-
-  useEffect(() => {
-    const terminalStatuses = new Set(['COMPLETED', 'FAILED', 'OPTIMIZATION_COMPLETED', 'OPTIMIZATION_FAILED']);
-    const activeJobIds = new Set<string>();
-
-    discoveryJobs.forEach((job) => {
-      if (!terminalStatuses.has(job.status)) {
-        activeJobIds.add(job.jobId);
-
-        // Only create a subscription if we don't already have one for this jobId
-        if (!subscriptionsRef.current.has(job.jobId)) {
-          type GqlSubscription = {
-            subscribe: (callbacks: Record<string, unknown>) => { unsubscribe: () => void };
-          };
-          const observable = client.graphql({
-            query: onDiscoveryJobStatusChange,
-            variables: { jobId: job.jobId },
-          }) as unknown as GqlSubscription;
-          const subscription = observable.subscribe({
-              next: (data: { data?: { onDiscoveryJobStatusChange?: DiscoveryJob } }) => {
-                console.log('Discovery job status changed:', data);
-                const changedJob = data?.data?.onDiscoveryJobStatusChange;
-                if (changedJob) {
-                  updateDiscoveryJob(changedJob);
-                  return;
-                }
-                console.warn('Received subscription update but no job data, falling back to refresh');
-                loadDiscoveryJobs();
-              },
-              error: (subscriptionError: unknown) => {
-                console.error('Discovery job subscription error:', subscriptionError);
-              },
-            });
-
-          subscriptionsRef.current.set(job.jobId, subscription);
-        }
-      }
-    });
-
-    // Clean up subscriptions for jobs that reached terminal state
-    subscriptionsRef.current.forEach((subscription, jobId) => {
-      if (!activeJobIds.has(jobId)) {
-        subscription.unsubscribe();
-        subscriptionsRef.current.delete(jobId);
-      }
-    });
-  }, [JSON.stringify(discoveryJobs.map((job) => ({ jobId: job.jobId, status: job.status }))), updateDiscoveryJob]);
-
-  // Clean up all subscriptions on unmount
-  useEffect(() => {
-    return () => {
-      subscriptionsRef.current.forEach((subscription) => {
-        subscription.unsubscribe();
-      });
-      subscriptionsRef.current.clear();
-    };
-  }, []);
 
   if (!settings.DiscoveryBucket) {
     return (
@@ -1106,7 +1027,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
                 <Button
                   iconName="refresh"
                   variant="icon"
-                  onClick={loadDiscoveryJobs}
+                  onClick={() => loadDiscoveryJobs()}
                   loading={isLoadingJobs}
                   ariaLabel="Refresh discovery jobs"
                 />

--- a/src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx
@@ -15,7 +15,7 @@
  * discovers document types, generates JSON Schemas, and saves to config.
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Button,
   Container,
@@ -43,13 +43,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { generateClient } from '../../api/client-shim';
 
-import {
-  startMultiDocDiscovery,
-  uploadMultiDocDiscoveryZip,
-  listDiscoveryJobs,
-  onDiscoveryJobStatusChange,
-  deleteDiscoveryJob,
-} from '../../graphql/generated';
+import { startMultiDocDiscovery, uploadMultiDocDiscoveryZip, listDiscoveryJobs, deleteDiscoveryJob } from '../../graphql/generated';
 import { useNavigate } from 'react-router-dom';
 import { DISCOVERY_JOB_PATH } from '../../routes/constants';
 import useSettingsContext from '../../contexts/settings';
@@ -189,57 +183,13 @@ const MultiDocDiscoveryPanel = () => {
     visibleContent: ['source', 'status', 'currentStep', 'totalDocuments', 'clustersFound', 'version', 'createdAt', 'duration', 'result'],
   });
 
-  // Subscriptions
-  const subscriptionsRef = useRef<Map<string, { unsubscribe: () => void }>>(new Map());
   // Timer for elapsed time
   const [, setTick] = useState(0);
 
-  // Load jobs on mount
-  useEffect(() => {
-    loadJobs();
-    // Tick timer for live elapsed time
-    const timer = setInterval(() => setTick((t) => t + 1), 5000);
-    return () => {
-      clearInterval(timer);
-      // Clean up subscriptions
-      subscriptionsRef.current.forEach((sub) => sub.unsubscribe());
-    };
-  }, []);
-
-  // Set up subscriptions for active jobs
-  useEffect(() => {
-    const activeJobs = jobs.filter((j) => !['COMPLETED', 'FAILED'].includes(j.status));
-    activeJobs.forEach((job) => {
-      if (!subscriptionsRef.current.has(job.jobId)) {
-        try {
-          const observable = client.graphql({
-            query: onDiscoveryJobStatusChange,
-            variables: { jobId: job.jobId },
-          });
-          const sub = (observable as any).subscribe({
-            next: ({ data }: any) => {
-              const update = data?.onDiscoveryJobStatusChange;
-              if (update) {
-                setJobs((prev) => prev.map((j) => (j.jobId === update.jobId ? { ...j, ...update } : j)));
-                // Clean up subscription if terminal
-                if (['COMPLETED', 'FAILED'].includes(update.status)) {
-                  subscriptionsRef.current.get(update.jobId)?.unsubscribe();
-                  subscriptionsRef.current.delete(update.jobId);
-                }
-              }
-            },
-            error: (err: any) => console.error('Subscription error:', err),
-          });
-          subscriptionsRef.current.set(job.jobId, sub);
-        } catch (err) {
-          console.error('Failed to subscribe:', err);
-        }
-      }
-    });
-  }, [jobs]);
-
-  const loadJobs = useCallback(async () => {
-    setLoading(true);
+  // `silent` skips the loading spinner so the status poll doesn't flicker the
+  // table on every tick.
+  const loadJobs = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
     try {
       const response = await client.graphql({ query: listDiscoveryJobs });
       const allJobs = (response as any)?.data?.listDiscoveryJobs?.DiscoveryJobs || [];
@@ -248,11 +198,30 @@ const MultiDocDiscoveryPanel = () => {
       setJobs(multiDocJobs);
     } catch (err: any) {
       console.error('Failed to load jobs:', err);
-      setError('Failed to load discovery jobs');
+      if (!silent) setError('Failed to load discovery jobs');
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }, []);
+
+  // Load jobs on mount
+  useEffect(() => {
+    loadJobs();
+  }, [loadJobs]);
+
+  // Poll for status updates + refresh the elapsed-time display while any job is
+  // active. Real-time GraphQL subscriptions were removed with AppSync (the REST
+  // transport has no push channel), so polling is the only way active jobs
+  // advance past PENDING here.
+  useEffect(() => {
+    const hasActiveJobs = jobs.some((j) => !['COMPLETED', 'FAILED'].includes(j.status));
+    if (!hasActiveJobs) return;
+    const timer = setInterval(() => {
+      setTick((t) => t + 1);
+      loadJobs(true);
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [jobs, loadJobs]);
 
   const handleStartDiscovery = async () => {
     if (!selectedVersion) {
@@ -915,7 +884,7 @@ const MultiDocDiscoveryPanel = () => {
                   options={TIME_RANGE_OPTIONS}
                   triggerVariant="option"
                 />
-                <Button iconName="refresh" variant="icon" onClick={loadJobs} loading={loading} ariaLabel="Refresh discovery jobs" />
+                <Button iconName="refresh" variant="icon" onClick={() => loadJobs()} loading={loading} ariaLabel="Refresh discovery jobs" />
                 <Button
                   iconName="remove"
                   variant="icon"


### PR DESCRIPTION
## Problem

Running a Discovery job redirected to `#/documents/discovery` and the page rendered **blank**, with this console error:

```
TypeError: Bd.graphql(...).subscribe is not a function
```

### Root cause

The AppSync→REST migration (#402) left `client.graphql()` in `rest-client.ts` as an `async` function, so it returned a **Promise for every operation — including subscriptions**. All subscription call sites invoke `.subscribe()` **synchronously** on the return value (mirroring Amplify's Observable, e.g. `client.graphql({...}).subscribe(...)`). A Promise has no `.subscribe`, so the `TypeError` was thrown inside a `useEffect` and crashed the whole page render.

The file's own "inert subscription that fails safe rather than throwing" design only works if the stub is returned **synchronously** — the `async` signature defeated it.

### Secondary bug (stuck "Pending")

Once subscriptions are correctly inert (the REST transport has no push channel), the Discovery panels had no way to advance job status: their 5-second `setInterval` only bumped a re-render tick for the elapsed-time clock and **never re-fetched**, so active jobs stayed on `PENDING` until a manual refresh.

## Fix

- **`rest-client.ts`** — split into an async `doGraphqlRequest` (queries/mutations) and a **synchronous** `doGraphql` dispatcher that returns the inert subscription stub immediately for subscription ops, restoring Amplify's sync-Observable contract. This also fixes the same latent crash in ChatPanel, use-agent-chat, and DocumentsAgentsLayout.
- **`DiscoveryPanel.tsx` / `MultiDocDiscoveryPanel.tsx`** — the active-job interval now calls `loadDiscoveryJobs(true)` / `loadJobs(true)` to poll status; added a `silent` param so the poll doesn't flicker the table spinner. Removed the now-dead subscription-setup effects and their unused imports/refs.

`DiscoveryJobDetails` already polls (`setInterval(loadJob, 10000)`); the chat and doc-agents subscription paths are guarded by `useHttpApiTransport` / have their own fallback poll, so no change was needed there.

## Testing

- Verified live against a deployed stack via the local dev server (`make ui-start`) + browser MCP: Discovery page renders fully, console is clean (no `TypeError`), and a fresh Discovery job advances `PENDING → Completed` on its own via the poll.
- `npx eslint` (changed files) — clean
- `npx tsc --noEmit` (full UI) — clean
- `vitest run src/components/discovery` — 4/4 pass

## Notes

- Targets `develop` per repo convention.
- No CHANGELOG entry — this is an intra-release fix.