### PR TITLE
fix(discovery): prevent overwriting the read-only 'default' config version

### DIFF
--- a/nested/api-resolvers/src/lambda/discovery_upload_resolver/index.py
+++ b/nested/api-resolvers/src/lambda/discovery_upload_resolver/index.py
@@ -184,7 +184,14 @@ def handle_upload_discovery_document(event, context):
 
         if not file_name:
             raise ValueError("fileName is required")
-        
+
+        # The 'default' config version is read-only — discovery must target a
+        # user-created version so the built-in defaults are never overwritten.
+        if version == 'default':
+            raise ValueError(
+                "The 'default' configuration version is read-only. Create a new version to save the discovered schema."
+            )
+
         # Get bucket from arguments
         bucket_name = arguments.get('bucket')
 
@@ -391,6 +398,13 @@ def handle_start_multi_doc_discovery(event, context):
 
     if not config_version:
         raise ValueError("configVersion is required")
+
+    # The 'default' config version is read-only — discovery must target a
+    # user-created version so the built-in defaults are never overwritten.
+    if config_version == 'default':
+        raise ValueError(
+            "The 'default' configuration version is read-only. Create a new version to save the discovered schema."
+        )
 
     if not s3_bucket and not zip_file_name:
         raise ValueError("Either s3Bucket/s3Prefix or zipFileName is required")

--- a/src/ui/src/components/discovery/DiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/DiscoveryPanel.tsx
@@ -389,6 +389,10 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
       setError('Please select a document file to upload');
       return;
     }
+    if (selectedVersion?.value === 'default') {
+      setError('The "default" configuration version is read-only. Create a new version to save the discovered schema.');
+      return;
+    }
 
     setIsUploading(true);
     setUploadStatus([]);
@@ -794,6 +798,14 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
             </SpaceBetween>
           </FormField>
 
+          {selectedVersion?.value === 'default' && (
+            <Alert type="warning">
+              The <strong>default</strong> configuration version is read-only and cannot be overwritten by discovery. Click{' '}
+              <strong>Create new version</strong> to save the discovered schema to a new version (it will be seeded from{' '}
+              <strong>default</strong>).
+            </Alert>
+          )}
+
           <FormField
             label="Save mode"
             description="Choose whether discovered classes are added to the version's existing schema or replace it"
@@ -980,7 +992,9 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
               variant="primary"
               onClick={uploadFiles}
               loading={isUploading}
-              disabled={!documentFile || !selectedVersion || isUploading || isValidatingJson}
+              disabled={
+                !documentFile || !selectedVersion || selectedVersion.value === 'default' || isUploading || isValidatingJson
+              }
             >
               {pageRanges.length > 0
                 ? `Start Discovery (${pageRanges.length} section${pageRanges.length !== 1 ? 's' : ''})`

--- a/src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx
@@ -234,6 +234,10 @@ const MultiDocDiscoveryPanel = () => {
       setError('Please select a configuration version');
       return;
     }
+    if (selectedVersion.value === 'default') {
+      setError('The "default" configuration version is read-only. Create a new version to save the discovered schema.');
+      return;
+    }
 
     setStarting(true);
     setError(null);
@@ -771,6 +775,14 @@ const MultiDocDiscoveryPanel = () => {
             </SpaceBetween>
           </FormField>
 
+          {selectedVersion?.value === 'default' && (
+            <Alert type="warning">
+              The <strong>default</strong> configuration version is read-only and cannot be overwritten by discovery. Click{' '}
+              <strong>Create new version</strong> to save the discovered schema to a new version (it will be seeded from{' '}
+              <strong>default</strong>).
+            </Alert>
+          )}
+
           {/* Save Mode */}
           <FormField
             label="Save mode"
@@ -863,7 +875,12 @@ const MultiDocDiscoveryPanel = () => {
               variant="primary"
               onClick={handleStartDiscovery}
               loading={starting || uploading}
-              disabled={!selectedVersion || (inputMode === 'zip' && !zipFile) || (inputMode === 's3path' && !s3Prefix)}
+              disabled={
+                !selectedVersion ||
+                selectedVersion.value === 'default' ||
+                (inputMode === 'zip' && !zipFile) ||
+                (inputMode === 's3path' && !s3Prefix)
+              }
             >
               {uploading ? 'Uploading...' : starting ? 'Starting...' : '🔍 Start Discovery'}
             </Button>


### PR DESCRIPTION
## Problem

In the Discovery UI, you could select any configuration version as the save target — including `default` — and discovery would then augment or replace that version's classes in place. This makes it easy to accidentally clobber the built-in `default` schema, which should be read-only.

## Change

`default` is now protected as a discovery save target in both the single-doc (`DiscoveryPanel`) and multi-doc (`MultiDocDiscoveryPanel`) flows:

- **Inline guidance** — a warning `Alert` under the version selector explains that `default` is read-only and points the user to **Create new version** (which seeds the new version from `default`).
- **Disabled action** — the **Start Discovery** button is disabled while `default` is selected.
- **Submit guard** — the submit handlers (`uploadFiles` / `handleStartDiscovery`) bail early with an error message if `default` slips through.
- **Backend defense-in-depth** — the resolver (`discovery_upload_resolver/index.py`) rejects `version` / `configVersion == 'default'` in both `handle_upload_discovery_document` and `handle_start_multi_doc_discovery`, so the API can't be driven against `default` directly.

This mirrors the existing treatment of `default` as a reserved name when *creating* a new version (`use-configuration-versions.ts`, `CreateDiscoveryVersionModal.tsx`).

## UX

```
[ default (Active) ▼ ]  [+ Create new version]

⚠ The default configuration version is read-only and cannot be
  overwritten by discovery. Click Create new version to save the
  discovered schema to a new version (it will be seeded from default).

[ Start Discovery ]  ← disabled
```

## Files

- `src/ui/src/components/discovery/DiscoveryPanel.tsx`
- `src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx`
- `nested/api-resolvers/src/lambda/discovery_upload_resolver/index.py`

## Testing

- ESLint clean on both modified UI components.
- Python resolver parses OK (`ast.parse`).

> Note: I did not touch the load-time auto-preselect (which picks the active version, often `default`). With this design that's intentional — the user lands on a clearly-blocked state with a nudge, rather than being silently switched off `default`.