### PR TITLE
fix(bda-ocr): map rectified BDA bounding boxes back to original-image space

### DIFF
--- a/lib/idp_common_pkg/idp_common/bda/bda_ocr.py
+++ b/lib/idp_common_pkg/idp_common/bda/bda_ocr.py
@@ -23,8 +23,20 @@ against the live service):
   the mean of its child words' confidence.
 
 BDA confidences are 0-1; Textract confidences are 0-100, so we scale by 100.
-BDA bounding boxes are already normalized 0-1 ({left, top, width, height}),
-matching Textract's convention.
+BDA bounding boxes are normalized 0-1 ({left, top, width, height}), matching
+Textract's convention.
+
+**Coordinate frame: BDA rectifies the page.** BDA internally deskews /
+perspective-corrects the input image and returns every bounding box normalized
+against that *rectified* image, not against the original page image the pipeline
+stored (``image.jpg``) and the UI displays. On a clean, axis-aligned scan the
+two frames coincide and boxes line up. On a skewed/rotated scan they don't, and
+overlays land in the wrong spot. Each page's ``asset_metadata.corners`` gives
+where the rectified image's four corners fall in the *original* image (0-1,
+ordered TL, TR, BR, BL), so we map every box back into original-image space via
+bilinear interpolation before emitting geometry. This makes BDA geometry agree
+with Textract's (which is never rectified). The mapping is a no-op when corners
+are absent or identity, preserving behavior for clean pages / older payloads.
 """
 
 from __future__ import annotations
@@ -42,29 +54,116 @@ logger = logging.getLogger(__name__)
 OCR_PROJECT_NAME = "GENAIIDP-OCR-StandardOutput"
 
 
-def _bbox_to_geometry(bbox: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    """Convert a BDA bounding_box (0-1) to a Textract-format Geometry, or None."""
+# A "corners" quad that is (within tolerance) the unit square: the rectified
+# image equals the original image, so no coordinate mapping is needed.
+_IDENTITY_CORNERS = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+_CORNERS_IDENTITY_TOL = 1e-3
+
+
+def _normalize_corners(
+    corners: Optional[Any],
+) -> Optional[List[tuple[float, float]]]:
+    """Coerce BDA ``asset_metadata.corners`` to four (x, y) tuples, or None.
+
+    Corners are the original-image (0-1) positions of the rectified image's four
+    corners, ordered top-left, top-right, bottom-right, bottom-left. Returns None
+    when absent/malformed, or when the quad is effectively the unit square (an
+    identity rectification, so no mapping is required).
+    """
+    if not isinstance(corners, (list, tuple)) or len(corners) != 4:
+        return None
+    pts: List[tuple[float, float]] = []
+    for c in corners:
+        if isinstance(c, (list, tuple)) and len(c) == 2:
+            try:
+                pts.append((float(c[0]), float(c[1])))
+            except (TypeError, ValueError):
+                return None
+        elif isinstance(c, dict) and "x" in c and "y" in c:
+            try:
+                pts.append((float(c["x"]), float(c["y"])))
+            except (TypeError, ValueError):
+                return None
+        else:
+            return None
+    if all(
+        abs(px - ix) <= _CORNERS_IDENTITY_TOL and abs(py - iy) <= _CORNERS_IDENTITY_TOL
+        for (px, py), (ix, iy) in zip(pts, _IDENTITY_CORNERS)
+    ):
+        return None
+    return pts
+
+
+def _map_point(
+    u: float, v: float, corners: List[tuple[float, float]]
+) -> tuple[float, float]:
+    """Bilinearly map a rectified-space point (u, v in 0-1) to original space.
+
+    ``corners`` are the original-image coordinates of the rectified corners in
+    TL, TR, BR, BL order. Bilinear interpolation across that quad inverts BDA's
+    rectification closely enough for overlay purposes (BDA rectification is an
+    affine/perspective deskew; bilinear is exact for affine and a good
+    approximation for mild perspective).
+    """
+    (tlx, tly), (trx, try_), (brx, bry), (blx, bly) = corners
+    top_x = tlx + (trx - tlx) * u
+    top_y = tly + (try_ - tly) * u
+    bot_x = blx + (brx - blx) * u
+    bot_y = bly + (bry - bly) * u
+    return (top_x + (bot_x - top_x) * v, top_y + (bot_y - top_y) * v)
+
+
+def _bbox_to_geometry(
+    bbox: Optional[Dict[str, Any]],
+    corners: Optional[List[tuple[float, float]]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Convert a BDA bounding_box (0-1) to a Textract-format Geometry, or None.
+
+    When ``corners`` is provided (a non-identity rectification quad), the box is
+    mapped from BDA's rectified frame back into original-image space so it aligns
+    with the stored page image / UI overlays. A rectified axis-aligned box maps
+    to a (possibly non-rectangular) quadrilateral, which becomes the ``Polygon``;
+    ``BoundingBox`` is that quad's axis-aligned envelope (Textract convention).
+    """
     if not isinstance(bbox, dict):
         return None
     left = bbox.get("left", 0.0)
     top = bbox.get("top", 0.0)
     width = bbox.get("width", 0.0)
     height = bbox.get("height", 0.0)
