### PR TITLE
fix(api-resolvers): bump API Gateway deployment id so CORS preflight fix reaches the stage

### DIFF
--- a/nested/api-resolvers/template.yaml
+++ b/nested/api-resolvers/template.yaml
@@ -3057,7 +3057,12 @@ Resources:
   # The stage selects whichever exists via Fn::If. Bump BOTH logical-id suffixes
   # (…WebUIV3 -> …WebUIV4) whenever methods/CORS/gateway-responses change, so a
   # fresh snapshot reaches the stage.
-  HttpApiDeploymentWithWebUIV3:
+  # V3 -> V4: the OPTIONS MOCK integration gained ContentHandling: CONVERT_TO_TEXT
+  # (CORS preflight fix). That is a method/integration change, so the deployment
+  # logical id MUST be bumped to force a fresh snapshot onto the stage — mutating
+  # an existing Deployment does not re-snapshot. Without the bump the stack update
+  # succeeds but the stage keeps serving the pre-fix snapshot (preflight 500s).
+  HttpApiDeploymentWithWebUIV4:
     Type: AWS::ApiGateway::Deployment
     Condition: ServeWebUICondition
     DependsOn:
@@ -3069,7 +3074,7 @@ Resources:
       RestApiId: !Ref HttpApi
       Description: !Sub "Dispatcher API deployment for ${StackName} (CORS + Web UI proxy)"
 
-  HttpApiDeploymentNoWebUIV3:
+  HttpApiDeploymentNoWebUIV4:
     Type: AWS::ApiGateway::Deployment
     Condition: DoNotServeWebUICondition
     DependsOn:
@@ -3136,8 +3141,8 @@ Resources:
       RestApiId: !Ref HttpApi
       DeploymentId: !If
         - ServeWebUICondition
-        - !Ref HttpApiDeploymentWithWebUIV3
-        - !Ref HttpApiDeploymentNoWebUIV3
+        - !Ref HttpApiDeploymentWithWebUIV4
+        - !Ref HttpApiDeploymentNoWebUIV4
       StageName: api
       # JSON access-log format: request metadata only, never bodies. The error
       # and authorizer fields are what diagnose requests that never reach the


### PR DESCRIPTION
## Problem

After merging the earlier CORS preflight fix (#482) and running a stack update, the browser CORS **preflight kept returning HTTP 500** and every web-UI API call failed with `Failed to fetch` — even though the stack update reported `UPDATE_COMPLETE` (no failure/rollback).

## Root cause

The CORS fix added `ContentHandling: CONVERT_TO_TEXT` to the `OPTIONS` MOCK integration (`HttpApiOptionsMethod`) but did **not** bump the `AWS::ApiGateway::Deployment` logical id.

An `AWS::ApiGateway::Deployment` only re-snapshots the API when the **resource itself is replaced** (new logical id) — mutating an existing deployment is a no-op. So on a stack update from that template:

- CloudFormation applied the `CONVERT_TO_TEXT` change to the API's Method/Integration resources (verified live: `get-integration` shows it), **but**
- created **no new deployment snapshot**, and repointed the `api` stage at the pre-fix CFN-owned deployment.
- Net: `test-invoke-method` (reads live resource config) returns 200, while the live stage (stale snapshot) returns 500 — the classic fingerprint of a missing deployment bump.

The template's own NB comment above the deployment resources documents exactly this rule ("whenever methods/CORS change, BUMP THE LOGICAL ID SUFFIX"); the earlier fix missed it.

## Fix

Bump the two condition-gated deployment resources `HttpApiDeployment{WithWebUI,NoWebUI}V3 → V4` and the two `HttpApiStage.DeploymentId` references. This forces CloudFormation to create a fresh snapshot (including the OPTIONS `ContentHandling` change) and repoint the stage to it on the next deploy — no manual API Gateway intervention needed.

Added a comment recording why the bump happened, to prompt the next editor of these methods.

## Testing

- `cfn-lint nested/api-resolvers/template.yaml` — no E-level errors.
- Verified no leftover `V3` references; both deployment definitions and both stage `DeploymentId` refs are consistently `V4`.
- Confirmed on the live stack that this is the failure mode: the OPTIONS integration already carries `CONVERT_TO_TEXT` (CFN applied it) while the stage still serves the pre-fix snapshot and returns 500; `test-invoke-method` returns 200.

## Notes
- Target branch: `develop`.
- The live stack was intentionally **not** modified in this change; the fix takes effect on the next stack deploy from this branch.