### PR TITLE
Fix config CORS preflight 500 + View/Edit Configuration UX improvements

### DIFF
--- a/nested/api-resolvers/template.yaml
+++ b/nested/api-resolvers/template.yaml
@@ -2743,10 +2743,13 @@ Resources:
     Properties:
       Name: !Sub "${StackName}-api"
       # Treat all media as binary so the S3-proxy web-UI routes (ServeWebUI)
-      # can return images/fonts/js/css bytes intact. The JSON /op transport is
-      # unaffected: the dispatcher base64-decodes isBase64Encoded request bodies
-      # (idp_common.api_adapter._parse_body) and returns a JSON string response,
-      # which API Gateway passes through unchanged.
+      # can return images/fonts/js/css bytes intact. The JSON /op POST transport
+      # is unaffected: the dispatcher base64-decodes isBase64Encoded request
+      # bodies (idp_common.api_adapter._parse_body) and returns a JSON string
+      # response, which API Gateway passes through unchanged. The CORS OPTIONS
+      # preflight, however, DOES need CONVERT_TO_TEXT on its MOCK integration
+      # (see HttpApiOptionsMethod) — otherwise */* makes API Gateway try to
+      # base64-encode the empty preflight body and it 500s.
       BinaryMediaTypes:
         - "*/*"
       EndpointConfiguration: !If
@@ -2829,10 +2832,18 @@ Resources:
         method.request.path.field: true
       Integration:
         Type: MOCK
+        # The API sets BinaryMediaTypes: */* (so the S3-proxy web-UI routes can
+        # return raw bytes). Browsers send Accept: */* on the CORS preflight, so
+        # without CONVERT_TO_TEXT API Gateway tries to base64-encode this MOCK
+        # response as binary and the preflight fails with a 500 (which blocks the
+        # subsequent POST with a browser "Failed to fetch"). Forcing text handling
+        # on both the integration and its response keeps the preflight a clean 200.
+        ContentHandling: CONVERT_TO_TEXT
         RequestTemplates:
           application/json: '{"statusCode": 200}'
         IntegrationResponses:
           - StatusCode: "200"
