### PR TITLE
fix(test-sets): support non-PDF documents in ZIP upload baseline matching

### DIFF
--- a/lib/idp_common_pkg/tests/unit/test_zip_extractor.py
+++ b/lib/idp_common_pkg/tests/unit/test_zip_extractor.py
@@ -1,21 +1,70 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
+import importlib.util
+import sys
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
+# Import the actual Lambda handler module so the tests exercise the real
+# baseline-matching logic instead of a duplicated copy.
+_LAMBDA_INDEX = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "lambda"
+    / "test_set_zip_extractor"
+    / "index.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "test_set_zip_extractor_index", _LAMBDA_INDEX
+)
+zip_extractor = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = zip_extractor
+_spec.loader.exec_module(zip_extractor)
+
+
+def _collect_names(mock_files):
+    """Replicate the extractor's two-pass partition + baseline resolution.
+
+    Uses the real ``_match_baseline_name`` helper from the Lambda so a
+    regression in the matching logic is caught here.
+    """
+    input_names = set()
+    baseline_names = set()
+    baseline_files = []
+
+    # First pass: collect input names, stash baseline files.
+    for file_info in mock_files:
+        if file_info.is_dir():
+            continue
+        file_path = file_info.filename
+        if "/input/" in file_path:
+            input_names.add(file_path.split("/")[-1])
+        elif "/baseline/" in file_path:
+            baseline_files.append(file_info)
+
+    # Second pass: resolve baseline directory names against known inputs.
+    for file_info in baseline_files:
+        parts = file_info.filename.split("/baseline/", 1)
+        if len(parts) == 2 and "/" in parts[1]:
+            path_parts = parts[1].split("/")
+            if len(path_parts) >= 2:
+                name = zip_extractor._match_baseline_name(path_parts, input_names)
+                if name:
+                    baseline_names.add(name)
+
+    return input_names, baseline_names
+
 
 @pytest.mark.unit
 def test_file_validation_logic():
-    """Test the file validation logic for input and baseline matching"""
+    """Test the file validation logic for input and baseline matching (PDF)"""
 
