### PR TITLE
fix: replace urlparse with parse_s3_uri to handle '#' in S3 keys

### DIFF
--- a/lib/idp_common_pkg/idp_common/models.py
+++ b/lib/idp_common_pkg/idp_common/models.py
@@ -899,9 +899,10 @@ class Document:
             Full Document object with all content restored
         """
         import logging
-        from urllib.parse import urlparse
 
         import boto3
+
+        from idp_common.utils import parse_s3_uri
 
         logger = logging.getLogger(__name__)
         s3_client = boto3.client("s3")
@@ -912,8 +913,7 @@ class Document:
             if not s3_uri:
                 raise ValueError("No s3_uri found in compressed data")
 
-            parsed_uri = urlparse(s3_uri)
-            s3_key = parsed_uri.path.lstrip("/")
+            _, s3_key = parse_s3_uri(s3_uri)
 
             # Retrieve full document from S3
             response = s3_client.get_object(Bucket=bucket, Key=s3_key)

--- a/lib/idp_common_pkg/idp_common/reporting/save_reporting_data.py
+++ b/lib/idp_common_pkg/idp_common/reporting/save_reporting_data.py
@@ -11,7 +11,7 @@ import json
 import logging
 import re
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlparse
+from idp_common.utils import parse_s3_uri
 
 import boto3
 import pyarrow as pa
@@ -126,14 +126,7 @@ class SaveReportingData:
         Returns:
             Tuple of (bucket, key)
         """
-        parsed = urlparse(uri)
-        if parsed.scheme != "s3":
-            raise ValueError(f"Not an S3 URI: {uri}")
-
-        bucket = parsed.netloc
-        # Remove leading slash from key
-        key = parsed.path.lstrip("/")
-
+        bucket, key = parse_s3_uri(uri)
         return bucket, key
 
     def _infer_pyarrow_type(self, value: Any) -> pa.DataType:

--- a/lib/idp_common_pkg/idp_common/utils/s3util.py
+++ b/lib/idp_common_pkg/idp_common/utils/s3util.py
@@ -8,7 +8,7 @@ Utility functions for working with Amazon S3.
 import json
 import boto3
 from typing import Dict, Any, Tuple, Optional, Union
-from urllib.parse import urlparse
+from idp_common.utils import parse_s3_uri
 
 
 class S3Util:
@@ -162,16 +162,5 @@ class S3Util:
         Raises:
             ValueError: If the URL is not a valid S3 URL
         """
-        if not s3_url.startswith("s3://"):
-            raise ValueError(f"Invalid S3 URL format: {s3_url}")
-
-        parts = s3_url[5:].split("/", 1)
-        if len(parts) != 2:
-            raise ValueError(f"Invalid S3 URI format: {s3_url}")
-
-        parsed = urlparse(s3_url)
-        bucket = parsed.netloc
-        # Remove leading slash from key
-        key = parsed.path.lstrip("/")
-
+        bucket, key = parse_s3_uri(s3_url)
         return bucket, key

--- a/lib/idp_common_pkg/tests/unit/test_document_compression.py
+++ b/lib/idp_common_pkg/tests/unit/test_document_compression.py
@@ -330,3 +330,26 @@ class TestDocumentCompression:
 
         assert ocr_doc.status == Status.CLASSIFYING  # Original status
         assert extraction_doc.status == Status.EXTRACTING  # Modified status
+
+    @mock_aws
+    def test_decompress_key_with_hash(self):
+        """Compress→decompress round-trip must preserve S3 keys that contain '#'.
+
+        urlparse treats '#' as a URL fragment delimiter and silently truncates
+        the key at that character. parse_s3_uri uses str.split and is safe.
+        """
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=self.bucket)
+
+        hash_doc = Document(
+            id="hash-doc-001",
+            input_bucket="input-bucket",
+            input_key="incoming/invoices/invoice #123.pdf",
+            output_bucket="output-bucket",
+            status=Status.CLASSIFYING,
+        )
+
+        compressed_data = hash_doc.compress(self.bucket, "ocr")
+        restored = Document.decompress(self.bucket, compressed_data)
+
+        assert restored.input_key == "incoming/invoices/invoice #123.pdf"

--- a/lib/idp_common_pkg/tests/unit/test_s3util.py
+++ b/lib/idp_common_pkg/tests/unit/test_s3util.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Unit tests for S3Util — specifically s3_url_to_bucket_key.
+"""
+
+import pytest
+from idp_common.utils.s3util import S3Util
+
+
+class TestS3UtilParsing:
+    """Test S3Util.s3_url_to_bucket_key URI parsing."""
+
+    def test_s3_url_to_bucket_key_plain(self):
+        """Plain S3 URI parses correctly."""
+        bucket, key = S3Util.s3_url_to_bucket_key("s3://my-bucket/path/to/document.pdf")
+        assert bucket == "my-bucket"
+        assert key == "path/to/document.pdf"
+
+    def test_s3_url_to_bucket_key_with_hash(self):
+        """S3 URI whose key contains '#' must not be truncated.
+
+        urlparse treats '#' as a URL fragment delimiter and silently drops
+        everything from '#' onward. parse_s3_uri uses str.split and is safe.
+        """
+        bucket, key = S3Util.s3_url_to_bucket_key("s3://my-bucket/path/file #99.pdf")
+        assert bucket == "my-bucket"
+        assert key == "path/file #99.pdf"
+
+    def test_s3_url_to_bucket_key_invalid_scheme(self):
+        """Non-S3 URI raises ValueError."""
+        with pytest.raises(ValueError):
+            S3Util.s3_url_to_bucket_key("https://my-bucket/path/file.pdf")