+
+    if corners is None:
+        # No rectification (clean page / identity corners): pass through, and
+        # synthesize a rectangular polygon so downstream geometry consumers (UI
+        # highlighting) have the same shape Textract provides.
+        polygon = [
+            (left, top),
+            (left + width, top),
+            (left + width, top + height),
+            (left, top + height),
+        ]
+    else:
+        # Map each rectified corner back into original-image space. Order is
+        # TL, TR, BR, BL to match Textract's polygon winding.
+        polygon = [
+            _map_point(left, top, corners),
+            _map_point(left + width, top, corners),
+            _map_point(left + width, top + height, corners),
+            _map_point(left, top + height, corners),
+        ]
+
+    xs = [p[0] for p in polygon]
+    ys = [p[1] for p in polygon]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
     return {
         "BoundingBox": {
-            "Left": left,
-            "Top": top,
-            "Width": width,
-            "Height": height,
+            "Left": min_x,
+            "Top": min_y,
+            "Width": max_x - min_x,
+            "Height": max_y - min_y,
         },
-        # Synthesize a rectangular polygon so downstream geometry consumers
-        # (UI highlighting) have the same shape Textract provides.
-        "Polygon": [
-            {"X": left, "Y": top},
-            {"X": left + width, "Y": top},
-            {"X": left + width, "Y": top + height},
-            {"X": left, "Y": top + height},
-        ],
+        "Polygon": [{"X": x, "Y": y} for x, y in polygon],
     }
 
 
@@ -110,6 +209,28 @@ def bda_standard_output_to_textract_blocks(
 
     text_lines: List[Dict[str, Any]] = standard_output.get("text_lines", []) or []
     text_words: List[Dict[str, Any]] = standard_output.get("text_words", []) or []
+
+    # Rectification corners are per-page (asset_metadata.corners). Map each
+    # page_index to its normalized corners so every box can be re-projected into
+    # original-image space; None means identity/absent (no mapping needed).
+    corners_by_page: Dict[Optional[int], Optional[List[tuple[float, float]]]] = {}
+    for page in standard_output.get("pages", []) or []:
+        if not isinstance(page, dict):
+            continue
+        asset_meta = page.get("asset_metadata") or {}
+        corners_by_page[page.get("page_index")] = _normalize_corners(
+            asset_meta.get("corners")
+        )
+
+    def _corners_for(unit: Dict[str, Any]) -> Optional[List[tuple[float, float]]]:
+        pi = unit.get("page_index")
+        if pi in corners_by_page:
+            return corners_by_page[pi]
+        # Single-page invocations sometimes omit a matching page_index on the
+        # unit; fall back to the sole page's corners when unambiguous.
+        if len(corners_by_page) == 1:
+            return next(iter(corners_by_page.values()))
+        return None
 
     def _on_page(unit: Dict[str, Any]) -> bool:
         if page_index is None:
@@ -169,7 +290,9 @@ def bda_standard_output_to_textract_blocks(
                     "Id": wid,
                     "Text": word.get("text", ""),
                     "Confidence": wconf_scaled,
-                    "Geometry": _bbox_to_geometry(_first_bbox(word)),
+                    "Geometry": _bbox_to_geometry(
+                        _first_bbox(word), _corners_for(word)
+                    ),
                 }
             )
             word_ids.append(wid)
