### PR TITLE
fix(govcloud): API Gateway Web UI hosting returns 500 (WebUIProxyRole trust policy)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -10133,13 +10133,14 @@ Resources:
             Principal:
               Service: !Sub "apigateway.${AWS::URLSuffix}"
             Action: sts:AssumeRole
-            # Confused-deputy guard: only API Gateway in THIS account may assume
-            # the role (the role can only read this one private bucket, so the
-            # blast radius is already tiny, but this matches the hardening used
-            # elsewhere in the template).
-            Condition:
-              StringEquals:
-                "aws:SourceAccount": !Ref "AWS::AccountId"
+            # NOTE: do NOT add an aws:SourceAccount / aws:SourceArn confused-deputy
+            # condition here. When API Gateway assumes an *integration credentials*
+            # role for an AWS-service (S3) proxy integration it does NOT populate
+            # aws:SourceAccount in the STS request context, so the condition never
+            # matches and every Web UI request fails with a 500 ("API Gateway does
+            # not have permission to assume the provided role"). The confused-deputy
+            # risk is already negligible: this role can only s3:GetObject from the
+            # single private Web UI bucket (see the WebUIBucketRead policy below).
       PermissionsBoundary:
         !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref AWS::NoValue]
       Policies:


### PR DESCRIPTION
## Summary

With API Gateway Web UI hosting (`WebUIHosting=APIGateway`), **every** Web UI request returned HTTP 500 `{"message": "Internal server error"}` — the app never loaded.

## Root cause

Confirmed via `test-invoke-method` against the live `idp-gc-global` stack:

> Execution failed due to configuration error: API Gateway does not have permission to assume the provided role `...WebUIProxyRole...`

`WebUIProxyRole` (the S3-proxy integration credentials role) had an `aws:SourceAccount` confused-deputy condition on its trust policy. **When API Gateway assumes an *integration credentials* role for an AWS-service (S3) proxy integration, it does not populate `aws:SourceAccount` in the STS request context.** So the `StringEquals` condition never matched, the `AssumeRole` was denied, and the S3 web-UI proxy hard-failed with a 500 on every path (`/`, `/{proxy+}`).

This affects the API Gateway hosting path in all partitions (surfaced during GovCloud testing but not GovCloud-specific).

## Fix

Removed the `aws:SourceAccount` condition from the trust policy. The confused-deputy blast radius is already negligible — the role's only permission is `s3:GetObject` on the single private Web UI bucket (`WebUIBucketRead`). Added a comment warning against re-adding the condition.

## Verification

On the live `idp-gc-global` stack (`https://oirzk4guh1.execute-api.us-west-2.amazonaws.com/api/`), after dropping the condition:

| Path | Before | After |
|------|--------|-------|
| `/api/` (root → index.html) | 500 | **200** `text/html` |
| `/api/index.html` | 500 | **200** `text/html` |
| `/api/assets/*.js` | 500 | **200** `application/javascript` |

`cfn-lint` clean (no new errors); `make check-arn-partitions` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)