+            ContentHandling: CONVERT_TO_TEXT
             ResponseParameters:
               method.response.header.Access-Control-Allow-Origin: "'*'"
               method.response.header.Access-Control-Allow-Headers: "'authorization,content-type'"

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -24,6 +24,7 @@ const AppContent = (): React.JSX.Element => {
   const { authStatus: authState, user } = useAuthenticator((context) => [context.authStatus, context.user]);
   const { currentSession, currentCredentials } = useCurrentSessionCreds({});
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const [successMessage, setSuccessMessage] = useState<string | undefined>();
   const [navigationOpen, setNavigationOpen] = useState<boolean>(true);
   const [activeTestRuns, setActiveTestRuns] = useState<AppActiveTestRun[]>([]);
 
@@ -39,9 +40,11 @@ const AppContent = (): React.JSX.Element => {
     authState,
     awsConfig,
     errorMessage,
+    successMessage,
     currentCredentials,
     currentSession,
     setErrorMessage,
+    setSuccessMessage,
     user,
     navigationOpen,
     setNavigationOpen,

--- a/src/ui/src/components/configuration-layout/ConfigBuilder.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigBuilder.tsx
@@ -18,6 +18,7 @@ import {
   ExpandableSection,
   Modal,
   Tabs,
+  Alert,
 } from '@cloudscape-design/components';
 import type { BoxProps } from '@cloudscape-design/components';
 import SchemaBuilder from '../json-schema-builder/SchemaBuilder';
@@ -1650,7 +1651,26 @@ const ConfigBuilder = ({
         </SpaceBetween>
       );
     } else if (property.type === 'boolean') {
-      input = <Toggle checked={!!displayValue} onChange={({ detail }) => updateValue(path, detail.checked)} />;
+      // The use_bda toggle changes the entire pipeline shape (Textract-based
+      // OCR/Classification/Extraction vs. Bedrock Data Automation). Surface an
+      // inline warning (S4) when the pending value differs from what's saved, so
+      // the large section swap isn't a silent surprise.
+      const isUseBda = path === 'use_bda';
+      const savedUseBda = isUseBda && mergedConfig ? !!getValueAtPath(mergedConfig, 'use_bda') : undefined;
+      const useBdaChanged = isUseBda && savedUseBda !== undefined && savedUseBda !== !!displayValue;
+      const toggle = <Toggle checked={!!displayValue} onChange={({ detail }) => updateValue(path, detail.checked)} />;
+      input = useBdaChanged ? (
+        <SpaceBetween size="xs">
+          {toggle}
+          <Alert type="warning">
+            {displayValue
+              ? 'Switching to BDA mode replaces the Textract OCR / Classification / Extraction steps with Bedrock Data Automation. Those sections are hidden and BDA settings apply instead. Save to keep this change.'
+              : 'Switching off BDA mode restores the Textract-based OCR / Classification / Extraction pipeline and hides the BDA settings. Save to keep this change.'}
+          </Alert>
+        </SpaceBetween>
+      ) : (
+        toggle
+      );
     } else if (property.type === 'array' || property.type === 'list') {
       // This should not happen if renderField is working correctly
       console.error(`Incorrectly trying to render array as input field: ${path}`);

--- a/src/ui/src/components/configuration-layout/ConfigBuilder.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigBuilder.tsx
@@ -539,6 +539,10 @@ const ConfigBuilder = ({
   // For handling dropdown selection in modal
   const [showNameAsDropdown, setShowNameAsDropdown] = useState(false);
 
+  // State for the "expand editor" modal used to edit large text (e.g. prompts) in a
+  // roomy full-height textarea instead of the cramped inline field.
+  const [expandEditor, setExpandEditor] = useState<{ path: string; label: string } | null>(null);
+
   // State for tab selection - use controlled props if provided, otherwise local state
   const [localActiveTabId, setLocalActiveTabId] = useState('configuration');
   const activeTabId = onTabChange ? controlledActiveTabId : localActiveTabId;
@@ -744,23 +748,10 @@ const ConfigBuilder = ({
     onChange?.(newValues);
   };
 
-  // Debug: Check if isCustomized function is properly passed
-  console.log('ConfigBuilder received isCustomized:', typeof isCustomized, !!isCustomized);
-
   // Define renderField first as a function declaration
   function renderField(key: string, property: SchemaProperty, path = ''): React.JSX.Element | null {
     const currentPath = path ? `${path}.${key}` : key;
     const value = getValueAtPath(formValues, currentPath);
-
-    // Add debugging for granular assessment
-    if (currentPath.includes('granular')) {
-      console.log(`DEBUG: Rendering granular field '${key}' at path '${currentPath}':`, {
-        // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
-        property,
-        value,
-        formValues: getValueAtPath(formValues, 'extraction.confidence'),
-      });
-    }
 
     // For objects with properties, ensure the object exists in formValues.
     // Exception: a `ghostGroup` object is a purely visual grouping whose own
@@ -836,21 +827,6 @@ const ConfigBuilder = ({
       // Get the current value of the dependency field
       const dependencyValue = getValueAtPath(formValues, dependencyPath);
 
-      // Enhanced debug logging for dependency checking
-      console.log(`DEBUG renderField dependency check for ${key}:`, {
-        // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
-        key,
-        currentPath,
-        dependencyField,
-        dependencyPath,
-        dependencyValue,
-        dependencyValueType: typeof dependencyValue,
-        dependencyValues,
-        dependencyValuesTypes: dependencyValues.map((v) => typeof v),
-        isNestedAttribute: currentPath.includes('groupAttributes[') || currentPath.includes('listItemTemplate.itemAttributes['),
-        shouldHide: dependencyValue === undefined || !dependencyValues.includes(dependencyValue),
-      });
-
       // Special handling for boolean dependencies
       let normalizedDependencyValue = dependencyValue;
       let normalizedDependencyValues = dependencyValues;
@@ -899,12 +875,6 @@ const ConfigBuilder = ({
         }
       } else if (normalizedDependencyValue === undefined || !normalizedDependencyValues.includes(normalizedDependencyValue)) {
         // If dependency value doesn't match any required values, hide this field
-        console.log(`Hiding field ${key} due to dependency mismatch:`, {
-          // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Data from trusted internal source only
-          normalizedDependencyValue,
-          normalizedDependencyValues,
-          includes: normalizedDependencyValues.includes(normalizedDependencyValue),
-        });
         return null; // Don't render this field
       }
     }
@@ -1107,7 +1077,6 @@ const ConfigBuilder = ({
     const values = (getValueAtPath(formValues, path) || []) as Record<string, unknown>[];
 
     // Add debug info
-    console.log(`Rendering list field: ${key}, type: ${property.type}, path: ${path}`, property, values); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
 
     // Get list item display settings from schema metadata
     const columnCount = property.columns ? parseInt(String(property.columns), 10) : 2;
@@ -1315,16 +1284,6 @@ const ConfigBuilder = ({
                           }
                         });
 
-                        // Add debugging to see field distribution
-                        console.log(`Field distribution for ${key}:`, {
-                          // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
-                          totalProperties: propEntries.length,
-                          requestedColumns: columnCount,
-                          visibleRegularFields: regularProps.length,
-                          specialFields: specialProps.length,
-                          hiddenByDependencies: propEntries.length - regularProps.length - specialProps.length,
-                        });
-
                         // Enhanced column distribution algorithm - only for visible fields
                         const distributeFieldsToColumns = (
                           fields: { propKey: string; propSchema: SchemaProperty }[],
@@ -1371,16 +1330,6 @@ const ConfigBuilder = ({
 
                         // Calculate maximum rows needed
                         const maxRows = Math.max(...fieldColumns.map((col) => col.length));
-
-                        // Validation and debugging for field distribution
-                        console.log(`Distribution result for ${key}:`, {
-                          // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
-                          actualColumnCount,
-                          maxRows,
-                          columnLengths: fieldColumns.map((col) => col.length),
-                          totalFieldsDistributed: fieldColumns.reduce((sum, col) => sum + col.length, 0),
-                          hasDescription: !!descriptionField,
-                        });
 
                         // Render the regular fields using HTML table for guaranteed columns
                         const renderedRegularFields = (
@@ -1568,14 +1517,12 @@ const ConfigBuilder = ({
 
     // If this is an object type, it should be rendered as an object field, not an input field
     if (property.type === 'object') {
-      console.log(`Redirecting object type ${key} to renderObjectField`); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
       return renderObjectField(key, property, path.substring(0, path.lastIndexOf('.')) || '') ?? <></>;
     }
 
     let input;
 
     // Add debug info
-    console.log(`Rendering input field: ${key}, type: ${property.type}, path: ${path}`, { property, value }); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
 
     // Check if we're trying to render an array as an input field (which would be incorrect)
     if (Array.isArray(value) && (property.type === 'array' || property.type === 'list')) {
@@ -1628,13 +1575,11 @@ const ConfigBuilder = ({
         const result = onResetToDefault(path) as unknown as { path: string; defaultValue: unknown } | void;
         if (result && (result as { defaultValue: unknown }).defaultValue !== undefined) {
           updateValue((result as { path: string }).path, (result as { defaultValue: unknown }).defaultValue);
-          console.log(`Restored default value for ${path} (unsaved - click Save to persist)`); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Data from trusted internal source only
         } else if (defaultConfig) {
           // Fallback: get default value directly
           const defaultValue = getValueAtPath(defaultConfig, path);
           if (defaultValue !== undefined) {
             updateValue(path, defaultValue);
-            console.log(`Restored default value for ${path} from defaultConfig`); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Data from trusted internal source only
           }
         }
       } else if (defaultConfig) {
@@ -1642,7 +1587,6 @@ const ConfigBuilder = ({
         const defaultValue = getValueAtPath(defaultConfig, path);
         if (defaultValue !== undefined) {
           updateValue(path, defaultValue);
-          console.log(`Restored default value for ${path} from defaultConfig`); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Data from trusted internal source only
         }
       }
     };
@@ -1680,13 +1624,30 @@ const ConfigBuilder = ({
         path.toLowerCase().includes('prompt') ||
         path.toLowerCase().includes('description'))
     ) {
+      // Prompt fields hold large, structured text (placeholders, <<CACHEPOINT>>),
+      // so give them more rows and an "Expand editor" affordance that opens a
+      // roomy full-height editor modal. Plain descriptions stay compact.
+      const isPromptField = path.toLowerCase().includes('prompt');
       input = (
-        <Textarea
-          value={displayValue !== undefined && displayValue !== null ? String(displayValue) : ''}
-          onChange={({ detail }) => updateValue(path, detail.value)}
-          rows={3}
-          className="expandable-textarea"
-        />
+        <SpaceBetween size="xxs">
+          <Textarea
+            value={displayValue !== undefined && displayValue !== null ? String(displayValue) : ''}
+            onChange={({ detail }) => updateValue(path, detail.value)}
+            rows={isPromptField ? 8 : 3}
+            className="expandable-textarea"
+          />
+          {isPromptField && (
+            <Box textAlign="right">
+              <Button
+                variant="inline-link"
+                iconName="expand"
+                onClick={() => setExpandEditor({ path, label: getFieldLabel(key, property) })}
+              >
+                Expand editor
+              </Button>
+            </Box>
+          )}
+        </SpaceBetween>
       );
     } else if (property.type === 'boolean') {
       input = <Toggle checked={!!displayValue} onChange={({ detail }) => updateValue(path, detail.checked)} />;
@@ -1786,12 +1747,6 @@ const ConfigBuilder = ({
 
   // Render each top-level property
   const renderTopLevelProperty = ({ key, property }: { key: string; property: SchemaProperty }) => {
-    // Debug info for sections
-    console.log(
-      `Rendering top level property: ${key}, type: ${property.type}, sectionLabel: ${property.sectionLabel}`, // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
-      property,
-    );
-
     // Check top-level dependsOn before rendering (hides entire sections when dependency not met)
     if (property.dependsOn) {
       const depField = property.dependsOn.field;
@@ -1819,7 +1774,6 @@ const ConfigBuilder = ({
       // exposes native slots: ExpandableSection.headerDescription and
       // Header.description.
       const sectionDescription = property.description as string | undefined;
-      console.log(`Creating section container for ${key} with title: ${sectionTitle}`); // nosemgrep: javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring - Debug logging with controlled internal data
 
       // Support collapsible top-level sections via schema property `collapsible: true`
       // defaultExpanded controls whether section starts expanded (defaults to true for backward compat)
@@ -2000,6 +1954,33 @@ const ConfigBuilder = ({
               />
             )}
           </FormField>
+        )}
+      </Modal>
+
+      {/* Expand editor for large text fields (prompts): a roomy full-height editor
+          that writes straight back to the same form path as the inline textarea. */}
+      <Modal
+        visible={!!expandEditor}
+        onDismiss={() => setExpandEditor(null)}
+        size="max"
+        header={expandEditor ? `Edit ${expandEditor.label}` : 'Edit'}
+        footer={
+          <ExtBox float="right">
+            <Button variant="primary" onClick={() => setExpandEditor(null)}>
+              Done
+            </Button>
+          </ExtBox>
+        }
+      >
+        {expandEditor && (
+          <Textarea
+            value={((): string => {
+              const v = getValueAtPath(formValues, expandEditor.path);
+              return v !== undefined && v !== null ? String(v) : '';
+            })()}
+            onChange={({ detail }) => updateValue(expandEditor.path, detail.value)}
+            rows={28}
+          />
         )}
       </Modal>
     </ExtBox>

--- a/src/ui/src/components/configuration-layout/ConfigurationComparison.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationComparison.tsx
@@ -224,10 +224,6 @@ const ConfigurationComparison = ({ versions, configs }: ConfigurationComparisonP
     URL.revokeObjectURL(url);
   };
 
-  // Debug logging
-  console.log('Configs received:', configs);
-  console.log('Differences found:', differences);
-
   // Create column definitions with equal width distribution
   const totalColumns = versions.length + 1; // +1 for field column
   const equalWidth = Math.floor(100 / totalColumns);

--- a/src/ui/src/components/configuration-layout/ConfigurationComparison.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationComparison.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
+/* eslint-disable react/no-array-index-key */
+
 import React from 'react';
 import { Table, Box, SpaceBetween, Badge, Header, ButtonDropdown } from '@cloudscape-design/components';
 
@@ -8,6 +10,95 @@ interface ConfigurationComparisonProps {
   versions: string[];
   configs: Record<string, unknown>;
 }
+
+// --- Word-level diff (used when exactly two versions are compared) -----------
+// Tokenize keeping whitespace so re-joined output is faithful to the original.
+const tokenize = (s: string): string[] => s.match(/\s+|\S+/g) ?? [];
+
+type DiffToken = { value: string; type: 'common' | 'removed' | 'added' };
+
+// Longest-common-subsequence word diff. Skipped for very large inputs to avoid
+// the O(n*m) table blowing up (falls back to plain full-text rendering).
+const MAX_DIFF_TOKENS = 4000;
+const diffTokens = (a: string, b: string): DiffToken[] | null => {
+  const at = tokenize(a);
+  const bt = tokenize(b);
+  if (at.length > MAX_DIFF_TOKENS || bt.length > MAX_DIFF_TOKENS) return null;
+
+  const n = at.length;
+  const m = bt.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      dp[i][j] = at[i] === bt[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out: DiffToken[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (at[i] === bt[j]) {
+      out.push({ value: at[i], type: 'common' });
+      i += 1;
+      j += 1;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ value: at[i], type: 'removed' });
+      i += 1;
+    } else {
+      out.push({ value: bt[j], type: 'added' });
+      j += 1;
+    }
+  }
+  while (i < n) {
+    out.push({ value: at[i], type: 'removed' });
+    i += 1;
+  }
+  while (j < m) {
+    out.push({ value: bt[j], type: 'added' });
+    j += 1;
+  }
+  return out;
+};
+
+// Render one side of a two-version diff: `side='left'` shows common + removed
+// tokens (what the first version has), `side='right'` shows common + added.
+const renderDiffSide = (tokens: DiffToken[], side: 'left' | 'right'): React.ReactNode => {
+  const dropType = side === 'left' ? 'added' : 'removed';
+  const markType = side === 'left' ? 'removed' : 'added';
+  const markStyle: React.CSSProperties =
+    side === 'left'
+      ? { backgroundColor: '#fdd8d8', textDecoration: 'line-through', color: '#8b0000' }
+      : { backgroundColor: '#d6f5d6', color: '#0a5a0a' };
+  return (
+    <Box>
+      <span style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'monospace', fontSize: '12px' }}>
+        {tokens
+          .filter((t) => t.type !== dropType)
+
+          .map((t, idx) =>
+            t.type === markType ? (
+              <mark key={idx} style={markStyle}>
+                {t.value}
+              </mark>
+            ) : (
+              <span key={idx}>{t.value}</span>
+            ),
+          )}
+      </span>
+    </Box>
+  );
+};
+
+// Scrollable, wrapping container for full-length text/JSON values (no truncation).
+const scrollBoxStyle: React.CSSProperties = {
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  fontFamily: 'monospace',
+  fontSize: '12px',
+  maxHeight: '240px',
+  overflow: 'auto',
+  display: 'block',
+};
 
 const ConfigurationComparison = ({ versions, configs }: ConfigurationComparisonProps): React.JSX.Element => {
   // Safety checks
@@ -157,33 +248,46 @@ const ConfigurationComparison = ({ versions, configs }: ConfigurationComparisonP
     return differences.sort((a, b) => a.field.localeCompare(b.field));
   };
 
-  // Format value for display
+  // Pretty-print a stored comparison string: if it's JSON, expand it with
+  // indentation; otherwise return as-is. Keeps full content (no truncation).
+  const prettify = (value: string): string => {
+    if ((value.startsWith('{') && value.endsWith('}')) || (value.startsWith('[') && value.endsWith(']'))) {
+      try {
+        return JSON.stringify(JSON.parse(value), null, 2);
+      } catch {
+        // not valid JSON — fall through
+      }
+    }
+    return value;
+  };
+
+  // Format a single value for display (used for 3+ version comparisons, where a
+  // pairwise diff doesn't apply). Shows the full value in a scrollable box.
   const formatValue = (value: unknown): React.ReactNode => {
     if (value === '<missing>') return <Badge color="grey">Missing</Badge>;
     if (value === undefined) return <Badge color="grey">Not set</Badge>;
     if (value === null) return <Badge color="grey">null</Badge>;
     if (typeof value === 'boolean') return value ? 'true' : 'false';
-    // Handle JSON-stringified arrays/objects from deep diff
-    if (typeof value === 'string' && value.startsWith('[') && value.endsWith(']')) {
-      try {
-        const parsed = JSON.parse(value);
-        if (Array.isArray(parsed)) return `[${parsed.length} items]`;
-      } catch {
-        // Not valid JSON, display as-is
-      }
-    }
-    if (typeof value === 'string' && value.startsWith('{') && value.endsWith('}')) {
-      try {
-        JSON.parse(value);
-        // Truncate long JSON objects for display
-        return value.length > 80 ? `${value.substring(0, 77)}...` : value;
-      } catch {
-        // Not valid JSON, display as-is
-      }
-    }
-    if (Array.isArray(value)) return `[${value.length} items]`;
-    if (typeof value === 'object') return '[Object]';
-    return String(value);
+    const text = prettify(String(value));
+    return <span style={scrollBoxStyle}>{text}</span>;
+  };
+
+  // Whether a stored value is "present" (renders as an absence badge otherwise).
+  const isAbsent = (value: string): boolean => value === '<missing>';
+
+  // Render a diff cell for the two-version case. `side` picks which version's
+  // perspective this column shows.
+  const renderDiffCell = (item: { field: string; values: Record<string, string> }, side: 'left' | 'right'): React.ReactNode => {
+    const [va, vb] = versions;
+    const aVal = item.values[va];
+    const bVal = item.values[vb];
+    const own = side === 'left' ? aVal : bVal;
+    if (isAbsent(own)) return <Badge color="grey">Missing</Badge>;
+    // If either side is missing, there's nothing to diff against — show full value.
+    if (isAbsent(aVal) || isAbsent(bVal)) return <span style={scrollBoxStyle}>{prettify(own)}</span>;
+    const tokens = diffTokens(prettify(aVal), prettify(bVal));
+    if (!tokens) return <span style={scrollBoxStyle}>{prettify(own)}</span>;
+    return <Box>{renderDiffSide(tokens, side)}</Box>;
   };
 
   // Now configs are already merged, no need to parse old format
@@ -228,6 +332,10 @@ const ConfigurationComparison = ({ versions, configs }: ConfigurationComparisonP
   const totalColumns = versions.length + 1; // +1 for field column
   const equalWidth = Math.floor(100 / totalColumns);
 
+  // Two-version comparisons get a word-level diff (added=green, removed=red);
+  // 3+ versions fall back to showing each full value side by side.
+  const isPairwiseDiff = versions.length === 2;
+
   const columnDefinitions = [
     {
       id: 'field',
@@ -236,10 +344,11 @@ const ConfigurationComparison = ({ versions, configs }: ConfigurationComparisonP
       sortingField: 'field',
       width: `${equalWidth}%`,
     },
-    ...versions.map((version) => ({
+    ...versions.map((version, index) => ({
       id: version,
       header: version,
-      cell: (item: { field: string; values: Record<string, string> }) => formatValue(item.values[version]),
+      cell: (item: { field: string; values: Record<string, string> }) =>
+        isPairwiseDiff ? renderDiffCell(item, index === 0 ? 'left' : 'right') : formatValue(item.values[version]),
       width: `${equalWidth}%`,
     })),
   ];

--- a/src/ui/src/components/configuration-layout/ConfigurationLayout.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationLayout.tsx
@@ -8,6 +8,7 @@ import {
   SpaceBetween,
   Box,
   Button,
+  ButtonDropdown,
   Alert,
   Spinner,
   Form,
@@ -41,6 +42,10 @@ import { parseConfigurationData } from '../../graphql/awsjson-parsers';
 
 const client = generateClient();
 const logger = new ConsoleLogger('ConfigurationLayout');
+
+// Shown as the disabled-reason tooltip on actions that cannot run against the
+// stack-managed `default` version (the user must first create an editable copy).
+const STACK_MANAGED_DISABLED_REASON = 'This is the stack-managed default version — use Save as Version to create an editable copy.';
 
 // Utility function to normalize boolean values from strings (same as use-configuration.js)
 interface SchemaProperty {
@@ -153,7 +158,9 @@ const ConfigurationLayout = (): React.JSX.Element => {
   const [selectedVersionsForCompare, setSelectedVersionsForCompare] = useState<string[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(getInitialVersionFromUrl);
   const location = useLocation();
-  const [versionsTableExpanded, setVersionsTableExpanded] = useState(false);
+  // Expanded by default so the version list — central to the config mental model —
+  // is visible on arrival (users pick / create / compare versions from here).
+  const [versionsTableExpanded, setVersionsTableExpanded] = useState(true);
 
   // Import as new version state
   const [importedConfigForNewVersion, setImportedConfigForNewVersion] = useState<Record<string, unknown> | null>(null);
@@ -594,13 +601,15 @@ const ConfigurationLayout = (): React.JSX.Element => {
         e.returnValue = '';
       }
     };
-    const handleHashChange = (): void => {
+    const handleHashChange = (e: HashChangeEvent): void => {
       // For SPA hash-based routing, intercept navigation when there are unsaved changes
       if (hasUnsavedChanges) {
         const confirmed = window.confirm('You have unsaved configuration changes. Are you sure you want to leave?');
         if (!confirmed) {
-          // Restore the hash to the config page
-          window.history.pushState(null, '', `${window.location.pathname}#/documents/config`);
+          // Restore the exact URL the user was on (e.oldURL preserves ?version= / ?tab=
+          // deep-link params) rather than bouncing them to the base config route.
+          // pushState does not re-fire hashchange, so this won't loop.
+          window.history.pushState(null, '', e.oldURL);
         }
       }
     };
@@ -655,6 +664,14 @@ const ConfigurationLayout = (): React.JSX.Element => {
 
   // Rule Schema/Validation is available in all modes (Unified, Pattern2, etc.) - only excluded for Pattern1-only
   const showRuleSchema = !isPattern1;
+
+  // BDA sync actions are only relevant when this is a BDA/Pattern-1 configuration.
+  const isBdaConfigActive = Boolean(isPattern1 || mergedConfig?.use_bda || formValues?.use_bda);
+
+  // Explains, on hover, why the primary Save changes button is disabled for
+  // stack-managed / default versions (mirrors the button's disabled condition).
+  const saveChangesDisabledReason =
+    currentVersionName === 'default' || currentVersion?.managed === true ? STACK_MANAGED_DISABLED_REASON : undefined;
 
   // Initialize form values from merged config
   useEffect(() => {
@@ -2292,83 +2309,112 @@ const ConfigurationLayout = (): React.JSX.Element => {
                     Format YAML
                   </Button>
                 )}
-                <Button variant="normal" onClick={() => setShowExportModal(true)}>
-                  Export
-                </Button>
                 <input id="import-file" type="file" accept=".json,.yaml,.yml" style={{ display: 'none' }} onChange={handleImport} />
                 <Button variant="normal" onClick={() => fetchConfiguration(currentVersionName)} loading={refreshing} iconName="refresh">
                   Refresh
                 </Button>
-                {Boolean(isPattern1 || mergedConfig?.use_bda || formValues?.use_bda) && (
-                  <>
-                    <span title={hasUnsavedChanges ? 'Save your changes first' : undefined}>
-                      <Button
-                        variant="normal"
-                        onClick={() => {
-                          setSyncFromBdaArnInput('');
-                          setSyncFromBdaMode('replace');
-                          setShowSyncFromBdaModal(true);
-                        }}
-                        loading={syncingDirection === 'bda_to_idp'}
-                        disabled={hasUnsavedChanges}
-                      >
-                        Sync from BDA
-                      </Button>
-                    </span>
-                    <span title={hasUnsavedChanges ? 'Save your changes first' : undefined}>
-                      <Button
-                        variant="normal"
-                        onClick={() => {
-                          setBdaSyncMode(currentVersion?.bdaProjectArn ? 'linked' : 'create');
-                          setShowSyncToBdaConfirmModal(true);
-                        }}
-                        loading={syncingDirection === 'idp_to_bda'}
-                        disabled={hasUnsavedChanges}
-                      >
-                        Sync to BDA
-                      </Button>
-                    </span>
-                  </>
-                )}
-                {canWrite && (
-                  <Button variant="normal" onClick={() => setShowResetModal(true)} disabled={currentVersionName === 'default'}>
-                    Restore default (All)
-                  </Button>
-                )}
-                {/* Save as default - Admin only */}
-                {isAdmin && (
-                  <Button variant="normal" onClick={() => setShowSaveAsDefaultModal(true)} disabled={currentVersionName === 'default'}>
-                    Save as default
-                  </Button>
-                )}
-                {isAdmin && (
-                  <Button
-                    variant="normal"
-                    onClick={() => {
-                      setSaveAsVersionName(`${currentVersionName}-copy`);
-                      setSaveAsVersionDescription(currentVersion?.description ? `${currentVersion.description} - copy` : '');
-                      setShowSaveAsVersionModal(true);
-                    }}
-                    disabled={validationErrors.length > 0}
-                  >
-                    Save as Version
-                  </Button>
-                )}
-                {/* Save changes - hidden for read-only users, disabled on default or managed versions */}
-                {canWrite && (
-                  <Button
-                    variant="primary"
-                    onClick={() => handleSave(false)}
-                    loading={isSaving}
-                    disabled={
-                      !hasUnsavedChanges ||
-                      validationErrors.length > 0 ||
-                      currentVersionName === 'default' ||
-                      currentVersion?.managed === true
+                {/* Secondary / less-frequent actions grouped into a single menu to keep the
+                    action bar scannable. Disabled items carry a disabledReason tooltip. */}
+                <ButtonDropdown
+                  items={[
+                    { id: 'export', text: 'Export…' },
+                    ...(isBdaConfigActive
+                      ? [
+                          {
+                            id: 'sync-from-bda',
+                            text: 'Sync from BDA…',
+                            disabled: hasUnsavedChanges,
+                            disabledReason: 'Save your changes first',
+                          },
+                          {
+                            id: 'sync-to-bda',
+                            text: 'Sync to BDA…',
+                            disabled: hasUnsavedChanges,
+                            disabledReason: 'Save your changes first',
+                          },
+                        ]
+                      : []),
+                    ...(isAdmin
+                      ? [
+                          {
+                            id: 'save-as-version',
+                            text: 'Save as Version…',
+                            disabled: validationErrors.length > 0,
+                            disabledReason: 'Resolve validation errors first',
+                          },
+                        ]
+                      : []),
+                    ...(canWrite
+                      ? [
+                          {
+                            id: 'restore-default-all',
+                            text: 'Restore default (All)',
+                            disabled: currentVersionName === 'default',
+                            disabledReason: STACK_MANAGED_DISABLED_REASON,
+                          },
+                        ]
+                      : []),
+                    ...(isAdmin
+                      ? [
+                          {
+                            id: 'save-as-default',
+                            text: 'Save as default…',
+                            disabled: currentVersionName === 'default',
+                            disabledReason: STACK_MANAGED_DISABLED_REASON,
+                          },
+                        ]
+                      : []),
+                  ]}
+                  onItemClick={({ detail }) => {
+                    switch (detail.id) {
+                      case 'export':
+                        setShowExportModal(true);
+                        break;
+                      case 'sync-from-bda':
+                        setSyncFromBdaArnInput('');
+                        setSyncFromBdaMode('replace');
+                        setShowSyncFromBdaModal(true);
+                        break;
+                      case 'sync-to-bda':
+                        setBdaSyncMode(currentVersion?.bdaProjectArn ? 'linked' : 'create');
+                        setShowSyncToBdaConfirmModal(true);
+                        break;
+                      case 'save-as-version':
+                        setSaveAsVersionName(`${currentVersionName}-copy`);
+                        setSaveAsVersionDescription(currentVersion?.description ? `${currentVersion.description} - copy` : '');
+                        setShowSaveAsVersionModal(true);
+                        break;
+                      case 'restore-default-all':
+                        setShowResetModal(true);
+                        break;
+                      case 'save-as-default':
+                        setShowSaveAsDefaultModal(true);
+                        break;
+                      default:
+                        break;
                     }
-                  >
-                    Save changes
-                  </Button>
+                  }}
+                >
+                  Actions
+                </ButtonDropdown>
+                {/* Save changes - hidden for read-only users, disabled on default or managed versions.
+                    A title tooltip explains why it's disabled on stack-managed versions. */}
+                {canWrite && (
+                  <span title={saveChangesDisabledReason}>
+                    <Button
+                      variant="primary"
+                      onClick={() => handleSave(false)}
+                      loading={isSaving}
+                      disabled={
+                        !hasUnsavedChanges ||
+                        validationErrors.length > 0 ||
+                        currentVersionName === 'default' ||
+                        currentVersion?.managed === true
+                      }
+                    >
+                      Save changes
+                    </Button>
+                  </span>
                 )}
               </SpaceBetween>
             }
@@ -2545,7 +2591,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
             </>
           )}
 
-          {hasUnsavedChanges && currentVersionName !== 'default' && (
+          {hasUnsavedChanges && (
             <Alert
               type="info"
               action={
@@ -2554,7 +2600,16 @@ const ConfigurationLayout = (): React.JSX.Element => {
                 </Button>
               }
             >
-              You have unsaved changes. Click <strong>Save changes</strong> to persist, or <strong>Discard changes</strong> to revert.
+              {currentVersionName === 'default' || currentVersion?.managed === true ? (
+                <>
+                  You have unsaved changes to this stack-managed version, which can&rsquo;t be saved directly. Use{' '}
+                  <strong>Save as Version</strong> to keep them as an editable copy, or <strong>Discard changes</strong> to revert.
+                </>
+              ) : (
+                <>
+                  You have unsaved changes. Click <strong>Save changes</strong> to persist, or <strong>Discard changes</strong> to revert.
+                </>
+              )}
             </Alert>
           )}
 

--- a/src/ui/src/components/configuration-layout/ConfigurationLayout.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationLayout.tsx
@@ -33,6 +33,7 @@ import useConfigurationVersions from '../../hooks/use-configuration-versions';
 import useConfigurationLibrary from '../../hooks/use-configuration-library';
 import useUserRole from '../../hooks/use-user-role';
 import useSettingsContext from '../../contexts/settings';
+import useAppContext from '../../contexts/app';
 import ConfigBuilder from './ConfigBuilder';
 import ConfigurationVersionsTable from './ConfigurationVersionsTable';
 import ConfigurationComparison from './ConfigurationComparison';
@@ -46,6 +47,13 @@ const logger = new ConsoleLogger('ConfigurationLayout');
 // Shown as the disabled-reason tooltip on actions that cannot run against the
 // stack-managed `default` version (the user must first create an editable copy).
 const STACK_MANAGED_DISABLED_REASON = 'This is the stack-managed default version — use Save as Version to create an editable copy.';
+
+// One-line explanations shown on hover for the version Type/state badges.
+const BADGE_TOOLTIPS = {
+  managed: 'Stack-managed: shipped with the solution and overwritten on stack updates; not directly editable.',
+  custom: 'Custom: a user-created version you can freely edit, save, and delete.',
+  active: 'Active: the version used to process newly uploaded documents.',
+};
 
 // Utility function to normalize boolean values from strings (same as use-configuration.js)
 interface SchemaProperty {
@@ -189,6 +197,10 @@ const ConfigurationLayout = (): React.JSX.Element => {
 
   // Get user role for scope and permissions
   const { isAdmin, canWrite } = useUserRole();
+
+  // App-wide success toast (sticky Flashbar region) so save confirmation is
+  // visible even when the user is scrolled deep into a long config form (C1).
+  const { setSuccessMessage } = useAppContext();
 
   // Get active version name — prefer first scoped version over system active
   const activeVersionName = useMemo(() => {
@@ -1506,6 +1518,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
 
       if (success) {
         setSaveSuccess(true);
+        setSuccessMessage(saveAsDefault ? 'Configuration saved as new default.' : 'Configuration saved successfully.');
         if (saveAsDefault) {
           setShowSaveAsDefaultModal(false);
         }
@@ -1544,6 +1557,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
 
       if (result.success) {
         setSaveSuccess(true);
+        setSuccessMessage(`Saved as new version "${saveAsVersionName}".`);
         setShowSaveAsVersionModal(false);
         setSaveAsVersionName('');
         setSaveAsVersionDescription('');
@@ -1613,6 +1627,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
 
       if (success) {
         setSaveSuccess(true);
+        setSuccessMessage('Configuration reset to default.');
         setShowResetModal(false);
         // Refresh to show the restored default configuration
         await fetchConfiguration(currentVersionName);
@@ -2425,11 +2440,19 @@ const ConfigurationLayout = (): React.JSX.Element => {
                 {currentVersion?.description ? ` - ${currentVersion.description}` : ''}
               </span>
               {currentVersion?.managed || currentVersionName === 'default' ? (
-                <Badge color="blue">Managed</Badge>
+                <span title={BADGE_TOOLTIPS.managed}>
+                  <Badge color="blue">Managed</Badge>
+                </span>
               ) : (
-                <Badge color="grey">Custom</Badge>
+                <span title={BADGE_TOOLTIPS.custom}>
+                  <Badge color="grey">Custom</Badge>
+                </span>
               )}
-              {currentVersion?.isActive && <Badge color="green">Active</Badge>}
+              {currentVersion?.isActive && (
+                <span title={BADGE_TOOLTIPS.active}>
+                  <Badge color="green">Active</Badge>
+                </span>
+              )}
             </SpaceBetween>
           </Header>
         }

--- a/src/ui/src/components/configuration-layout/ConfigurationVersionsTable.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationVersionsTable.tsx
@@ -15,6 +15,7 @@ import {
   Badge,
   SegmentedControl,
   CollectionPreferences,
+  Modal,
 } from '@cloudscape-design/components';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
@@ -42,6 +43,13 @@ interface ConfigurationVersionsTableProps {
 }
 
 type TypeFilter = 'all' | 'managed' | 'custom';
+
+// One-line explanations shown on hover for the version Type/state badges.
+const BADGE_TOOLTIPS = {
+  managed: 'Stack-managed: shipped with the solution and overwritten on stack updates; not directly editable.',
+  custom: 'Custom: a user-created version you can freely edit, save, and delete.',
+  active: 'Active: the version used to process newly uploaded documents.',
+};
 
 const PAGE_SIZE_OPTIONS = [
   { value: 5, label: '5 versions' },
@@ -80,6 +88,8 @@ const ConfigurationVersionsTable = ({
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [preferences, setPreferences] = useState(DEFAULT_PREFERENCES);
+  // Versions confirmed for deletion (drives the confirmation modal).
+  const [pendingDeleteVersions, setPendingDeleteVersions] = useState<string[] | null>(null);
 
   // Helper: treat both managed flag and 'default' version as managed
   const isVersionManaged = (v: ConfigVersion): boolean => v.managed === true || v.versionName === 'default';
@@ -96,38 +106,6 @@ const ConfigurationVersionsTable = ({
   const customCount = useMemo(() => versions.filter((v) => !isVersionManaged(v)).length, [versions]);
 
   const allColumnDefinitions = [
-    {
-      id: 'select',
-      header: (
-        <input
-          type="checkbox"
-          checked={selectedVersionsForCompare.length === filteredByType.length && filteredByType.length > 0}
-          onChange={(e) => {
-            if (e.target.checked) {
-              const allVersionNames = filteredByType.map((v) => v.versionName);
-              allVersionNames.forEach((versionName) => {
-                if (!selectedVersionsForCompare.includes(versionName)) {
-                  onVersionSelectForCompare?.(versionName, true);
-                }
-              });
-            } else {
-              selectedVersionsForCompare.forEach((versionName) => {
-                onVersionSelectForCompare?.(versionName, false);
-              });
-            }
-          }}
-          title="Select/Deselect All"
-        />
-      ),
-      cell: (item: ConfigVersion) => (
-        <input
-          type="checkbox"
-          checked={selectedVersionsForCompare.includes(item.versionName)}
-          onChange={(e) => onVersionSelectForCompare?.(item.versionName, e.target.checked)}
-        />
-      ),
-      width: 50,
-    },
     {
       id: 'versionName',
       header: 'Version Name',
@@ -155,8 +133,20 @@ const ConfigurationVersionsTable = ({
       header: 'Type',
       cell: (item: ConfigVersion) => (
         <SpaceBetween direction="horizontal" size="xxs">
-          {isVersionManaged(item) ? <Badge color="blue">Managed</Badge> : <Badge color="grey">Custom</Badge>}
-          {item.isActive && <Badge color="green">Active</Badge>}
+          {isVersionManaged(item) ? (
+            <span title={BADGE_TOOLTIPS.managed}>
+              <Badge color="blue">Managed</Badge>
+            </span>
+          ) : (
+            <span title={BADGE_TOOLTIPS.custom}>
+              <Badge color="grey">Custom</Badge>
+            </span>
+          )}
+          {item.isActive && (
+            <span title={BADGE_TOOLTIPS.active}>
+              <Badge color="green">Active</Badge>
+            </span>
+          )}
         </SpaceBetween>
       ),
       sortingComparator: (a: ConfigVersion, b: ConfigVersion) => {
@@ -188,9 +178,16 @@ const ConfigurationVersionsTable = ({
     },
   ];
 
-  // Filter column definitions based on visible content preferences
-  // Always include the select column, then only show columns the user has enabled
-  const columnDefinitions = allColumnDefinitions.filter((col) => col.id === 'select' || preferences.visibleContent.includes(col.id));
+  // Filter column definitions based on visible content preferences.
+  // (Row selection is handled by the Table's native selectionType, not a column.)
+  const columnDefinitions = allColumnDefinitions.filter((col) => preferences.visibleContent.includes(col.id));
+
+  // Map the parent's selectedVersionsForCompare (names) to the item objects the
+  // Cloudscape Table expects for controlled multi-selection.
+  const selectedItems = useMemo(
+    () => filteredByType.filter((v) => selectedVersionsForCompare.includes(v.versionName)),
+    [filteredByType, selectedVersionsForCompare],
+  );
 
   const { items, collectionProps, paginationProps, filteredItemsCount, filterProps } = useCollection(filteredByType, {
     pagination: { pageSize: preferences.pageSize },
@@ -239,6 +236,26 @@ const ConfigurationVersionsTable = ({
         loadingText="Loading versions..."
         resizableColumns
         stripedRows
+        selectionType="multi"
+        selectedItems={selectedItems}
+        onSelectionChange={({ detail }) => {
+          const newNames = detail.selectedItems.map((v) => v.versionName);
+          // Diff against current selection and emit per-item toggles so the
+          // parent's existing handler contract is preserved.
+          filteredByType.forEach((v) => {
+            const wasSelected = selectedVersionsForCompare.includes(v.versionName);
+            const isSelected = newNames.includes(v.versionName);
+            if (wasSelected !== isSelected) {
+              onVersionSelectForCompare?.(v.versionName, isSelected);
+            }
+          });
+        }}
+        trackBy="versionName"
+        ariaLabels={{
+          selectionGroupLabel: 'Version selection',
+          allItemsSelectionLabel: () => 'Select all versions',
+          itemSelectionLabel: (_sel, item) => `Select version ${item.versionName}`,
+        }}
         wrapLines={preferences.wrapLines}
         empty={
           <Box margin={{ vertical: 'xs' }} textAlign="center" color="inherit">
@@ -294,7 +311,8 @@ const ConfigurationVersionsTable = ({
                   }
 
                   setDeleteError(null);
-                  onDeleteVersions?.(selectedVersionsForCompare);
+                  // Confirm before the destructive delete (S5).
+                  setPendingDeleteVersions(selectedVersionsForCompare);
                 }}
                 disabled={selectedVersionsForCompare.length === 0}
               >
@@ -351,6 +369,48 @@ const ConfigurationVersionsTable = ({
           />
         }
       />
+
+      {/* Delete confirmation (S5): destructive delete requires explicit confirm. */}
+      <Modal
+        visible={!!pendingDeleteVersions}
+        onDismiss={() => setPendingDeleteVersions(null)}
+        header="Delete configuration versions"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" onClick={() => setPendingDeleteVersions(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  if (pendingDeleteVersions) {
+                    onDeleteVersions?.(pendingDeleteVersions);
+                  }
+                  setPendingDeleteVersions(null);
+                }}
+              >
+                Delete
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="s">
+          <Box>
+            {pendingDeleteVersions && pendingDeleteVersions.length === 1
+              ? `Permanently delete the configuration version "${pendingDeleteVersions[0]}"? This action cannot be undone.`
+              : `Permanently delete these ${pendingDeleteVersions?.length ?? 0} configuration versions? This action cannot be undone.`}
+          </Box>
+          {pendingDeleteVersions && pendingDeleteVersions.length > 1 && (
+            <ul>
+              {pendingDeleteVersions.map((name) => (
+                <li key={name}>{name}</li>
+              ))}
+            </ul>
+          )}
+        </SpaceBetween>
+      </Modal>
     </SpaceBetween>
   );
 };

--- a/src/ui/src/components/configuration-layout/tools-panel.tsx
+++ b/src/ui/src/components/configuration-layout/tools-panel.tsx
@@ -41,17 +41,37 @@ const ToolsPanel = (): React.JSX.Element => (
   >
     <div>
       <p>
-        Edit and manage the IDP processing configuration. Default values are set by the system during deployment. Any customized values will
-        override the defaults.
+        View and edit the configuration that drives document processing — models, prompts, document classes, and each pipeline stage (OCR,
+        Classification, Extraction, and optional steps like Summarization and Evaluation).
       </p>
-      <h3>Features</h3>
+
+      <h3>Versions</h3>
+      <p>
+        Each configuration is a self-contained <strong>version</strong>. The <strong>default</strong> version is managed by the stack and is
+        read-only — it is overwritten on stack upgrades. To customize it, open it and click <strong>Save as Version</strong> to create an
+        editable copy. Use the <strong>Configuration Versions</strong> table at the top of the page to open, activate, compare, import, or
+        delete versions.
+      </p>
+
+      <h3>Editing</h3>
       <ul>
-        <li>Edit configuration in YAML or JSON using the built-in code editor</li>
-        <li>Use the visual Config Builder to construct configurations without writing code</li>
-        <li>Manage configuration versions — compare, restore, or roll back changes</li>
-        <li>Import pre-built configurations from the Configuration Library</li>
-        <li>Sync configuration with BDA (Business Document Automation) projects</li>
-        <li>Reset customized values back to system defaults</li>
+        <li>
+          Switch between <strong>Form View</strong> (guided fields with inline help), <strong>JSON View</strong>, and{' '}
+          <strong>YAML View</strong> (raw editing) using the view toggle.
+        </li>
+        <li>
+          Use the <strong>Document Schema</strong> and <strong>Policy Schema</strong> tabs to edit document classes and validation rules,
+          and the <strong>Prompt Preview</strong> tab to see the exact prompts sent to the model.
+        </li>
+        <li>
+          Edited fields show an orange dot; a per-field <strong>Restore default</strong> resets a single value. An unsaved-changes banner
+          offers <strong>Discard changes</strong>, and the app warns you before navigating away with unsaved edits.
+        </li>
+        <li>
+          <strong>Save changes</strong> persists your edits to an editable version. <strong>Refresh</strong> reloads the saved configuration
+          from the server. Additional actions (Export, Save as default, Restore default (All), and BDA sync) are in the{' '}
+          <strong>Actions</strong> menu.
+        </li>
       </ul>
     </div>
   </HelpPanel>

--- a/src/ui/src/contexts/app.ts
+++ b/src/ui/src/contexts/app.ts
@@ -16,9 +16,11 @@ export interface AppContextValue {
   authState: string;
   awsConfig: Record<string, unknown> | undefined;
   errorMessage: string | undefined;
+  successMessage: string | undefined;
   currentCredentials: unknown;
   currentSession: unknown;
   setErrorMessage: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setSuccessMessage: React.Dispatch<React.SetStateAction<string | undefined>>;
   user: AuthUser | undefined;
   navigationOpen: boolean;
   setNavigationOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/ui/src/hooks/use-notifications.ts
+++ b/src/ui/src/hooks/use-notifications.ts
@@ -21,7 +21,7 @@ const initialNotifications: Omit<Notification, 'onDismiss'>[] = [
 ];
 
 const useNotifications = (): Notification[] => {
-  const { errorMessage, setErrorMessage } = useAppContext();
+  const { errorMessage, setErrorMessage, successMessage, setSuccessMessage } = useAppContext();
 
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
@@ -108,6 +108,33 @@ const useNotifications = (): Notification[] => {
     setNotifications((current) => [...current, errorNotification]);
     setErrorMessage('');
   }, [errorMessage, notifications]);
+
+  useEffect(() => {
+    // adds success messages to notifications; auto-dismisses after a few seconds
+    // so transient confirmations (e.g. "Configuration saved") don't linger.
+    if (!successMessage) {
+      return undefined;
+    }
+
+    const id = performance.now();
+    const successNotification: Notification = {
+      type: 'success',
+      content: successMessage,
+      dismissible: true,
+      dismissLabel: 'Dismiss message',
+      id,
+      onDismiss: () => {
+        setNotifications((current) => current.filter((i) => i.id !== id));
+      },
+    };
+    setNotifications((current) => [...current, successNotification]);
+    setSuccessMessage('');
+
+    const timer = setTimeout(() => {
+      setNotifications((current) => current.filter((i) => i.id !== id));
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [successMessage]);
 
   return notifications;
 };


### PR DESCRIPTION
## Summary

Fixes a CORS preflight regression that broke the web UI's API calls, and improves the UX of the **View/Edit Configuration** page.

### 1. Fix: CORS preflight 500 under `BinaryMediaTypes: */*` (`nested/api-resolvers/template.yaml`)
The REST API sets `BinaryMediaTypes: */*` so the S3-proxy web-UI routes can return raw bytes. But `*/*` is API-wide, and browsers send `Accept: */*` on the CORS `OPTIONS` preflight, so API Gateway tried to base64-encode the MOCK preflight response as binary and returned a platform-level **500**. A non-2xx preflight makes the browser abort the subsequent POST with `Failed to fetch`, breaking every UI API call.

Fix: force `ContentHandling: CONVERT_TO_TEXT` on the `OPTIONS` MOCK integration and its 200 response so the preflight is a clean 200. The binary web-UI GET routes keep `CONVERT_TO_BINARY` and are unaffected.

### 2. View/Edit Configuration UX improvements
- **Toolbar de-crowding:** secondary actions (Export, Save as default, Restore default (All), Save as Version, BDA sync) grouped into a single **Actions** menu; view toggle, Refresh, and primary Save changes stay prominent.
- **Disabled-action tooltips:** `disabledReason`/title tooltips explain why Save changes and grouped actions are disabled on stack-managed/default versions.
- **Unsaved-changes banner + Discard on all versions** (incl. default/managed), with copy that points managed versions to *Save as Version*.
- **SPA navigation guard fix:** restores the actual previous URL (preserving `?version=` / `?tab=` deep links) instead of bouncing to the base config route.
- **Versions table expanded by default** so the version list is visible on arrival.
- **Prompt editing:** larger textareas + an **Expand editor** modal for prompt fields.
- **HelpPanel copy** refreshed to describe the real Form/JSON/YAML + versions flow; removed leftover debug `console.log`s.
- **Use BDA impact warning:** inline alert when the pending `use_bda` value differs from saved, explaining the whole-pipeline swap before Save.
- **Delete confirmation modal** for destructive version deletes (lists affected versions).
- **Success toasts:** added a success channel to the app-wide notification system (sticky Flashbar) so save/version/reset confirmations are visible even when scrolled deep; auto-dismisses after 5s.
- **Richer version comparison:** full untruncated values in a scrollable box, and a word-level inline diff for two-version compares (added=green, removed=red).
- **Native table selection:** replaced raw HTML checkboxes in the versions table with Cloudscape multi-selection (a11y/keyboard/consistency).
- **Badge tooltips:** Managed/Custom/Active badges (header + versions table) now have one-line hover descriptions.

## Testing
- `npm run typecheck`, `npm run lint`, and `npm run build` all pass.
- Verified live against a running stack: the CORS fix restores config loading; the new controls (Actions menu, native selection, expanded versions table, prompt expand editor, HelpPanel copy) render correctly.

## Notes
- Target branch: `develop` (per repo convention).
- The CORS fix rebased cleanly on top of the recent API Gateway access-logging change to the same template.