@@ -187,7 +310,7 @@ def bda_standard_output_to_textract_blocks(
             "Id": line_id,
             "Text": line.get("text", ""),
             "Confidence": line_conf,
-            "Geometry": _bbox_to_geometry(_first_bbox(line)),
+            "Geometry": _bbox_to_geometry(_first_bbox(line), _corners_for(line)),
         }
         if word_ids:
             line_block["Relationships"] = [{"Type": "CHILD", "Ids": word_ids}]

--- a/lib/idp_common_pkg/idp_common/ocr/README.md
+++ b/lib/idp_common_pkg/idp_common/ocr/README.md
@@ -43,6 +43,18 @@ concurrent load. BDA standard output is converted to Amazon Textract response
 format (PAGE/LINE/WORD blocks), so it flows through the same
 `textConfidence.json` / `pageData.json` path as the Textract backend.
 
+> **Geometry / rectification:** BDA internally deskews (perspective-corrects)
+> each page and returns bounding boxes normalized against that *rectified*
+> image, while the pipeline stores and the UI overlays the *original* page image.
+> On a skewed/rotated scan this offsets every box (visibly misaligned overlays in
+> the Page/Section Visual Editors); clean, axis-aligned pages coincide and look
+> fine. `bda_ocr.py` corrects this by reading each page's
+> `asset_metadata.corners` (where the rectified corners fall in the original
+> image, 0–1) and bilinearly mapping every box back into original-image space, so
+> BDA geometry agrees with Textract's (which is never rectified). A rectified
+> axis-aligned box becomes a quadrilateral `Polygon` with an axis-aligned
+> `BoundingBox` envelope. The mapping is a no-op when corners are identity/absent.
+
 ### 3. Bedrock Backend (LLM-based OCR, incl. LambdaHook)
 - **Technology**: Amazon Bedrock LLMs (Claude, Nova) for text extraction, or a custom `LambdaHook` (`model_id: "LambdaHook"`) that proxies to any inference provider.
 - **Confidence Data**:

