### PR TITLE
docs: cross-link document versions from README, Web UI, and CLI guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Concierge support for customization, deployment, and integration of production u
 - **Comprehensive Monitoring**: Rich CloudWatch dashboard with detailed metrics and logs
 - **Web User Interface**: Modern UI for inspecting document workflow status and results
 - **Configuration Versioning**: Support for multiple configuration versions with version-specific processing and test comparison
+- **Document Versioning**: Every processing run of a document is retained as an immutable version — view, compare, download, and manage prior outputs (see [document-versions.md](./docs/document-versions.md))
 - **Human-in-the-Loop (HITL)**: Built-in review system for human validation workflows
 - **AI-Powered Evaluation**: Framework to assess accuracy against baseline data
 - **Extraction Confidence Assessment**: LLM-powered assessment of extraction confidence with multimodal document analysis
@@ -180,6 +181,7 @@ For detailed deployment and testing instructions, see the [Deployment Guide](./d
 - [Headless Deployment](./docs/headless-deployment.md) - Backend-only deployment (no UI/AppSync/Cognito/WAF) for API-only use cases; required for GovCloud
 - [IDP CLI](./docs/idp-cli.md) - Command line interface for batch processing, evaluation workflows, and interactive Agent Chat
 - [Web UI](./docs/web-ui.md) - Web interface features and usage
+- [Document Versions](./docs/document-versions.md) - Retain, view, compare, and manage every processing run of a document
 - [Agent Analysis](./docs/agent-analysis.md) - Natural language analytics and data visualization feature
 - [Custom MCP Agent](./docs/custom-MCP-agent.md) - Integrating external MCP servers for custom tools and capabilities
 - [Configuration](./docs/configuration.md) - Configuration and customization options

--- a/docs/idp-cli.md
+++ b/docs/idp-cli.md
@@ -1070,7 +1070,9 @@ idp-cli download-results [OPTIONS]
 
 **Options:**
 - `--stack-name` (required): CloudFormation stack name
-- `--batch-id` (required): Batch identifier
+- `--batch-id`: Batch identifier (mutually exclusive with `--document-id`/`--run-id`)
+- `--document-id`: Document object key — required with `--run-id` to download a specific [document version](document-versions.md)
+- `--run-id`: Version run id (from `idp-cli list-versions`). Downloads the exact pinned S3 bytes of that processing run. Requires `--document-id`.
 - `--output-dir` (required): Local directory to download to
 - `--file-types`: File types to download (default: `all`)
   - Options: `pages`, `sections`, `summary`, `evaluation`, or `all`
@@ -1098,6 +1100,13 @@ idp-cli download-results \
     --batch-id eval-batch-20251015 \
     --output-dir ./eval-results/ \
     --file-types evaluation
+
+# Download a specific document VERSION (exact bytes of one processing run)
+idp-cli download-results \
+    --stack-name my-stack \
+    --document-id loan-12345/package.pdf \
+    --run-id 20250707T141530Z-exec-abc \
+    --output-dir ./results/
 ```
 
 **Output Structure:**
@@ -1122,6 +1131,32 @@ idp-cli download-results \
             ├── report.json              # Detailed metrics
             └── report.md                # Human-readable report
 ```
+
+---
+
+### `list-versions`
+
+List the retained processing-run [versions](document-versions.md) of a document, newest first. Each successful run of a document is retained as a version whose output bytes are pinned by S3 object version; use a version's `Run ID` with `download-results --run-id` to fetch that exact version.
+
+**Usage:**
+```bash
+idp-cli list-versions [OPTIONS]
+```
+
+**Options:**
+- `--stack-name` (required): CloudFormation stack name
+- `--document-id` (required): Document object key (its tracking id)
+- `--region`: AWS region (optional)
+
+**Example:**
+
+```bash
+idp-cli list-versions \
+    --stack-name my-stack \
+    --document-id loan-12345/package.pdf
+```
+
+Output is a table of `Run ID`, `Completed`, `Config Version`, `Pages`, and `Files`. See the [Document Versions guide](document-versions.md) for how versioning works and the Web UI / API surfaces.
 
 ---
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -24,6 +24,7 @@ _The GenAIIDP Web Interface showing the document tracking dashboard with status 
 - Accuracy evaluation reports when baseline data is provided
 - View and edit pattern configuration, including document classes, prompt engineering, and model settings
 - Manage multiple configuration versions — create, compare, activate, and delete versions (see [configuration-versions.md](configuration-versions.md))
+- Retain, view, compare, and delete **document versions** — every processing run of a document is kept and viewable read-only (see [document-versions.md](document-versions.md))
 - **Confidence threshold configuration** for HITL (Human-in-the-Loop) triggering through the Assessment & HITL Configuration section
 - Document upload from local computer
 - Knowledge base querying for document collections
@@ -315,6 +316,18 @@ A self-describing `manifest.json` is written at the ZIP root capturing the expor
 ### Fetching mechanics
 
 Every file in the archive is fetched directly from S3 using a short-lived presigned URL generated client-side with your browser's Cognito credentials, preserving binary content byte-for-byte. A progress modal reports status during the download and offers a **Cancel** button for large documents. The per-section **Download Data** / **Download Baseline** buttons in the Sections panel remain available for single-file downloads.
+
+## Document Versions
+
+The Document Details page includes a **Version History** panel listing every retained processing run of the document, newest first (with the current run badged). Re-uploading a document under the same key — or reprocessing it — no longer discards the prior results; each successful run is kept as an immutable version whose exact output bytes are pinned by S3 object version.
+
+From the panel you can:
+
+- **View** any past version's outputs read-only — its sections, page text/images, extraction results, and summary/evaluation reports are fetched from that run's pinned S3 versions, so you see exactly what that run produced even after later runs overwrote the outputs. Editing is disabled while viewing history; a banner offers **Return to current version**.
+- **Compare** any two versions — a section-by-section, field-level diff of their extraction results.
+- **Delete** a version (Admin only) — permanently removes that run's pinned object versions; the current version cannot be deleted, and versions still referenced by another retained run are preserved.
+
+See the [Document Versions guide](document-versions.md) for how versioning works, retention, the CLI/API surfaces, and caveats.
 
 ## Chat with Document
 


### PR DESCRIPTION
## Summary

Follow-up to the document-versions feature (merged in #446). That PR added the dedicated `docs/document-versions.md` guide, but the feature wasn't cross-linked from the high-traffic entry points, hurting discoverability. This docs-only PR fixes that.

- **README.md** — adds a **Document Versioning** bullet to Key Features (next to Configuration Versioning) and a docs-index entry.
- **docs/web-ui.md** — adds a Features bullet and a full **Document Versions** section (view read-only / compare / admin delete) next to "Download Document Data".
- **docs/idp-cli.md** — documents the new `list-versions` command and the `download-results` `--document-id` / `--run-id` options for downloading a specific version's pinned bytes.

All link to the existing `docs/document-versions.md` guide. Verified the link targets exist so the Starlight docs-site build won't break on a dangling reference.

Docs-only — no code, template, or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)