### PR TITLE
fix(bda-ocr): recover table-cell text/confidence/geometry in pageData (#512)

### DIFF
--- a/lib/idp_common_pkg/idp_common/bda/bda_ocr.py
+++ b/lib/idp_common_pkg/idp_common/bda/bda_ocr.py
@@ -338,10 +338,19 @@ def bda_standard_output_to_textract_blocks(
             lc = line.get("confidence")
             line_conf = float(lc) * 100.0 if isinstance(lc, (int, float)) else 0.0
 
+        # BDA leaves ``text`` empty on table-cell lines (the content lives only in
+        # ``text_words``). Synthesize the LINE text from its child words so the line
+        # is not later discarded by the pageData builder, which drops empty-text
+        # LINE blocks and would otherwise strip all table-cell text/confidence/
+        # geometry for BDA-as-OCR runs.
+        line_text = line.get("text", "")
+        if not line_text and word_blocks:
+            line_text = " ".join(wb["Text"] for wb in word_blocks if wb.get("Text"))
+
         line_block: Dict[str, Any] = {
             "BlockType": "LINE",
             "Id": line_id,
-            "Text": line.get("text", ""),
+            "Text": line_text,
             "Confidence": line_conf,
             "Geometry": _bbox_to_geometry(_first_bbox(line), _corners_for(line)),
         }

--- a/lib/idp_common_pkg/tests/unit/bda/test_bda_ocr.py
+++ b/lib/idp_common_pkg/tests/unit/bda/test_bda_ocr.py
@@ -169,6 +169,112 @@ def test_line_to_word_child_relationships():
 
 
 @pytest.mark.unit
+def test_empty_text_table_cell_line_synthesizes_text_from_words():
+    """BDA leaves ``text`` empty on table-cell lines; the content lives only in
+    ``text_words``. The converter must synthesize the LINE text from its child
+    words so the line survives the pageData builder's empty-text filter (which
+    would otherwise strip all table-cell text/confidence/geometry for BDA OCR).
+    """
+    payload = _sample_standard_output()
+    # A table-cell line: no line-level text, but two child words carry the value.
+    payload["text_lines"].append(
+        {
+            "id": "line-cell",
+            "text": "",  # BDA emits empty text for table cells
+            "confidence": 0.99,
+            "page_index": 0,
+            "locations": [
+                {
+                    "page_index": 0,
+                    "bounding_box": {
+                        "left": 0.5,
+                        "top": 0.5,
+                        "width": 0.2,
+                        "height": 0.05,
+                    },
+                }
+            ],
+        }
+    )
+    payload["text_words"].extend(
+        [
+            {
+                "id": "wc1",
+                "text": "1159.3",
+                "confidence": 0.95,
+                "line_id": "line-cell",
+                "page_index": 0,
+                "locations": [
+                    {
+                        "bounding_box": {
+                            "left": 0.5,
+                            "top": 0.5,
+                            "width": 0.1,
+                            "height": 0.05,
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "wc2",
+                "text": "grams",
+                "confidence": 0.85,
+                "line_id": "line-cell",
+                "page_index": 0,
+                "locations": [
+                    {
+                        "bounding_box": {
+                            "left": 0.6,
+                            "top": 0.5,
+                            "width": 0.1,
+                            "height": 0.05,
+                        }
+                    }
+                ],
+            },
+        ]
+    )
+
+    out = bda_standard_output_to_textract_blocks(payload)
+    cell = next(b for b in out["Blocks"] if b.get("Id") == "line-cell")
+    # Text is joined from the child words rather than left empty.
+    assert cell["Text"] == "1159.3 grams"
+    # Confidence is still the word-confidence mean, not the broken BDA value.
+    assert cell["Confidence"] == pytest.approx(90.0)
+    # Word children (with their own text/confidence/geometry) are preserved.
+    assert cell["Relationships"][0]["Ids"] == ["wc1", "wc2"]
+
+
+@pytest.mark.unit
+def test_empty_text_line_without_words_stays_empty():
+    """A truly empty line (no words) has no text to synthesize and stays empty."""
+    payload = _sample_standard_output()
+    payload["text_lines"].append(
+        {
+            "id": "line-blank",
+            "text": "",
+            "confidence": 0.5,
+            "page_index": 0,
+            "locations": [
+                {
+                    "page_index": 0,
+                    "bounding_box": {
+                        "left": 0.5,
+                        "top": 0.7,
+                        "width": 0.2,
+                        "height": 0.05,
+                    },
+                }
+            ],
+        }
+    )
+    out = bda_standard_output_to_textract_blocks(payload)
+    blank = next(b for b in out["Blocks"] if b.get("Id") == "line-blank")
+    assert blank["Text"] == ""
+    assert "Relationships" not in blank
+
+
+@pytest.mark.unit
 def test_geometry_is_normalized_boundingbox_and_polygon():
     out = bda_standard_output_to_textract_blocks(_sample_standard_output())
     line1 = next(b for b in out["Blocks"] if b.get("Id") == "line-1")


### PR DESCRIPTION
## Summary

Fixes #512.

When BDA is used for OCR, the per-page `pageData.json` artifact was omitting the text/confidence/geometry for **table-cell content**, even though that data was present in the underlying BDA word output and rendered correctly in the extracted markdown. The equivalent Textract-based OCR run includes those cell lines.

## Root cause

BDA's standard output leaves the line-level `text` field empty on `text_lines` entries that correspond to table cells (the content lives only in `text_words`). The BDA→Textract-block converter (`bda_standard_output_to_textract_blocks`) copied that emptiness onto the `LINE` block, and the shared pageData builder (`_build_page_data`) drops every `LINE` block whose `Text` is empty — taking the line's valid word children (text/confidence/geometry) with it.

Textract is unaffected because it populates a real `Text` on every LINE block, including in-cell lines. The table still *rendered* in both variants because the markdown in `result.json` comes from a separate path (`extract_markdown`) that the filter doesn't touch.

## Fix (option 1)

In `bda_ocr.py`, when a `text_lines` entry has no `text` but has child words, synthesize the LINE `Text` by joining the child word texts. This keeps the fix in the BDA adapter where the empty-text quirk originates, leaves the generic `_build_page_data` builder untouched for all other providers, and lets the table-cell lines pass the existing filter with their word-level data intact.

## Verification

- **Live data** (stack IDP1, `rvl_cdip_package.pdf` page 2 "Bank Statement"): re-deriving line text the way the fix does and re-applying the builder filter recovers **all 91 lines**, matching the Textract OCR variant — up from **26** before the fix. The 65 recovered lines are exactly the table cells (columns A–I and values).
- **Unit tests**: added `test_empty_text_table_cell_line_synthesizes_text_from_words` (empty line with words → text joined from words, confidence still word-mean, relationships preserved) and `test_empty_text_line_without_words_stays_empty` (truly empty line stays empty). All 33 tests in `tests/unit/bda/test_bda_ocr.py` pass.
- `ruff check`, `ruff format`, and `basedpyright` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)