### PR TITLE
fix(summarization): prevent large-document input-token overflow (A+B+C)

### DIFF
--- a/lib/idp_common_pkg/idp_common/config/models.py
+++ b/lib/idp_common_pkg/idp_common/config/models.py
@@ -1079,6 +1079,18 @@ class SummarizationConfig(BaseModel):
         gt=0,
         description="Optional cap on output tokens. Leave empty to use the selected model's maximum output limit (recommended). If set, it must not exceed the model's limit.",
     )
+    max_extraction_array_items: int = Field(
+        default=50,
+        ge=0,
+        description=(
+            "When injecting EXTRACTION_RESULTS into the summarization prompt, any "
+            "array longer than this is elided to its first/last few items plus a "
+            "'... (N items total)' marker. A summary needs counts/totals, not "
+            "every row, and the full pretty-printed list is the dominant token "
+            "term that overflows the model context window on large documents. "
+            "0 disables elision (inject the full arrays)."
+        ),
+    )
 
     @field_validator("temperature", "top_p", "top_k", mode="before")
     @classmethod
@@ -1093,6 +1105,14 @@ class SummarizationConfig(BaseModel):
     def parse_int(cls, v: Any) -> Optional[int]:
         """Parse optional max_tokens (empty/0 -> None = use model max)."""
         return _parse_optional_max_tokens(v)
+
+    @field_validator("max_extraction_array_items", mode="before")
+    @classmethod
+    def parse_array_cap(cls, v: Any) -> int:
+        """Parse the array cap (empty string -> default 50)."""
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return 50
+        return int(v)
 
 
 class ChatConfig(BaseModel):

--- a/lib/idp_common_pkg/idp_common/config/system_defaults/base-summarization.yaml
+++ b/lib/idp_common_pkg/idp_common/config/system_defaults/base-summarization.yaml
@@ -7,7 +7,12 @@
 
 summarization:
   enabled: true
-  model: us.amazon.nova-pro-v1:0
+  # Default uses the 1M-context (:1m) Sonnet 5 variant so very large documents
+  # (100+ pages / thousands of extracted rows) don't overflow the summarization
+  # input window. Combined with extraction-JSON elision + a fit-or-truncate
+  # guard (see summarization/service.py), this keeps large docs from failing at
+  # the summarization step. Note the higher per-token cost of the :1m variant.
+  model: us.anthropic.claude-sonnet-5:1m
   top_p: "0.0"
   # Empty => use the selected model's maximum output limit (model_config_limits.yaml).
   # Set a positive value only to cap output below the model max.

--- a/lib/idp_common_pkg/idp_common/summarization/service.py
+++ b/lib/idp_common_pkg/idp_common/summarization/service.py
@@ -28,6 +28,80 @@ from idp_common.utils import extract_json_from_text
 
 logger = logging.getLogger(__name__)
 
