### PR TITLE
fix(api-resolvers): route validateTestFileName in HTTP API dispatcher

### DIFF
--- a/nested/api-resolvers/template.yaml
+++ b/nested/api-resolvers/template.yaml
@@ -2457,6 +2457,7 @@ Resources:
             "uploadDiscoveryDocument": "${DiscoveryUploadResolverFunction}",
             "uploadDocument": "${UploadResolverFunction}",
             "uploadMultiDocDiscoveryZip": "${DiscoveryUploadResolverFunction}",
+            "validateTestFileName": "${TestSetResolverFunction}",
             "claimReview": "${CompleteSectionReviewFunctionArn}",
             "completeSectionReview": "${CompleteSectionReviewFunctionArn}",
             "releaseReview": "${CompleteSectionReviewFunctionArn}",


### PR DESCRIPTION
## Summary

The Test Sets **ZIP upload** flow calls the `validateTestFileName` operation to check whether a test set already exists. Since AppSync was replaced by the HTTP API dispatcher, Lambda-backed fields are routed via `FIELD_FUNCTION_MAP` (an SSM parameter built in `nested/api-resolvers/template.yaml`).

`validateTestFileName` was **missing from that map** even though `test_set_resolver` handles it, so the dispatcher fell through to its `404 unknown operation` branch. In the UI this surfaced as:

> Failed to validate test set name: unknown operation: validateTestFileName

and blocked ZIP upload of test sets.

## Fix

Added the missing entry:

```json
"validateTestFileName": "${TestSetResolverFunction}",
```

consistent with the other test-set fields already in the map (`addTestSet`, `addTestSetFromUpload`, `listBucketFiles`, `getTestSets`, `deleteTestSets`, etc.).

## Verification

- `test_set_resolver/index.py` already handles `field_name == 'validateTestFileName'` — no resolver change needed.
- Confirmed the field-function-map JSON block still parses cleanly with the new entry (75 entries).

## Notes

- This is a **CloudFormation template change** — deploying requires a stack update so the SSM `field-function-map` parameter is rewritten; the dispatcher loads it at cold start.
- Distinct from the ZIP-extractor non-PDF fix (#380 / PR #442): different file, different root cause. This is an AppSync→REST migration gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)