-    # Mock zip file structure
     mock_files = [
-        # Input files
         Mock(filename="my-test-set/input/document1.pdf", is_dir=lambda: False),
         Mock(filename="my-test-set/input/document2.pdf", is_dir=lambda: False),
-        # Baseline files
         Mock(
             filename="my-test-set/baseline/document1.pdf/sections/result.json",
             is_dir=lambda: False,
@@ -33,48 +82,12 @@ def test_file_validation_logic():
         Mock(filename="my-test-set/baseline/", is_dir=lambda: True),
     ]
 
-    # Simulate the validation logic
-    input_files = []
-    baseline_files = []
-    input_names = set()
-    baseline_names = set()
+    input_names, baseline_names = _collect_names(mock_files)
 
-    for file_info in mock_files:
-        if not file_info.is_dir():
-            file_path = file_info.filename
-
-            if "/input/" in file_path:
-                input_files.append(file_info)
-                # Extract filename for matching
-                filename = file_path.split("/")[-1]
-                input_names.add(filename)
-            elif "/baseline/" in file_path:
-                baseline_files.append(file_info)
-                # Extract folder name after /baseline/ for matching
-                parts = file_path.split("/baseline/", 1)
-                if len(parts) == 2 and "/" in parts[1]:
-                    # Handle nested structure: baseline/category/filename.pdf/sections/...
-                    path_parts = parts[1].split("/")
-                    if len(path_parts) >= 2:
-                        # Look for the .pdf file
-                        for part in path_parts:
-                            if part.endswith(".pdf"):
-                                baseline_names.add(part)
-                                break
-
-    # Assertions
-    assert len(input_files) == 2
-    assert len(baseline_files) == 3
     assert input_names == {"document1.pdf", "document2.pdf"}
     assert baseline_names == {"document1.pdf", "document2.pdf"}
-
-    # Validation checks
-    assert len(input_files) == len(input_names)  # Each input file should be unique
-    missing_baselines = input_names - baseline_names
-    assert not missing_baselines, f"Missing baseline files for: {missing_baselines}"
-
-    extra_baselines = baseline_names - input_names
-    assert not extra_baselines, f"Extra baseline files: {extra_baselines}"
+    assert not (input_names - baseline_names)
+    assert not (baseline_names - input_names)
 
 
 @pytest.mark.unit
@@ -82,7 +95,6 @@ def test_complex_file_structure():
     """Test with complex nested structure like the real S3 bucket"""
 
     mock_files = [
-        # Input files with nested structure
         Mock(
             filename="fcc_benchmark/input/fcc_benchmark/033f718b16cb597c065930410752c294.pdf",
             is_dir=lambda: False,
@@ -91,7 +103,6 @@ def test_complex_file_structure():
             filename="fcc_benchmark/input/fcc_benchmark/03f65053aea282ad8d5e759a9f18bdbb.pdf",
             is_dir=lambda: False,
         ),
-        # Baseline files with nested structure
         Mock(
             filename="fcc_benchmark/baseline/fcc_benchmark/033f718b16cb597c065930410752c294.pdf/sections/1/result.json",
             is_dir=lambda: False,
@@ -102,31 +113,88 @@ def test_complex_file_structure():
         ),
     ]
 
-    input_names = set()
-    baseline_names = set()
+    input_names, baseline_names = _collect_names(mock_files)
 
-    for file_info in mock_files:
-        if not file_info.is_dir():
-            file_path = file_info.filename
-
-            if "/input/" in file_path:
-                filename = file_path.split("/")[-1]
-                input_names.add(filename)
-            elif "/baseline/" in file_path:
-                parts = file_path.split("/baseline/", 1)
-                if len(parts) == 2 and "/" in parts[1]:
-                    path_parts = parts[1].split("/")
-                    if len(path_parts) >= 2:
-                        for part in path_parts:
-                            if part.endswith(".pdf"):
-                                baseline_names.add(part)
-                                break
-
-    # Should match the complex filenames
     expected_names = {
         "033f718b16cb597c065930410752c294.pdf",
         "03f65053aea282ad8d5e759a9f18bdbb.pdf",
     }
     assert input_names == expected_names
     assert baseline_names == expected_names
-    assert input_names == baseline_names
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "ext",
+    ["png", "jpg", "jpeg", "tiff", "tif"],
+)
+def test_non_pdf_documents_flat(ext):
+    """Regression for issue #380: non-PDF documents must match baselines."""
+
+    mock_files = [
+        Mock(filename=f"imgset/input/document1.{ext}", is_dir=lambda: False),
+        Mock(filename=f"imgset/input/document2.{ext}", is_dir=lambda: False),
+        Mock(
+            filename=f"imgset/baseline/document1.{ext}/sections/1/result.json",
+            is_dir=lambda: False,
+        ),
+        Mock(
+            filename=f"imgset/baseline/document2.{ext}/sections/1/result.json",
+            is_dir=lambda: False,
+        ),
+    ]
+
+    input_names, baseline_names = _collect_names(mock_files)
+
+    assert input_names == {f"document1.{ext}", f"document2.{ext}"}
+    assert baseline_names == input_names
+    assert not (input_names - baseline_names)
+
+
+@pytest.mark.unit
+def test_non_pdf_documents_nested_with_dotted_category():
+    """Non-PDF docs in a nested layout under a dotted category folder.
+
+    A category folder containing a dot must not be mistaken for the document
+    directory; matching against known input names avoids that false positive.
+    """
+
+    mock_files = [
+        Mock(
+            filename="ds/input/my.category/scan1.png",
+            is_dir=lambda: False,
+        ),
+        Mock(
+            filename="ds/baseline/my.category/scan1.png/sections/1/result.json",
+            is_dir=lambda: False,
+        ),
+    ]
+
+    input_names, baseline_names = _collect_names(mock_files)
+
+    assert input_names == {"scan1.png"}
+    assert baseline_names == {"scan1.png"}
+
+
+@pytest.mark.unit
+def test_orphaned_non_pdf_baseline_reported_as_extra():
+    """A baseline with no matching input is still surfaced (fallback path)."""
+
+    mock_files = [
+        Mock(filename="ds/input/document1.png", is_dir=lambda: False),
+        Mock(
+            filename="ds/baseline/document1.png/sections/1/result.json",
+            is_dir=lambda: False,
+        ),
+        Mock(
+            filename="ds/baseline/orphan.tiff/sections/1/result.json",
+            is_dir=lambda: False,
+        ),
+    ]
+
+    input_names, baseline_names = _collect_names(mock_files)
+
+    assert input_names == {"document1.png"}
+    # orphan.tiff has no matching input but is caught by the extension fallback
+    assert baseline_names == {"document1.png", "orphan.tiff"}
+    assert (baseline_names - input_names) == {"orphan.tiff"}

--- a/src/lambda/test_set_zip_extractor/index.py
+++ b/src/lambda/test_set_zip_extractor/index.py
@@ -14,6 +14,34 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 s3 = boto3.client('s3')
 dynamodb = boto3.resource('dynamodb')
 
+# Document formats supported as test set inputs. Used as a fallback when a
+# baseline directory name does not match any known input filename, so that
+# genuinely orphaned baselines still surface as "extra baselines" rather than
+# being silently dropped.
+SUPPORTED_EXTENSIONS = ('.pdf', '.png', '.jpg', '.jpeg', '.tiff', '.tif')
+
+
+def _match_baseline_name(path_parts, input_names):
+    """Find the baseline directory name for a baseline file's path segments.
+
+    The baseline directory is named after the input filename (e.g.
+    ``baseline/category/document1.png/sections/1/result.json``). Match it
+    extension-agnostically against the set of known input filenames; fall back
+    to a supported-extension check only when no segment matches an input name.
+    """
+    # Prefer an exact match against a known input filename (extension-agnostic).
+    for part in path_parts:
+        if part in input_names:
+            return part
+
+    # Fallback: a segment that looks like a supported document filename. This
+    # lets orphaned baselines still be reported as extras instead of vanishing.
+    for part in path_parts:
+        if part.lower().endswith(SUPPORTED_EXTENSIONS):
+            return part
+
+    return None
+
 def handler(event, context):
     """Process S3 events for uploaded ZIP files"""
     logger.info(f"Zip extractor invoked with {len(event['Records'])} S3 events")
