### PR TITLE
fix(ui): sort Configuration Version picklists alphanumerically

### DIFF
--- a/src/ui/src/components/custom-models/CreateConfigVersionModal.tsx
+++ b/src/ui/src/components/custom-models/CreateConfigVersionModal.tsx
@@ -260,11 +260,13 @@ const CreateConfigVersionModal = ({
     }
   };
 
-  const versionOptions: SelectOption[] = configVersions.map((v) => ({
-    label: v.isActive ? `${v.versionName} (Active)` : v.versionName,
-    value: v.versionName,
-    description: v.description || undefined,
-  }));
+  const versionOptions: SelectOption[] = [...configVersions]
+    .sort((a, b) => a.versionName.localeCompare(b.versionName, undefined, { numeric: true, sensitivity: 'base' }))
+    .map((v) => ({
+      label: v.isActive ? `${v.versionName} (Active)` : v.versionName,
+      value: v.versionName,
+      description: v.description || undefined,
+    }));
 
   const atLeastOneChecked = useForExtraction || useForClassification;
 

--- a/src/ui/src/components/user-management/UserManagementLayout.tsx
+++ b/src/ui/src/components/user-management/UserManagementLayout.tsx
@@ -82,10 +82,12 @@ const UserManagementLayout = (): React.JSX.Element => {
   ];
 
   const configVersionOptions = useMemo(() => {
-    return versions.map((v) => ({
-      label: v.versionName + (v.isActive ? ' (active)' : ''),
-      value: v.versionName,
-    }));
+    return [...versions]
+      .sort((a, b) => a.versionName.localeCompare(b.versionName, undefined, { numeric: true, sensitivity: 'base' }))
+      .map((v) => ({
+        label: v.versionName + (v.isActive ? ' (active)' : ''),
+        value: v.versionName,
+      }));
   }, [versions]);
 
   const validateEmail = useCallback(

--- a/src/ui/src/hooks/use-configuration-versions.ts
+++ b/src/ui/src/hooks/use-configuration-versions.ts
@@ -214,19 +214,23 @@ const useConfigurationVersions = (): UseConfigurationVersionsReturn => {
     fetchVersions();
   }, []);
 
-  // Utility function to generate version options for Select components
+  // Utility function to generate version options for Select components.
+  // Sorted alphanumerically by version name (numeric-aware, so "v2" sorts
+  // before "v10") to give the picklists a stable, predictable order.
   const getVersionOptions = (): VersionOption[] => {
-    return versions.map((version) => {
-      const truncatedDescription =
-        version.description && version.description.length > 50 ? `${version.description.substring(0, 50)}...` : version.description;
+    return [...versions]
+      .sort((a, b) => a.versionName.localeCompare(b.versionName, undefined, { numeric: true, sensitivity: 'base' }))
+      .map((version) => {
+        const truncatedDescription =
+          version.description && version.description.length > 50 ? `${version.description.substring(0, 50)}...` : version.description;
 
-      return {
-        label: version.isActive
-          ? `${version.versionName} (Active)${truncatedDescription ? ` - ${truncatedDescription}` : ''}`
-          : `${version.versionName}${truncatedDescription ? ` - ${truncatedDescription}` : ''}`,
-        value: version.versionName,
-      };
-    });
+        return {
+          label: version.isActive
+            ? `${version.versionName} (Active)${truncatedDescription ? ` - ${truncatedDescription}` : ''}`
+            : `${version.versionName}${truncatedDescription ? ` - ${truncatedDescription}` : ''}`,
+          value: version.versionName,
+        };
+      });
   };
 
   return {


### PR DESCRIPTION
## Summary

Configuration Version pickers throughout the UI were rendered in raw API-response order (effectively random). This sorts them all by `versionName` using a numeric-aware, case-insensitive `localeCompare` so `v2` sorts before `v10`.

## Picklists covered (8 total)

| Location | Consumers |
|----------|-----------|
| `getVersionOptions()` in `use-configuration-versions.ts` | TestRunner, ReprocessDocumentModal, UploadDocumentPanel, DiscoveryPanel, MultiDocDiscoveryPanel, CapacityPlanningLayout |
| `CreateConfigVersionModal` | source-version picklist |
| `UserManagementLayout` | config-version scope multiselect |

## Testing
- `npx eslint` passes clean on all 3 changed files.
- Sort is applied to a copy (`[...versions]`) so no upstream state is mutated.