### PR TITLE
fix(ui): remove duplicate success icon in feature up-to-date banner

### DIFF
--- a/src/ui/src/components/feature-page/FeatureStateMessages.tsx
+++ b/src/ui/src/components/feature-page/FeatureStateMessages.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { Alert, Box, Button, Container, Header, Link, SpaceBetween, Spinner, StatusIndicator } from '@cloudscape-design/components';
+import { Alert, Box, Button, Container, Header, Link, SpaceBetween, Spinner } from '@cloudscape-design/components';
 
 import type { FeatureEntitlement } from '../../types/feature-platform';
 
@@ -177,9 +177,7 @@ export const UpToDateBanner: React.FC<{ version: string; source: string }> = ({ 
   const showSource = source !== 'auto';
   return (
     <Alert type="success" statusIconAriaLabel="Active" dismissible={false}>
-      <StatusIndicator type="success">
-        v{version} — up to date{showSource ? ` (${source})` : ''}
-      </StatusIndicator>
+      v{version} — up to date{showSource ? ` (${source})` : ''}
     </Alert>
   );
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The UpToDateBanner rendered a Cloudscape StatusIndicator (type="success") nested inside a Cloudscape Alert (type="success"). Both draw their own green success icon, so the banner showed two checkmarks before the version text, e.g. "⊘ ⊘ v0.1.5 — up to date".

Drop the redundant inner StatusIndicator and render the text directly in the Alert, leaving the Alert's own success icon as the single intended checkmark. Banner text is unchanged, so existing FeaturePage tests still pass.

*Testing:*
- `npm run build` (eslint + tsc + vite) passes clean.
- Deployed the built UI to a running IDP stack and confirmed the banner now shows a single checkmark on the feature page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