@@ -70,10 +98,13 @@ def _extract_uploaded_zip(bucket, test_set_id, zip_key):
             input_names = set()
             baseline_names = set()
             
+            # First pass: partition input vs baseline files and collect input
+            # filenames. ZIP entry order is not guaranteed, so baseline names
+            # are resolved in a second pass once all input names are known.
             for file_info in zip_ref.infolist():
                 if not file_info.is_dir():
                     file_path = file_info.filename
-                    
+
                     # Check if file is in input/ or baseline/ folder
                     if '/input/' in file_path:
                         input_files.append(file_info)
@@ -82,20 +113,23 @@ def _extract_uploaded_zip(bucket, test_set_id, zip_key):
                         input_names.add(filename)
                     elif '/baseline/' in file_path:
                         baseline_files.append(file_info)
-                        # Extract folder name after /baseline/ for matching
-                        parts = file_path.split('/baseline/', 1)
-                        if len(parts) == 2 and '/' in parts[1]:
-                            # Handle nested structure: baseline/category/filename.pdf/sections/...
-                            path_parts = parts[1].split('/')
-                            if len(path_parts) >= 2:
-                                # Look for the .pdf file (second level folder)
-                                for part in path_parts:
-                                    if part.endswith('.pdf'):
-                                        baseline_names.add(part)
-                                        break
                     else:
                         logger.warning(f"Skipping file not in input/ or baseline/ folder: {file_path}")
-            
+
+            # Second pass: resolve baseline directory names. The baseline dir is
+            # named after the input filename and may use any supported document
+            # extension (.pdf, .png, .jpg, .jpeg, .tiff, .tif), not just .pdf.
+            for file_info in baseline_files:
+                # Extract folder name after /baseline/ for matching
+                parts = file_info.filename.split('/baseline/', 1)
+                if len(parts) == 2 and '/' in parts[1]:
+                    # Handle nested structure: baseline/category/filename.png/sections/...
+                    path_parts = parts[1].split('/')
+                    if len(path_parts) >= 2:
+                        baseline_name = _match_baseline_name(path_parts, input_names)
+                        if baseline_name:
+                            baseline_names.add(baseline_name)
+
             if not input_files:
                 raise ValueError(f"No files found in input/ folder within zip file")
             


### PR DESCRIPTION
## Summary

Fixes #380 — Test set **ZIP upload** fails for non-PDF documents (PNG, JPG, TIFF) with `Missing baseline files for: ...` even when the baseline structure is correct.

### Root cause
`src/lambda/test_set_zip_extractor/index.py` hardcoded a `.pdf` check when matching baseline directories to input filenames:

```python
if part.endswith('.pdf'):
    baseline_names.add(part)
    break
```

For a PNG/JPG/TIFF test set, no baseline path segment ends in `.pdf`, so `baseline_names` stays empty → every input is flagged as a missing baseline → test set status `FAILED`. The sibling `test_set_file_copier` Lambda does not have this bug because it uses extension-agnostic prefix lookups.

### Fix
- Added a `_match_baseline_name()` helper that resolves the baseline directory name **extension-agnostically by matching against the set of known input filenames** (mirroring `test_set_file_copier`). A supported-extension allowlist (`.pdf/.png/.jpg/.jpeg/.tiff/.tif`) is used only as a fallback, so genuinely orphaned baselines still surface as *extra baselines* rather than being silently dropped.
- Split extraction into **two passes** so `input_names` is fully collected before baselines are resolved — ZIP entry order is not guaranteed, and the previous single-pass logic only worked when input entries happened to precede baseline entries.

Matching against the known input names (rather than the simpler "any segment with a dot" heuristic suggested in the issue) also avoids a false positive in the nested layout where a *category* folder contains a dot (e.g. `baseline/my.category/scan1.png/...`).

### Tests
- Refactored `lib/idp_common_pkg/tests/unit/test_zip_extractor.py` to **import and exercise the real Lambda helper** instead of a duplicated copy of the logic (the old tests would have stayed green while the real code was broken).
- Added regression coverage:
  - parametrized flat layouts for `png`, `jpg`, `jpeg`, `tiff`, `tif`
  - nested layout under a dotted-category folder
  - orphaned baseline correctly reported as an extra

### Verification
- `cd lib/idp_common_pkg && python -m pytest tests/unit/test_zip_extractor.py -v` → **9 passed**
- Test file passes `ruff check` and `ruff format --check`

### Scope / notes
- Two files changed: the Lambda source + its unit tests. No template/IAM/infra changes.
- The pre-existing `F541` ruff warnings in the Lambda are in the CI-excluded `src/` tree and were left untouched to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)