### PR TITLE
fix(summarization,agent): surface real error + improve failure triage (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ SPDX-License-Identifier: MIT-0
 
 - **Blogs, Customer Stories & Research references page.** A new [references doc](docs/references.md) collects and summarizes external publications about the accelerator: AWS ML blog feature deep-dives, customer reference stories (Myriad Genetics, Associa, Ricoh, Built Technologies) with real-world accuracy/cost/throughput results, and the peer-reviewed research papers (the IDP Accelerator arxiv paper and DocSplit, both ACL 2026). Linked from the docs index and the Starlight sidebar. (#507)
 
+### Changed
+
+- **Summarization failures now surface the underlying error, not a generic wrapper.** When a section's summarization fails (e.g. a Bedrock `ResourceNotFoundException` from a retired model, or a context-window overflow), the Summarization Lambda now includes the real cause in the exception it raises to Step Functions instead of a bare `"Summarization failed for document X"`, so the failure is diagnosable from the execution error and tracking record without opening CloudWatch (GitHub #504).
+
+- **Error Analyzer agent drills into the failing stage's own logs and no longer conflates non-fatal issues with the failure.** The troubleshooting prompt now explicitly instructs the agent to treat stage-level wrapper messages as symptoms and read the first underlying exception in the failing Lambda's log group, to not attribute a `FAILED` workflow to unrelated non-fatal `ProcessingIssue` warnings from a different stage, and adds a "retired / unavailable model" error pattern (`ResourceNotFoundException` / end-of-life).
+
 ## [0.6.0]
 
 This release (v0.6) reframes **per-field confidence and bounding-box geometry as

--- a/lib/idp_common_pkg/idp_common/config/models.py
+++ b/lib/idp_common_pkg/idp_common/config/models.py
@@ -1416,6 +1416,32 @@ TOOL USAGE:
 
 Always use at least 2 different tool sources before concluding a root cause. If a tool call returns no useful data, try an alternative — never guess without evidence.
 
+CRITICAL — DRILL INTO THE FAILING STAGE'S OWN LOGS:
+The Step Functions error and the DynamoDB status_reason usually show a
+GENERIC WRAPPER message (e.g. "Summarization failed for document X.pdf",
+"Extraction failed"), because each stage Lambda catches the underlying
+exception and re-raises a stage-level summary. That wrapper is a SYMPTOM,
+not the root cause. You MUST fetch the CloudWatch logs of the specific
+Lambda function for the failing stage and read the FIRST underlying
+exception/traceback it logged (e.g. a Bedrock ResourceNotFoundException,
+ThrottlingException, ValidationException, or a Python traceback). Search
+that stage's log group by the failing Lambda's request ID (from the
+Step Functions error cause or the X-Ray trace) with an "ERROR" filter, and
+quote the earliest real error — not the last wrapper line. If the wrapper
+message names a stage, the log group you need is that stage's function
+(e.g. SummarizationFunction, ExtractionFunction, AssessmentFunction).
+
+DO NOT CONFLATE UNRELATED NON-FATAL ISSUES WITH THE FAILURE:
+A document's DynamoDB record may carry `ProcessingIssue` entries with
+severity "warning" or non-terminal notes (e.g. an `assessment_incomplete`
+row that self-healed or was recorded but did not stop the pipeline). These
+are NOT necessarily the cause of a FAILED workflow. Before attributing the
+failure to a ProcessingIssue, confirm it occurred in the SAME stage that
+Step Functions reports as the failure point AND that its severity is
+"error". If the failing stage differs from the stage that logged the
+ProcessingIssue, treat the ProcessingIssue as context, not root cause, and
+keep drilling into the failing stage's logs.
+
 INVESTIGATION STRATEGY:
 Use this approach for all investigations, whether a single document or a large batch:
 
@@ -1479,6 +1505,10 @@ Use these patterns to guide your investigation and accelerate diagnosis:
 7. BEDROCK MODEL ERRORS — ModelErrorException, "model returned an error", context length exceeded
    Likely cause: Document content too large for model context window, model unavailable in region, prompt issue
    Check: Document page count, OCR text length, model availability, extraction prompt configuration
+
+8. RETIRED / UNAVAILABLE MODEL — ResourceNotFoundException, "This model version has reached the end of its life", "model identifier is invalid", "could not be found"
+   Likely cause: The model ID configured for a stage (OCR/classification/extraction/assessment/summarization) has been retired (end-of-life) by Bedrock, or is not enabled/available in this account/region
+   Check: The configured model ID for the FAILING stage in the config version the document used; whether that model is still offered and access is granted in this region. Root cause is a retired/unavailable model — recommend switching that stage to a currently-supported model in the UI Configuration panel.
 
 OUTPUT FORMAT:
 Always format your response with exactly these three sections in this order:
@@ -1611,6 +1641,32 @@ TOOL USAGE:
 
 Always use at least 2 different tool sources before concluding a root cause. If a tool call returns no useful data, try an alternative — never guess without evidence.
 
+CRITICAL — DRILL INTO THE FAILING STAGE'S OWN LOGS:
+The Step Functions error and the DynamoDB status_reason usually show a
+GENERIC WRAPPER message (e.g. "Summarization failed for document X.pdf",
+"Extraction failed"), because each stage Lambda catches the underlying
+exception and re-raises a stage-level summary. That wrapper is a SYMPTOM,
+not the root cause. You MUST fetch the CloudWatch logs of the specific
+Lambda function for the failing stage and read the FIRST underlying
+exception/traceback it logged (e.g. a Bedrock ResourceNotFoundException,
+ThrottlingException, ValidationException, or a Python traceback). Search
+that stage's log group by the failing Lambda's request ID (from the
+Step Functions error cause or the X-Ray trace) with an "ERROR" filter, and
+quote the earliest real error — not the last wrapper line. If the wrapper
+message names a stage, the log group you need is that stage's function
+(e.g. SummarizationFunction, ExtractionFunction, AssessmentFunction).
+
+DO NOT CONFLATE UNRELATED NON-FATAL ISSUES WITH THE FAILURE:
+A document's DynamoDB record may carry `ProcessingIssue` entries with
+severity "warning" or non-terminal notes (e.g. an `assessment_incomplete`
+row that self-healed or was recorded but did not stop the pipeline). These
+are NOT necessarily the cause of a FAILED workflow. Before attributing the
+failure to a ProcessingIssue, confirm it occurred in the SAME stage that
+Step Functions reports as the failure point AND that its severity is
+"error". If the failing stage differs from the stage that logged the
+ProcessingIssue, treat the ProcessingIssue as context, not root cause, and
+keep drilling into the failing stage's logs.
+
 INVESTIGATION STRATEGY:
 Use this approach for all investigations, whether a single document or a large batch:
 
@@ -1674,6 +1730,10 @@ Use these patterns to guide your investigation and accelerate diagnosis:
 7. BEDROCK MODEL ERRORS — ModelErrorException, "model returned an error", context length exceeded
    Likely cause: Document content too large for model context window, model unavailable in region, prompt issue
    Check: Document page count, OCR text length, model availability, extraction prompt configuration
+
+8. RETIRED / UNAVAILABLE MODEL — ResourceNotFoundException, "This model version has reached the end of its life", "model identifier is invalid", "could not be found"
+   Likely cause: The model ID configured for a stage (OCR/classification/extraction/assessment/summarization) has been retired (end-of-life) by Bedrock, or is not enabled/available in this account/region
+   Check: The configured model ID for the FAILING stage in the config version the document used; whether that model is still offered and access is granted in this region. Root cause is a retired/unavailable model — recommend switching that stage to a currently-supported model in the UI Configuration panel.
 
 OUTPUT FORMAT:
 Always format your response with exactly these three sections in this order:

--- a/lib/idp_common_pkg/idp_common/config/system_defaults/base-agents.yaml
+++ b/lib/idp_common_pkg/idp_common/config/system_defaults/base-agents.yaml
@@ -58,6 +58,32 @@ agents:
 
       Always use at least 2 different tool sources before concluding a root cause. If a tool call returns no useful data, try an alternative — never guess without evidence.
 
+      CRITICAL — DRILL INTO THE FAILING STAGE'S OWN LOGS:
+      The Step Functions error and the DynamoDB status_reason usually show a
+      GENERIC WRAPPER message (e.g. "Summarization failed for document X.pdf",
+      "Extraction failed"), because each stage Lambda catches the underlying
+      exception and re-raises a stage-level summary. That wrapper is a SYMPTOM,
+      not the root cause. You MUST fetch the CloudWatch logs of the specific
+      Lambda function for the failing stage and read the FIRST underlying
+      exception/traceback it logged (e.g. a Bedrock ResourceNotFoundException,
+      ThrottlingException, ValidationException, or a Python traceback). Search
+      that stage's log group by the failing Lambda's request ID (from the
+      Step Functions error cause or the X-Ray trace) with an "ERROR" filter, and
+      quote the earliest real error — not the last wrapper line. If the wrapper
+      message names a stage, the log group you need is that stage's function
+      (e.g. SummarizationFunction, ExtractionFunction, AssessmentFunction).
+
+      DO NOT CONFLATE UNRELATED NON-FATAL ISSUES WITH THE FAILURE:
+      A document's DynamoDB record may carry `ProcessingIssue` entries with
+      severity "warning" or non-terminal notes (e.g. an `assessment_incomplete`
+      row that self-healed or was recorded but did not stop the pipeline). These
+      are NOT necessarily the cause of a FAILED workflow. Before attributing the
+      failure to a ProcessingIssue, confirm it occurred in the SAME stage that
+      Step Functions reports as the failure point AND that its severity is
+      "error". If the failing stage differs from the stage that logged the
+      ProcessingIssue, treat the ProcessingIssue as context, not root cause, and
+      keep drilling into the failing stage's logs.
+
       INVESTIGATION STRATEGY:
       Use this approach for all investigations, whether a single document or a large batch:
 
@@ -121,6 +147,10 @@ agents:
       7. BEDROCK MODEL ERRORS — ModelErrorException, "model returned an error", context length exceeded
          Likely cause: Document content too large for model context window, model unavailable in region, prompt issue
          Check: Document page count, OCR text length, model availability, extraction prompt configuration
+
+      8. RETIRED / UNAVAILABLE MODEL — ResourceNotFoundException, "This model version has reached the end of its life", "model identifier is invalid", "could not be found"
+         Likely cause: The model ID configured for a stage (OCR/classification/extraction/assessment/summarization) has been retired (end-of-life) by Bedrock, or is not enabled/available in this account/region
+         Check: The configured model ID for the FAILING stage in the config version the document used; whether that model is still offered and access is granted in this region. Root cause is a retired/unavailable model — recommend switching that stage to a currently-supported model in the UI Configuration panel.
 
       OUTPUT FORMAT:
       Always format your response with exactly these three sections in this order:

--- a/patterns/unified/src/summarization_function/index.py
+++ b/patterns/unified/src/summarization_function/index.py
@@ -90,7 +90,20 @@ def handler(event, context):
         
         # Check if document processing failed
         if processed_document.status == Status.FAILED:
-            error_message = f"Summarization failed for document {processed_document.id}"
+            # Surface the underlying cause (e.g. a Bedrock ResourceNotFoundException
+            # for a retired model, a context-window overflow, etc.) instead of a
+            # bare "Summarization failed" wrapper. The real error is otherwise only
+            # visible in the Lambda logs, which sends failure triage down the wrong
+            # path (GitHub #504). SummarizationService records the cause on
+            # document.errors / status_reason.
+            detail = getattr(processed_document, "status_reason", None)
+            if not detail and processed_document.errors:
+                detail = "; ".join(str(e) for e in processed_document.errors)
+            error_message = (
+                f"Summarization failed for document {processed_document.id}: {detail}"
+                if detail
+                else f"Summarization failed for document {processed_document.id}"
+            )
             logger.error(error_message)
             raise Exception(error_message)
         


### PR DESCRIPTION
## Summary

Robustness follow-up to #504. That issue was a retired Bedrock model failing the Summarization stage, but two things made it hard to diagnose — both fixed here. (The config fix itself is #505.)

## Problem

1. **The real error was hidden.** The Summarization Lambda catches the service failure and raises a generic `"Summarization failed for document X.pdf"`. The actual Bedrock `ResourceNotFoundException: This model version has reached the end of its life` was only in CloudWatch — the Step Functions error and DynamoDB tracking record showed only the wrapper.
2. **The Error Analyzer agent misdiagnosed it.** Given only the wrapper message, the agent anchored on unrelated non-fatal `assessment_incomplete` `ProcessingIssue` warnings (on a *different* stage) and reported those as the cause, instead of drilling into the SummarizationFunction log group where the real Bedrock error was.

## Changes

**1. Surface the underlying cause (`patterns/unified/src/summarization_function/index.py`)**
When `process_document` returns `FAILED`, include `document.status_reason` / `document.errors` in the raised exception. The real error now propagates to Step Functions and the tracking record.

**2. Sharpen the Error Analyzer prompt** (`config/system_defaults/base-agents.yaml` + the `ErrorAnalyzerConfig` and `ChatCompanionConfig` defaults in `config/models.py`, kept in sync):
- **Drill into the failing stage's own logs** — treat stage-level wrapper messages as symptoms; fetch the failing Lambda's log group and quote the *first* underlying exception, not the last wrapper line.
- **Don't conflate non-fatal `ProcessingIssue` warnings with the failure** — only attribute a `FAILED` workflow to a `ProcessingIssue` if it's in the same stage Step Functions reports AND severity is `error`.
- **New common-error pattern #8: retired / unavailable model** (`ResourceNotFoundException` / "reached the end of its life") → root cause is a retired model, recommend switching that stage's model.

## Testing

- `pytest tests/unit/agents/error_analyzer tests/unit/summarization` → 61 passed, 1 skipped.
- Verified `ErrorAnalyzerConfig()` / `ChatCompanionConfig()` defaults load and contain the new guidance.
- No test asserts the exact prompt text or wrapper message, so nothing regresses.

## Notes

- The prompt change updates the shipped defaults; existing deployments whose config version pins an older `error_analyzer.system_prompt` will keep theirs until reconfigured — this is a defaults improvement, not a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)