### PR TITLE
fix(ui): restore header banner on Test Studio tabs (#381)

### DIFF
--- a/src/ui/src/components/test-studio/TestStudioLayout.tsx
+++ b/src/ui/src/components/test-studio/TestStudioLayout.tsx
@@ -89,6 +89,7 @@ const TestStudioLayout = (): React.JSX.Element => {
 
   return (
     <AppLayout
+      headerSelector="#top-navigation"
       ariaLabels={appLayoutLabels}
       navigation={<Navigation />}
       navigationOpen={navigationOpen}

--- a/src/ui/src/routes/TestStudioRoutes.tsx
+++ b/src/ui/src/routes/TestStudioRoutes.tsx
@@ -4,11 +4,20 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
 import TestStudioLayout from '../components/test-studio/TestStudioLayout';
+import GenAIIDPTopNavigation from '../components/genai-idp-top-navigation';
 
 const TestStudioRoutes = (): React.JSX.Element => {
   return (
     <Routes>
-      <Route path="*" element={<TestStudioLayout />} />
+      <Route
+        path="*"
+        element={
+          <div>
+            <GenAIIDPTopNavigation />
+            <TestStudioLayout />
+          </div>
+        }
+      />
     </Routes>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #381 — the "IDP Accelerator Console" top-navigation banner (and its logout button) disappeared on the **Test Sets** and **Test Executions** tabs.

## Root cause

The header banner is rendered per-route rather than globally. Every other route wraps its layout with `<GenAIIDPTopNavigation />` (e.g. `DocumentsRoutes`, `DocumentsQueryRoutes`, `DocumentsAnalyticsRoutes`, `FeaturesRoutes`, and `AgentChatPageLayout`). `TestStudioRoutes` rendered only `<TestStudioLayout />` with no banner, so both Test Studio tabs (served by `TestStudioLayout`) lost the banner and logout button.

A related detail: the banner renders into a sticky `<div id="top-navigation">`, and every working `AppLayout` sets `headerSelector="#top-navigation"` so Cloudscape offsets content below it. `TestStudioLayout` was missing this prop.

## Changes

- **`TestStudioRoutes.tsx`** — wrap `TestStudioLayout` with `<GenAIIDPTopNavigation />`, mirroring the `DocumentsRoutes` pattern.
- **`TestStudioLayout.tsx`** — add `headerSelector="#top-navigation"` to `AppLayout` so content offsets below the sticky banner (matching `GenAIIDPLayout`).

## Testing

- `eslint` passes on both changed files.
- Verify manually: banner + logout button now persist across all Test Studio tabs (sets, executions, results, comparison) with no content overlap.

UI-only change confined to two files, matching the established route/layout pattern.