+# Rough chars-per-token estimate, matching idp_common.utils.check_token_limit and
+# idp_common.extraction.sharding. Deliberately conservative (English prose is
+# ~4 chars/token; dense numeric/tabular text can be lower, so this slightly
+# *under*-counts — we compensate with a context-window safety buffer below).
+_CHARS_PER_TOKEN = 4.0
+
+# Fraction of the model's input window reserved for the system prompt, the
+# static task-prompt boilerplate, and generation headroom. We only allow the
+# variable payload (DOCUMENT_TEXT + EXTRACTION_RESULTS) to occupy the rest.
+_CONTEXT_SAFETY_FRACTION = 0.85
+
+# Fallback input window when model_config_limits.yaml can't resolve the model
+# (unknown/misconfigured id). Nova/Claude base windows are >=200K, so 180K is a
+# safe conservative floor.
+_DEFAULT_MAX_INPUT_TOKENS = 180_000
+
+# How many head/tail items to keep when eliding a large array.
+_ELIDE_HEAD = 3
+_ELIDE_TAIL = 2
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate the token count of a string using a conservative chars/token ratio."""
+    if not text:
+        return 0
+    return int(len(text) / _CHARS_PER_TOKEN)
+
+
+def _elide_large_arrays(obj: Any, max_items: int) -> Any:
+    """Recursively replace arrays longer than ``max_items`` with a head/tail
+    sample plus a marker string.
+
+    A statement/document summary needs counts and totals, not every row. The
+    full pretty-printed extraction list is the dominant token term that
+    overflows the model context window on large documents (e.g. a 6400-row
+    table). This keeps enough example rows for the model to understand the
+    shape of the data while collapsing the bulk.
+
+    ``max_items <= 0`` disables elision (returns the object unchanged).
+    """
+    if max_items and max_items > 0:
+        if isinstance(obj, list):
+            if len(obj) > max_items:
+                head = [_elide_large_arrays(x, max_items) for x in obj[:_ELIDE_HEAD]]
+                tail = (
+                    [_elide_large_arrays(x, max_items) for x in obj[-_ELIDE_TAIL:]]
+                    if _ELIDE_TAIL
+                    else []
+                )
+                marker = f"... ({len(obj)} items total, {len(obj) - _ELIDE_HEAD - _ELIDE_TAIL} elided)"
+                return head + [marker] + tail
+            return [_elide_large_arrays(x, max_items) for x in obj]
+        if isinstance(obj, dict):
+            return {k: _elide_large_arrays(v, max_items) for k, v in obj.items()}
+    return obj
+
+
+def _is_input_token_overflow(error: Exception) -> bool:
+    """Return True if the exception looks like a Bedrock input/context overflow.
+
+    Bedrock raises ``ValidationException`` with messages such as
+    "Input is too long for requested model" or "Input Tokens Exceeded" /
+    "input token count ... exceeds the maximum". We match loosely so a
+    summarization overflow degrades gracefully instead of failing the document.
+    """
+    msg = str(error).lower()
+    if "too long" in msg and "input" in msg:
+        return True
+    if "input token" in msg or "input tokens" in msg:
+        return True
+    if "context" in msg and ("exceed" in msg or "too long" in msg):
+        return True
+    return False
+
 
 class SummarizationService:
     """Service for summarizing documents using various backends."""
@@ -153,6 +227,107 @@ class SummarizationService:
             metadata={"error": error_message},
         )
 
+    def _get_max_input_tokens(self) -> int:
+        """Resolve the model's input (context-window) token limit.
+
+        Falls back to a conservative default if the model id can't be resolved
+        against model_config_limits.yaml.
+        """
+        try:
+            from idp_common.bedrock.model_utils import get_model_max_input_tokens
+
+            return get_model_max_input_tokens(self.bedrock_model)
+        except Exception as e:
+            logger.warning(
+                "Could not resolve max_input_tokens for model %s (%s); "
+                "falling back to %d.",
+                self.bedrock_model,
+                e,
+                _DEFAULT_MAX_INPUT_TOKENS,
+            )
+            return _DEFAULT_MAX_INPUT_TOKENS
+
+    def _build_placeholders(
+        self, text: str, extraction_results: Dict[str, Any], config: Dict[str, Any]
+    ) -> Tuple[Dict[str, str], bool]:
+        """Build the prompt placeholders, applying compaction/elision and a
+        fit-or-truncate guard against the model's input window.
+
+        Fix A: EXTRACTION_RESULTS is compact (no indent) and large arrays are
+        elided to head/tail samples so the dominant token term is removed.
+
+        Fix B: if the estimated prompt would still overflow the model window,
+        DOCUMENT_TEXT is truncated (and EXTRACTION_RESULTS further collapsed)
+        so the call fits instead of failing.
+
+        Returns:
+            (placeholders, truncated) where ``truncated`` is True if the payload
+            had to be reduced to fit.
+        """
+        array_cap = self.config.summarization.max_extraction_array_items
+
+        extraction_json = ""
+        if extraction_results:
+            elided = _elide_large_arrays(extraction_results, array_cap)
+            # Compact (no indent=2) — Fix A removes the pretty-print token bloat.
+            extraction_json = json.dumps(elided, default=str)
+
+        # Fix B: fit-or-truncate guard. Reserve a fraction of the window for the
+        # system prompt, task-prompt boilerplate, and output generation.
+        max_input_tokens = self._get_max_input_tokens()
+        budget_tokens = int(max_input_tokens * _CONTEXT_SAFETY_FRACTION)
+
+        # Account for the static task-prompt/system-prompt boilerplate.
+        boilerplate_tokens = _estimate_tokens(
+            config["task_prompt"]
+        ) + _estimate_tokens(config.get("system_prompt", ""))
+        payload_budget = max(0, budget_tokens - boilerplate_tokens)
+
+        truncated = False
+        extraction_tokens = _estimate_tokens(extraction_json)
+        text_tokens = _estimate_tokens(text)
+
+        if extraction_tokens + text_tokens > payload_budget:
+            truncated = True
+            logger.warning(
+                "Summarization prompt (~%d text + ~%d extraction tokens) exceeds "
+                "payload budget (~%d of %d window); truncating to fit.",
+                text_tokens,
+                extraction_tokens,
+                payload_budget,
+                max_input_tokens,
+            )
+            # First, hard-cap the extraction JSON to at most a third of the budget
+            # (it is supplemental — the document text is primary for a summary).
+            extraction_cap_tokens = max(0, payload_budget // 3)
+            if extraction_tokens > extraction_cap_tokens:
+                extraction_char_cap = int(extraction_cap_tokens * _CHARS_PER_TOKEN)
+                if extraction_char_cap <= 0:
+                    extraction_json = ""
+                else:
+                    extraction_json = (
+                        extraction_json[:extraction_char_cap]
+                        + '\n... (extraction results truncated to fit model context window)'
+                    )
+                extraction_tokens = _estimate_tokens(extraction_json)
+
+            # Then truncate DOCUMENT_TEXT to whatever remains.
+            text_budget_tokens = max(0, payload_budget - extraction_tokens)
+            text_char_cap = int(text_budget_tokens * _CHARS_PER_TOKEN)
+            if text_char_cap < len(text):
+                notice = (
+                    "\n\n[NOTE: Document text was truncated to fit the model "
+                    "context window. The summary is based on the leading portion "
+                    "of the document.]"
+                )
+                keep = max(0, text_char_cap - len(notice))
+                text = text[:keep] + notice
+
+        placeholders = {"DOCUMENT_TEXT": text}
+        if extraction_json:
+            placeholders["EXTRACTION_RESULTS"] = extraction_json
+        return placeholders, truncated
+
     def process_text(
         self, text: str, extraction_results: Dict[str, Any] = None
     ) -> DocumentSummary:
@@ -173,12 +348,11 @@ class SummarizationService:
         # Get summarization configuration
         config = self._get_summarization_config()
 
-        # Build placeholders for the prompt
-        placeholders = {"DOCUMENT_TEXT": text}
-        if extraction_results:
-            placeholders["EXTRACTION_RESULTS"] = json.dumps(
-                extraction_results, indent=2
-            )
+        # Build placeholders for the prompt (Fix A: compact/elide extraction JSON;
+        # Fix B: fit-or-truncate DOCUMENT_TEXT/EXTRACTION_RESULTS to the window).
+        placeholders, _truncated = self._build_placeholders(
+            text, extraction_results, config
+        )
 
         # Use common function to prepare prompt with required placeholder validation
         task_prompt = bedrock.format_prompt(
@@ -256,6 +430,35 @@ class SummarizationService:
                 )
 
         except Exception as e:
+            # Fix B: graceful degradation. If Bedrock still rejects the prompt as
+            # too large for the input window (despite the fit-or-truncate guard —
+            # e.g. our char/token estimate under-counted dense numeric text),
+            # return a partial/skipped summary stub instead of raising. A
+            # summarization overflow must NEVER fail the whole document when the
+            # (expensive) extraction already succeeded.
+            if _is_input_token_overflow(e):
+                logger.warning(
+                    "Summarization input exceeded the model context window even "
+                    "after truncation (%s); returning a partial summary stub so "
+                    "the document completes with extraction intact.",
+                    e,
+                )
+                return DocumentSummary(
+                    content={
+                        "summary": (
+                            "## Summary Unavailable\n\n"
+                            "This section could not be summarized because its "
+                            "content exceeded the summarization model's context "
+                            "window. Extraction results for this section are "
+                            "available and unaffected."
+                        )
+                    },
+                    metadata={
+                        "summarization_skipped": True,
+                        "skip_reason": "input_token_overflow",
+                        "error": str(e),
+                    },
+                )
             logger.error(f"Error summarizing text: {str(e)}")
             raise
 

--- a/lib/idp_common_pkg/idp_common/summarization/service.py
+++ b/lib/idp_common_pkg/idp_common/summarization/service.py
@@ -278,9 +278,9 @@ class SummarizationService:
         budget_tokens = int(max_input_tokens * _CONTEXT_SAFETY_FRACTION)
 
         # Account for the static task-prompt/system-prompt boilerplate.
-        boilerplate_tokens = _estimate_tokens(
-            config["task_prompt"]
-        ) + _estimate_tokens(config.get("system_prompt", ""))
+        boilerplate_tokens = _estimate_tokens(config["task_prompt"]) + _estimate_tokens(
+            config.get("system_prompt", "")
+        )
         payload_budget = max(0, budget_tokens - boilerplate_tokens)
 
         truncated = False
@@ -307,7 +307,7 @@ class SummarizationService:
                 else:
                     extraction_json = (
                         extraction_json[:extraction_char_cap]
-                        + '\n... (extraction results truncated to fit model context window)'
+                        + "\n... (extraction results truncated to fit model context window)"
                     )
                 extraction_tokens = _estimate_tokens(extraction_json)
 

--- a/lib/idp_common_pkg/tests/unit/summarization/test_summarization_service.py
+++ b/lib/idp_common_pkg/tests/unit/summarization/test_summarization_service.py
@@ -743,3 +743,129 @@ class TestSummarizationService:
         # Verify error was added and status set to FAILED
         assert "Document has no pages to summarize" in result.errors
         assert result.status == Status.FAILED
+
+
+@pytest.mark.unit
+class TestExtractionArrayElision:
+    """Tests for Fix A: compact/elide extraction JSON before injection."""
+
+    def test_elide_large_array_replaces_with_head_tail_and_marker(self):
+        from idp_common.summarization.service import _elide_large_arrays
+
+        data = {"transactions": [{"i": i} for i in range(6400)], "total": 6400}
+        out = _elide_large_arrays(data, 50)
+
+        # head (3) + marker (1) + tail (2) == 6 entries
+        assert len(out["transactions"]) == 6
+        assert out["transactions"][0] == {"i": 0}
+        assert out["transactions"][-1] == {"i": 6399}
+        assert "6400 items total" in out["transactions"][3]
+        # Scalars/counts preserved
+        assert out["total"] == 6400
+
+    def test_small_array_not_elided(self):
+        from idp_common.summarization.service import _elide_large_arrays
+
+        data = {"items": [1, 2, 3]}
+        assert _elide_large_arrays(data, 50) == {"items": [1, 2, 3]}
+
+    def test_cap_zero_disables_elision(self):
+        from idp_common.summarization.service import _elide_large_arrays
+
+        data = {"items": list(range(1000))}
+        assert _elide_large_arrays(data, 0) == data
+
+    def test_nested_arrays_elided(self):
+        from idp_common.summarization.service import _elide_large_arrays
+
+        data = {"outer": {"inner": list(range(500))}}
+        out = _elide_large_arrays(data, 10)
+        assert len(out["outer"]["inner"]) == 6
+
+    @patch("idp_common.bedrock.invoke_model")
+    def test_process_text_injects_compact_elided_extraction(self, mock_invoke_model):
+        """The prompt sent to Bedrock must NOT contain the full 6400-row list."""
+        mock_invoke_model.return_value = {
+            "response": {
+                "output": {
+                    "message": {"content": [{"text": '{"summary": "ok"}'}]}
+                }
+            },
+            "metering": {"input_tokens": 10, "output_tokens": 5},
+        }
+        config = {
+            "summarization": {
+                "enabled": True,
+                "model": "us.amazon.nova-pro-v1:0",
+                "system_prompt": "sys",
+                "task_prompt": "Doc: {DOCUMENT_TEXT}\nAttrs: {EXTRACTION_RESULTS}",
+                "max_extraction_array_items": 50,
+            }
+        }
+        service = SummarizationService(region="us-west-2", config=config)
+        extraction = {"transactions": [{"i": i} for i in range(6400)]}
+        service.process_text("short document text", extraction)
+
+        sent_prompt = mock_invoke_model.call_args.kwargs["content"][0]["text"]
+        # Elided: marker present, not every row.
+        assert "6400 items total" in sent_prompt
+        # Compact (no indent) — pretty-printed 2-space indent should be absent.
+        assert '\n  "transactions"' not in sent_prompt
+
+
+@pytest.mark.unit
+class TestFitOrSkipGuard:
+    """Tests for Fix B: fit-or-truncate guard + graceful overflow degradation."""
+
+    def _make_service(self, model="us.amazon.nova-pro-v1:0"):
+        config = {
+            "summarization": {
+                "enabled": True,
+                "model": model,
+                "system_prompt": "sys",
+                "task_prompt": "Doc: {DOCUMENT_TEXT}\nAttrs: {EXTRACTION_RESULTS}",
+            }
+        }
+        return SummarizationService(region="us-west-2", config=config)
+
+    def test_build_placeholders_truncates_oversized_text(self):
+        service = self._make_service()
+        config = service._get_summarization_config()
+        # ~2M chars ≈ 500K tokens, far over Nova Pro's 300K window.
+        huge_text = "word " * 400_000
+        placeholders, truncated = service._build_placeholders(
+            huge_text, {}, config
+        )
+        assert truncated is True
+        assert len(placeholders["DOCUMENT_TEXT"]) < len(huge_text)
+        assert "truncated" in placeholders["DOCUMENT_TEXT"].lower()
+
+    def test_build_placeholders_no_truncation_when_small(self):
+        service = self._make_service()
+        config = service._get_summarization_config()
+        placeholders, truncated = service._build_placeholders(
+            "small text", {"a": 1}, config
+        )
+        assert truncated is False
+        assert placeholders["DOCUMENT_TEXT"] == "small text"
+
+    @patch("idp_common.bedrock.invoke_model")
+    def test_process_text_overflow_returns_stub_not_raise(self, mock_invoke_model):
+        """An input-token overflow from Bedrock must degrade to a stub, not raise."""
+        mock_invoke_model.side_effect = Exception(
+            "ValidationException: Input Tokens Exceeded"
+        )
+        service = self._make_service()
+        result = service.process_text("some document text", {"a": 1})
+
+        assert result.metadata.get("summarization_skipped") is True
+        assert result.metadata.get("skip_reason") == "input_token_overflow"
+        assert "Summary Unavailable" in result.content["summary"]
+
+    @patch("idp_common.bedrock.invoke_model")
+    def test_process_text_non_overflow_error_still_raises(self, mock_invoke_model):
+        """Non-overflow errors must still propagate (not silently swallowed)."""
+        mock_invoke_model.side_effect = Exception("AccessDeniedException")
+        service = self._make_service()
+        with pytest.raises(Exception, match="AccessDeniedException"):
+            service.process_text("some document text", {"a": 1})

--- a/lib/idp_common_pkg/tests/unit/summarization/test_summarization_service.py
+++ b/lib/idp_common_pkg/tests/unit/summarization/test_summarization_service.py
@@ -787,9 +787,7 @@ class TestExtractionArrayElision:
         """The prompt sent to Bedrock must NOT contain the full 6400-row list."""
         mock_invoke_model.return_value = {
             "response": {
-                "output": {
-                    "message": {"content": [{"text": '{"summary": "ok"}'}]}
-                }
+                "output": {"message": {"content": [{"text": '{"summary": "ok"}'}]}}
             },
             "metering": {"input_tokens": 10, "output_tokens": 5},
         }
@@ -833,9 +831,7 @@ class TestFitOrSkipGuard:
         config = service._get_summarization_config()
         # ~2M chars ≈ 500K tokens, far over Nova Pro's 300K window.
         huge_text = "word " * 400_000
-        placeholders, truncated = service._build_placeholders(
-            huge_text, {}, config
-        )
+        placeholders, truncated = service._build_placeholders(huge_text, {}, config)
         assert truncated is True
         assert len(placeholders["DOCUMENT_TEXT"]) < len(huge_text)
         assert "truncated" in placeholders["DOCUMENT_TEXT"].lower()


### PR DESCRIPTION
## Problem
On very large documents, the **summarization** step fails the entire document with
`ValidationException: Input Tokens Exceeded` — *after* a successful, expensive extraction.
Root cause (measured on a 131-page / 6400-row doc): `process_document_section` builds the
prompt as `DOCUMENT_TEXT` (all page OCR text) **+** `EXTRACTION_RESULTS`
(`json.dumps(inference_result, indent=2)` — the entire extracted list), in one non-sharded
Converse call. The pretty-printed extraction list is the dominant token term (~200K+ tokens
for 6400 rows) and pushes the prompt past the model's input window.

## Fix (A + B + C)
- **A — compact/elide extraction JSON:** drop `indent=2`; recursively elide arrays longer
  than a configurable cap to head/tail samples + a `"... (N items total)"` marker. A summary
  needs counts/totals, not every row. New config `SummarizationConfig.max_extraction_array_items`
  (default 50; `0` disables).
- **B — fit-or-skip guard:** estimate prompt tokens vs the model's input window
  (`get_model_max_input_tokens` × 0.85); truncate `EXTRACTION_RESULTS` then `DOCUMENT_TEXT` to
  fit; and catch input-overflow `ValidationException` to persist a partial summary stub so the
  **document completes with extraction intact** instead of failing. Non-overflow errors still raise.
- **C — larger-window default:** `base-summarization.yaml` model
  `us.amazon.nova-pro-v1:0` → `us.anthropic.claude-sonnet-5:1m` (1M input window).

## Validation
- 54 summarization unit tests pass (9 new for A + B); no regressions.
- Ran the **actual** summarization task_prompt through both Nova Pro and Sonnet 5 :1m on real
  27-page OCR text via direct Converse: **both** produce the required markdown with hyperlinked
  citations `[[Cite-X, Page-Y]](#...)` + References section. Sonnet 5 was markedly richer
  (found all sub-documents, cross-checked extraction vs raw text). No prompt change needed.

## Cost note
Sonnet 5 :1m is ~8× Nova Pro per token (summarization is one call/section, a small share of
pipeline cost). Deployments without Claude Sonnet 5 access, or cost-sensitive ones, can keep
Nova Pro and are still protected by A + B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)