### PR TITLE
fix(sdlc): grant CodeBuild role EC2/VPC permissions for the Step 4b hosting test

### DIFF
--- a/scripts/sdlc/cfn/codepipeline-s3.yml
+++ b/scripts/sdlc/cfn/codepipeline-s3.yml
@@ -454,6 +454,64 @@ Resources:
               - 'cognito-idp:UpdateUserPoolClient'
             Resource: !Sub 'arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*'
 
+  # EC2/VPC access for the API Gateway + VPC hosting test (Step 4b in
+  # codebuild_deployment.py): it deploys a self-contained throwaway VPC
+  # (scripts/sdlc/apigw-hosting-test-vpc.yaml — VPC, subnets, IGW, NAT gateway +
+  # EIP, route tables, security groups, execute-api VPC endpoint) to validate
+  # PRIVATE API Gateway hosting, then tears it all down. Networking create/*
+  # actions cannot be resource-scoped (the resource does not exist yet), so
+  # these are scoped by action; Describe* is required by CloudFormation to poll
+  # resource state during create and delete.
+  CodeBuildEC2VPCPolicy:
+    Type: 'AWS::IAM::Policy'
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: "EC2 networking create/delete actions cannot be resource-scoped (resources are created by this policy); the test VPC is a throwaway stack torn down in the same build"
+    Properties:
+      PolicyName: CodeBuildEC2VPCTest
+      Roles:
+        - !Ref CodeBuildRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'ec2:CreateVpc'
+              - 'ec2:DeleteVpc'
+              - 'ec2:ModifyVpcAttribute'
+              - 'ec2:CreateSubnet'
+              - 'ec2:DeleteSubnet'
+              - 'ec2:ModifySubnetAttribute'
+              - 'ec2:CreateInternetGateway'
+              - 'ec2:DeleteInternetGateway'
+              - 'ec2:AttachInternetGateway'
+              - 'ec2:DetachInternetGateway'
+              - 'ec2:CreateNatGateway'
+              - 'ec2:DeleteNatGateway'
+              - 'ec2:AllocateAddress'
+              - 'ec2:ReleaseAddress'
+              - 'ec2:CreateRouteTable'
+              - 'ec2:DeleteRouteTable'
+              - 'ec2:CreateRoute'
+              - 'ec2:DeleteRoute'
+              - 'ec2:AssociateRouteTable'
+              - 'ec2:DisassociateRouteTable'
+              - 'ec2:CreateSecurityGroup'
+              - 'ec2:DeleteSecurityGroup'
+              - 'ec2:AuthorizeSecurityGroupIngress'
+              - 'ec2:AuthorizeSecurityGroupEgress'
+              - 'ec2:RevokeSecurityGroupIngress'
+              - 'ec2:RevokeSecurityGroupEgress'
+              - 'ec2:CreateVpcEndpoint'
+              - 'ec2:DeleteVpcEndpoints'
+              - 'ec2:ModifyVpcEndpoint'
+              - 'ec2:CreateTags'
+              - 'ec2:DeleteTags'
+              - 'ec2:Describe*'
+            Resource: '*'
+
   IdkInstallCodeBuild:
     Type: 'AWS::CodeBuild::Project'
     Metadata:


### PR DESCRIPTION
## Problem
The API Gateway + VPC hosting test (Step 4b in `codebuild_deployment.py`) deploys a self-contained throwaway VPC to validate PRIVATE API Gateway hosting, but the CodeBuild role only had ENI-level EC2 permissions (`VPCNetworkAccess`, for running *inside* a VPC), not the create/delete networking actions needed to build one. The test stack failed with:

```
is not authorized to perform: ec2:CreateVpc on resource: arn:aws:ec2:us-east-1:...:vpc/*
because no identity-based policy allows the ec2:CreateVpc action
```

## Fix
New `CodeBuildEC2VPCPolicy` grants the VPC / subnet / IGW / NAT+EIP / route-table / security-group / VPC-endpoint create+delete+describe actions the test VPC template (`apigw-hosting-test-vpc.yaml`) requires. Networking `create/*` actions can't be resource-scoped (the resource doesn't exist yet), so it's action-scoped with a W12 suppression — the same pattern as the existing `CodeBuildCognitoPolicy`.

Already applied to the live `genaiic-sdlc-codepipeline` stack (us-east-1) via change set; this PR keeps the template (source of truth) in sync so a fresh pipeline deploy doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)