### PR TITLE
chore(gitignore): ignore SRT notebook-conversion artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ __pycache__
 notebooks/examples/data
 .idea/
 .srt/
+# SRT converts notebooks to scripts (jupyter nbconvert --output "<nb>-converted")
+# to run bandit on them, and only cleans up the .py form; notebooks missing
+# language_info.file_extension get a .txt instead, which is left behind.
+*-converted.py
+*-converted.txt
 *tmp-dev-assets*
 scratch/
 .mcp.json


### PR DESCRIPTION
## Summary

Follow-up to #499. The SRT security scan leaves stray untracked files in the tree after every run — this ignores them.

## Why

To run bandit on Jupyter notebooks (which bandit can't read directly), SRT converts each `.ipynb` to a script with:

```
jupyter nbconvert --log-level WARN --to script "<notebook>.ipynb" --output "<notebook>-converted"
```

Because `--output` has no extension, `nbconvert` picks it from the notebook's `metadata.language_info.file_extension`:

- Notebooks with full metadata (`file_extension: ".py"`) → `…-converted.py`. SRT's post-scan cleanup handles these (its bandit result-mapper is hardcoded to `-converted.py` and removes them).
- Notebooks **missing** `language_info.file_extension` → `nbconvert` defaults to `…-converted.txt`, which falls outside SRT's cleanup pattern and is **left behind** as an untracked file.

Today two notebooks trip this (`notebooks/examples/step5_rule_validation.ipynb`, `notebooks/usecase-specific-examples/multi-page-bank-statement/step3_extraction_with_missing_pages.ipynb`), but any future notebook missing that metadata — or an interrupted scan that leaves `.py` outputs uncleaned — would too.

## Change

Adds `*-converted.py` and `*-converted.txt` to `.gitignore` (next to the existing `.srt/` entry), with a comment explaining the source. Verified no tracked file matches either pattern, so nothing real is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)