### PR DESCRIPTION
## Summary

`urlparse` treats `#` as a URL fragment delimiter (RFC 3986), silently truncating S3 keys at that character. Documents with `#` in their filenames cause `NoSuchKey` errors in every Lambda pipeline stage that calls `Document.decompress()` or `S3Util.s3_url_to_bucket_key()`.

The fix replaces all three `urlparse`-on-S3-URI call sites with the existing `parse_s3_uri()` utility (`idp_common.utils`), which uses `str.split("/", 3)` and is not subject to fragment parsing.

## Affected call sites

| File | Symbol | Impact |
|---|---|---|
| `idp_common/models.py` | `Document.decompress()` | **Primary** — all 12 Lambda handlers call `Document.load_document()` → `decompress()`. Any document with `#` in its filename fails with `NoSuchKey` at every processing stage. |
| `idp_common/utils/s3util.py` | `S3Util.s3_url_to_bucket_key()` | All callers receive a truncated key for `#`-bearing URIs. |
| `idp_common/reporting/save_reporting_data.py` | `SaveReportingData._parse_s3_uri()` | Reporting data for documents with `#` in filenames written to wrong S3 path. |

## Root cause

```python
# BEFORE — urlparse strips everything from '#' onward
parsed_uri = urlparse("s3://bucket/path/invoice #123.pdf")
s3_key = parsed_uri.path.lstrip("/")
# s3_key == "path/invoice "  ← truncated, causes NoSuchKey
```

```python
# AFTER — parse_s3_uri uses str.split, safe for any key character
_, s3_key = parse_s3_uri("s3://bucket/path/invoice #123.pdf")
# s3_key == "path/invoice #123.pdf"  ✓
```

`parse_s3_uri` already exists in `idp_common.utils` (`utils/__init__.py` lines 52–71) and validates the `s3://` prefix with a `ValueError` on malformed input.

## Tests added

- `test_document_compression.py::TestDocumentCompression::test_decompress_key_with_hash` — full `compress → decompress` round-trip with `#` in `input_key`; asserts recovered key is untruncated.
- `test_s3util.py::TestS3UtilParsing::test_s3_url_to_bucket_key_with_hash` — asserts `S3Util.s3_url_to_bucket_key` returns the full key including `#`.
- Regression tests for plain URIs (no `#`) confirm no behavior change on normal inputs.

## Test plan

- [ ] `cd lib/idp_common_pkg && python -m pytest tests/unit/test_document_compression.py tests/unit/test_s3util.py -v`
- [ ] `make lint` (ruff) — no new violations
- [ ] `make test` — full suite green

## Notes

- `%23`-percent-encoded filenames are a separate concern and out of scope for this PR.
- Truncated keys stored in DynamoDB job-state rows before this fix are not remediated here — those would require a separate data-cleanup pass.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)