--- a/lib/idp_common_pkg/tests/unit/bda/test_bda_ocr.py
+++ b/lib/idp_common_pkg/tests/unit/bda/test_bda_ocr.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock
 
 from idp_common.bda.bda_ocr import (
     OCR_PROJECT_NAME,
+    _map_point,
+    _normalize_corners,
     bda_standard_output_to_textract_blocks,
     build_ocr_project_override_config,
     build_ocr_project_standard_output_config,
@@ -171,10 +173,116 @@ def test_geometry_is_normalized_boundingbox_and_polygon():
     out = bda_standard_output_to_textract_blocks(_sample_standard_output())
     line1 = next(b for b in out["Blocks"] if b.get("Id") == "line-1")
     bb = line1["Geometry"]["BoundingBox"]
-    assert bb == {"Left": 0.1, "Top": 0.2, "Width": 0.3, "Height": 0.05}
+    # BoundingBox is derived from the polygon envelope; compare with tolerance
+    # since (left + width) - left can introduce tiny float error.
+    assert bb["Left"] == pytest.approx(0.1)
+    assert bb["Top"] == pytest.approx(0.2)
+    assert bb["Width"] == pytest.approx(0.3)
+    assert bb["Height"] == pytest.approx(0.05)
     poly = line1["Geometry"]["Polygon"]
-    assert poly[0] == {"X": 0.1, "Y": 0.2}
+    assert poly[0] == {"X": pytest.approx(0.1), "Y": pytest.approx(0.2)}
     assert poly[2] == {"X": pytest.approx(0.4), "Y": pytest.approx(0.25)}
+
+
+@pytest.mark.unit
+def test_normalize_corners_treats_identity_as_no_mapping():
+    """Unit-square corners (a clean, un-rectified page) => no mapping needed."""
+    assert _normalize_corners([[0, 0], [1, 0], [1, 1], [0, 1]]) is None
+    # Near-identity within tolerance is also treated as identity.
+    assert (
+        _normalize_corners(
+            [[1e-8, -3e-6], [1.0000074, -4e-8], [0.9999999, 1.0000025], [-4e-7, 1.0]]
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_normalize_corners_rejects_malformed():
+    assert _normalize_corners(None) is None
+    assert _normalize_corners([[0, 0], [1, 0], [1, 1]]) is None  # only 3 corners
+    assert _normalize_corners([[0, 0], [1, 0], [1, 1], ["x", 1]]) is None
+    # Accepts {x, y} dict form as well as [x, y] pairs.
+    assert _normalize_corners(
+        [
+            {"x": 0.1, "y": 0.0},
+            {"x": 0.9, "y": 0.1},
+            {"x": 0.8, "y": 1.0},
+            {"x": 0.0, "y": 0.9},
+        ]
+    ) == [(0.1, 0.0), (0.9, 0.1), (0.8, 1.0), (0.0, 0.9)]
+
+
+@pytest.mark.unit
+def test_map_point_bilinear_over_corners():
+    """Bilinear map: (0,0)->TL, (1,0)->TR, (1,1)->BR, (0,1)->BL, (.5,.5)->center."""
+    corners = [(0.1, 0.0), (0.9, 0.1), (0.8, 1.0), (0.0, 0.9)]
+    assert _map_point(0.0, 0.0, corners) == pytest.approx((0.1, 0.0))
+    assert _map_point(1.0, 0.0, corners) == pytest.approx((0.9, 0.1))
+    assert _map_point(1.0, 1.0, corners) == pytest.approx((0.8, 1.0))
+    assert _map_point(0.0, 1.0, corners) == pytest.approx((0.0, 0.9))
+    cx = (0.1 + 0.9 + 0.8 + 0.0) / 4
+    cy = (0.0 + 0.1 + 1.0 + 0.9) / 4
+    assert _map_point(0.5, 0.5, corners) == pytest.approx((cx, cy))
+
+
+@pytest.mark.unit
+def test_geometry_mapped_back_to_original_space_when_rectified():
+    """A rectified (skewed) page maps boxes back into original-image space.
+
+    BDA returns boxes normalized against its internally-rectified image; the
+    stored page image and UI overlay use original-image space. With non-identity
+    corners the converter must re-project, producing a quadrilateral polygon and
+    an axis-aligned envelope that lands on the tilted text (not the deskewed
+    grid). Regression test for BDA-OCR bounding boxes being visibly offset on
+    skewed scans while Textract's were fine.
+    """
+    payload = _sample_standard_output()
+    # Simulate a page rotated ~clockwise: rectified corners fall on a tilted quad
+    # in the original image (TL, TR, BR, BL).
+    corners = [[0.1, 0.0], [0.9, 0.1], [0.8, 1.0], [0.0, 0.9]]
+    payload["pages"][0]["asset_metadata"] = {"corners": corners}
+
+    out = bda_standard_output_to_textract_blocks(payload)
+    line1 = next(b for b in out["Blocks"] if b.get("Id") == "line-1")
+    geom = line1["Geometry"]
+
+    # Raw BDA box for line-1 is left=0.1, top=0.2, width=0.3, height=0.05. Mapped
+    # through the tilted quad it is NO LONGER the raw rectangle.
+    bb = geom["BoundingBox"]
+    assert bb != {"Left": 0.1, "Top": 0.2, "Width": 0.3, "Height": 0.05}
+
+    # Every mapped polygon vertex must equal the bilinear map of the raw corner.
+    raw_corners = [(0.1, 0.2), (0.4, 0.2), (0.4, 0.25), (0.1, 0.25)]
+    corner_pts = [(c[0], c[1]) for c in corners]
+    for poly_pt, (u, v) in zip(geom["Polygon"], raw_corners):
+        exp_x, exp_y = _map_point(u, v, corner_pts)
+        assert poly_pt["X"] == pytest.approx(exp_x)
+        assert poly_pt["Y"] == pytest.approx(exp_y)
+
+    # BoundingBox is the axis-aligned envelope of that polygon.
+    xs = [p["X"] for p in geom["Polygon"]]
+    ys = [p["Y"] for p in geom["Polygon"]]
+    assert bb["Left"] == pytest.approx(min(xs))
+    assert bb["Top"] == pytest.approx(min(ys))
+    assert bb["Width"] == pytest.approx(max(xs) - min(xs))
+    assert bb["Height"] == pytest.approx(max(ys) - min(ys))
+
+
+@pytest.mark.unit
+def test_identity_corners_leave_geometry_unchanged():
+    """A clean page (identity corners) must pass geometry through untouched."""
+    payload = _sample_standard_output()
+    payload["pages"][0]["asset_metadata"] = {
+        "corners": [[0, 0], [1, 0], [1, 1], [0, 1]]
+    }
+    out = bda_standard_output_to_textract_blocks(payload)
+    line1 = next(b for b in out["Blocks"] if b.get("Id") == "line-1")
+    bb = line1["Geometry"]["BoundingBox"]
+    assert bb["Left"] == pytest.approx(0.1)
+    assert bb["Top"] == pytest.approx(0.2)
+    assert bb["Width"] == pytest.approx(0.3)
+    assert bb["Height"] == pytest.approx(0.05)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

When BDA is used as the OCR backend, bounding boxes in the **Page Visual Editor** (and the **Section Visual Editor** when using `ocr_only` for geometry) are offset — they don't land on the right spot on the page image. Textract geometry is fine.

## Root cause

BDA internally **rectifies** (deskews / perspective-corrects) each page and returns bounding boxes normalized against that *rectified* image. The pipeline stores and the UI overlays the *original* page image (`image.jpg`), so:

- **Clean, axis-aligned pages** — the rectified and original frames coincide, boxes line up (this is why it looked fine in many cases).
- **Skewed/rotated scans** — every box sits on the deskewed grid instead of the tilted text, producing the visibly-offset overlays.

Textract never rectifies, so its geometry was always correct.

The signal is in each page's `asset_metadata.corners`: the 0–1 positions where the rectified image's four corners fall in the *original* image. On a clean page they're ≈ the unit square; on a skewed page they form a rotated quad.

## Fix (`lib/idp_common_pkg/idp_common/bda/bda_ocr.py`)

- `_normalize_corners()` — parse `asset_metadata.corners` (accepts `[x,y]` or `{x,y}`); returns `None` for absent/malformed **or identity** corners so clean pages / older payloads are untouched.
- `_map_point()` — bilinearly map a rectified-space point back into original-image space via the corner quad (exact for affine/rotation, close for mild perspective).
- `_bbox_to_geometry()` now optionally takes `corners`: when present, maps the box's four corners, emitting the real (possibly non-rectangular) quad as `Polygon` and its axis-aligned envelope as `BoundingBox`; when absent, passes through unchanged.
- The converter extracts per-page corners and threads them into every LINE/WORD block.

## Testing (validated against Textract on live BDA output)

Captured real BDA standard output from the deployed OCR project and ran Textract on the same images:

- **Clean page — fixed BDA vs Textract:** center offset mean 0.0004, max 0.0011 (essentially pixel-identical).
- **Skewed page:** overlaid Textract and mapped-BDA on the same image — before the fix, BDA boxes sat on the deskewed grid (badly offset); after the fix, mapped-BDA polygons and Textract boxes both land on the same tilted words.

Unit tests: 28 passed (added 5 regression tests: corners parsing, bilinear mapping, skew remap, identity no-op; fixed one float-precision assertion to use `approx`). Ruff + basedpyright clean. Updated `ocr/README.md` with the rectification note.

### Note

The remap uses **bilinear** interpolation — exact for pure rotation/affine deskew and a very good approximation for BDA's mild perspective correction. Extreme keystone/perspective distortion would be marginally more precise with a full homography, but bilinear was visually spot-on here and keeps the converter dependency-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)