### PR TITLE
fix(ci): Step 8 Nuveen config must set extraction.mode: advanced (agentic silently disabled)

### DIFF
--- a/lib/idp_common_pkg/tests/unit/config/test_merge_migration_order.py
+++ b/lib/idp_common_pkg/tests/unit/config/test_merge_migration_order.py
@@ -139,5 +139,42 @@ class TestHandleUpdateMigratesBeforeMerge:
         _assert_customizations_survived(saved["config"])
 
 
+class TestAgenticEnabledRequiresMode:
+    """Regression for the Step-8 Nuveen timeout: a config that sets
+    ``extraction.agentic.enabled: true`` but omits ``extraction.mode`` has its
+    ``agentic.enabled`` SILENTLY reset to False on upload.
+
+    In v0.6 ``extraction.mode`` is authoritative and ``agentic.enabled`` is
+    derived from it (ExtractionConfig.reconcile_mode_and_agentic). When the
+    delta omits ``mode``, the merge inherits the default's ``mode: simple``,
+    which then forces ``agentic.enabled=False`` — overriding the ``true`` the
+    author intended. The whole doc then runs traditional single-pass extraction
+    and (for a large 17-page/532-row doc) times out the 900s Lambda.
+
+    The fix is to set ``extraction.mode: advanced`` in the config; these tests
+    pin that contract so the footgun is caught if the config regresses.
+    """
+
+    def test_agentic_enabled_without_mode_is_silently_disabled(self):
+        """Documents the footgun: agentic.enabled=true + no mode -> disabled."""
+        merged = merge_config_with_defaults(
+            {"extraction": {"agentic": {"enabled": True}}}, pattern="pattern-2"
+        )
+        cfg = IDPConfig(**merged)
+        # The default's mode ('simple') wins and disables agentic.
+        assert cfg.extraction.mode == "simple"
+        assert cfg.extraction.agentic.enabled is False
+
+    def test_mode_advanced_keeps_agentic_enabled(self):
+        """The fix: mode=advanced makes agentic.enabled survive the merge."""
+        merged = merge_config_with_defaults(
+            {"extraction": {"mode": "advanced", "agentic": {"enabled": True}}},
+            pattern="pattern-2",
+        )
+        cfg = IDPConfig(**merged)
+        assert cfg.extraction.mode == "advanced"
+        assert cfg.extraction.agentic.enabled is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/scripts/sdlc/config/nuveen.yaml
+++ b/scripts/sdlc/config/nuveen.yaml
@@ -90,6 +90,7 @@ classification:
     dpi: null
     preprocessing: null
 extraction:
+  mode: advanced
   model: us.anthropic.claude-sonnet-4-6
   model_lambda_hook_arn: null
   system_prompt: >-


### PR DESCRIPTION
## Root cause
The CI Step 8 config `scripts/sdlc/config/nuveen.yaml` set `extraction.agentic.enabled: true` but **omitted `extraction.mode`**. In v0.6 `extraction.mode` is the authoritative control and `agentic.enabled` is *derived* from it (`ExtractionConfig.reconcile_mode_and_agentic`). `config-upload` deep-merges the delta onto the **default** config (`mode: simple`); with no `mode` in the delta, the merge inherits `simple`, and the validator then **silently flips `agentic.enabled` → false**.

So the stored `Config#agentic-nuveen` ran the **traditional single-pass** path — never touching the deterministic table parser — attaching all 17 page images and issuing one `max_tokens: 128000` Converse call that never returned → `Sandbox.Timedout` at 900s, retried ×3, no results. This is why Step 8 was disabled.

The table parser and its ≥50-row pre-flight gate were **never** the problem — verified by running `parse_markdown_tables` on the failed run's real OCR: `status: success`, 16 tables, 549 rows, in milliseconds.

## Fix
One line in `nuveen.yaml`: `extraction.mode: advanced` (the authoritative v0.6 control; keeps `agentic.enabled` through the merge). Plus a regression test (`test_merge_migration_order.py::TestAgenticEnabledRequiresMode`) pinning the contract.

## Live validation (IDPBenchmark, dev17)
Ran the actual Nuveen extraction with the fixed config:
- **Completed in ~7 min end-to-end** (extraction 305s, well under the 900s cap; old path timed out ×3).
- `document_class: Estimated2024AnnualTaxableDistributions` ✓, `FundInformation` length **532** ✓.
- Logs confirm the fast path: *"Using Agentic extraction"*, *"Pre-flight table parsing complete"*, lazy-image suppression.

## Scope / follow-ups
- **Step 8 stays disabled** in `codebuild_deployment.py` here — re-enable in a separate change once it's confirmed green in a full pipeline run.
- **Secondary finding (not fixed here):** *any* hand-written config that sets `agentic.enabled` without `mode` hits this silent-override footgun. `nuveen.yaml` was the only affected config in the repo. A durable hardening would be: when a delta sets `agentic.enabled` but omits `mode`, derive `mode` from the delta rather than inheriting the default's. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)