### PR TITLE
fix(iam): propagate PermissionsBoundaryArn to Feature Platform stack and auto-role Lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ SPDX-License-Identifier: MIT-0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Feature Platform stack now honors `PermissionsBoundaryArn`, fixing rollback in SCP-enforced accounts.** When `EnableFeaturePlatform=true`, the main template did not forward `PermissionsBoundaryArn` to the Feature Platform nested stack (`feature-platform/main-stack-extensions`), and that nested template neither declared the parameter nor attached a boundary to its `FeaturePlatformLambdaRole` — so in accounts whose SCP requires a permissions boundary on every IAM role, `iam:CreateRole` was denied and the nested stack rolled back on creation. The parameter is now declared in the nested template, attached to the role, and forwarded from the main stack. The same gap on the SAM-auto-role Lambda functions in the installable feature templates (`feature-template`, `sample-feature`, `sample-health-insurance-review`) and on the conditional `BastionRole` / AgentCore roles/function in the main template is fixed as well. A static regression test (`lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py`) now asserts every deployed-stack template attaches the boundary to each role it creates and forwards the parameter to every nested stack that accepts it.
-
 ## [0.6.1]
 
 ### Added
@@ -34,6 +30,8 @@ SPDX-License-Identifier: MIT-0
 - **Bedrock client logs the model ID on non-retryable errors.** Non-retryable `Converse` and embedding failures now include the model ID in the log line (e.g. `Non-retryable Bedrock error for model us.anthropic.claude-3-7-sonnet-20250219-v1:0: ResourceNotFoundException - ...`), so the offending model is explicit in the function logs — Bedrock's own message for a retired model does not name it.
 
 ### Fixed
+
+- **Feature Platform stack now honors `PermissionsBoundaryArn`, fixing rollback in SCP-enforced accounts.** When `EnableFeaturePlatform=true`, the main template did not forward `PermissionsBoundaryArn` to the Feature Platform nested stack (`feature-platform/main-stack-extensions`), and that nested template neither declared the parameter nor attached a boundary to its `FeaturePlatformLambdaRole` — so in accounts whose SCP requires a permissions boundary on every IAM role, `iam:CreateRole` was denied and the nested stack rolled back on creation. The parameter is now declared in the nested template, attached to the role, and forwarded from the main stack. The same gap on the SAM-auto-role Lambda functions in the installable feature templates (`feature-template`, `sample-feature`, `sample-health-insurance-review`) and on the conditional `BastionRole` / AgentCore roles/function in the main template is fixed as well. A static regression test (`lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py`) now asserts every deployed-stack template attaches the boundary to each role it creates and forwards the parameter to every nested stack that accepts it. (#521)
 
 - **OpenAI (bedrock-mantle) metering no longer double-counts cached tokens.** OpenAI's Responses `usage.input_tokens` is the *total* prompt count and already **includes** the cached / cache-write tokens as a subset — unlike Bedrock Converse, where `inputTokens` is the disjoint uncached count. The mantle usage mapper reported that total as `inputTokens` while *also* emitting `cacheReadInputTokens` / `cacheWriteInputTokens`, so the cost calculator billed cached tokens twice (full input rate **and** cache rate) — turning the cache discount into a ~64% overcharge on warm calls. `inputTokens` is now the disjoint fresh count (`input_tokens − cached − cache_write`), so `inputTokens + cacheReadInputTokens` reconciles to the true prompt size. Affects all GPT-5.x models (5.4 / 5.5 / 5.6). Verified live end-to-end. See the [bedrock module README](lib/idp_common_pkg/idp_common/bedrock/README.md#openai-gpt-5x-models-bedrock-mantle-responses-api). (#519)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Feature Platform stack now honors `PermissionsBoundaryArn`, fixing rollback in SCP-enforced accounts.** When `EnableFeaturePlatform=true`, the main template did not forward `PermissionsBoundaryArn` to the Feature Platform nested stack (`feature-platform/main-stack-extensions`), and that nested template neither declared the parameter nor attached a boundary to its `FeaturePlatformLambdaRole` — so in accounts whose SCP requires a permissions boundary on every IAM role, `iam:CreateRole` was denied and the nested stack rolled back on creation. The parameter is now declared in the nested template, attached to the role, and forwarded from the main stack. The same gap on the SAM-auto-role Lambda functions in the installable feature templates (`feature-template`, `sample-feature`, `sample-health-insurance-review`) and on the conditional `BastionRole` / AgentCore roles/function in the main template is fixed as well. A static regression test (`lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py`) now asserts every deployed-stack template attaches the boundary to each role it creates and forwards the parameter to every nested stack that accepts it.
+
 ## [0.6.1]
 
 ### Added

--- a/feature-platform/feature-template/template.yaml
+++ b/feature-platform/feature-template/template.yaml
@@ -133,6 +133,10 @@ Resources:
   FeatureApiFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # SAM auto-generates this function's execution role. Set the boundary on
+      # the function so it flows onto that generated role — otherwise install
+      # fails in accounts whose SCP requires a boundary on every IAM role.
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref 'AWS::NoValue']
       CodeUri: feature-api/
       Handler: handler.lambda_handler
       Environment:

--- a/feature-platform/main-stack-extensions/template.yaml
+++ b/feature-platform/main-stack-extensions/template.yaml
@@ -197,6 +197,14 @@ Parameters:
     Default: 'INFO'
     AllowedValues: [DEBUG, INFO, WARNING, ERROR]
 
+  PermissionsBoundaryArn:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) ARN of an existing IAM Permissions Boundary policy to attach to
+      all IAM roles. Required by some organizations with Service Control
+      Policies (SCPs). Forwarded from the main stack's PermissionsBoundaryArn.
+
 Conditions:
 
   HasConfigurationTable: !Not [!Equals [!Ref ConfigurationTableName, '']]
@@ -207,6 +215,7 @@ Conditions:
   HasDiscoveryBucket: !Not [!Equals [!Ref DiscoveryBucketName, '']]
   HasCustomerManagedEncryptionKey: !Not [!Equals [!Ref CustomerManagedEncryptionKeyArn, '']]
   HasSellerBuckets: !Not [!Equals [!Join ['', !Ref SellerBucketObjectArns], '']]
+  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryArn, '']]
 
 Globals:
 
@@ -246,6 +255,7 @@ Resources:
   FeaturePlatformLambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref 'AWS::NoValue']
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/feature-platform/sample-feature/template.yaml
+++ b/feature-platform/sample-feature/template.yaml
@@ -120,6 +120,10 @@ Resources:
   FeatureApiFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # SAM auto-generates this function's execution role. Set the boundary on
+      # the function so it flows onto that generated role — otherwise install
+      # fails in accounts whose SCP requires a boundary on every IAM role.
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref 'AWS::NoValue']
       CodeUri: feature-api/
       Handler: handler.lambda_handler
       Environment:

--- a/feature-platform/sample-health-insurance-review/template.yaml
+++ b/feature-platform/sample-health-insurance-review/template.yaml
@@ -114,6 +114,10 @@ Resources:
   ClaimStatusHookFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # SAM auto-generates this function's execution role. Set the boundary on
+      # the function so it flows onto that generated role — otherwise install
+      # fails in accounts whose SCP requires a boundary on every IAM role.
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref 'AWS::NoValue']
       CodeUri: hook/
       Handler: handler.lambda_handler
       Tags:
@@ -204,6 +208,10 @@ Resources:
   FeatureApiFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # SAM auto-generates this function's execution role. Set the boundary on
+      # the function so it flows onto that generated role — otherwise install
+      # fails in accounts whose SCP requires a boundary on every IAM role.
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref 'AWS::NoValue']
       CodeUri: feature-api/
       Handler: handler.lambda_handler
       Environment:

--- a/lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py
+++ b/lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py
@@ -213,7 +213,7 @@ def test_nested_stacks_forward_permissions_boundary():
         if not (root / child_src).is_file():
             # Child template isn't a committed source we can introspect; skip.
             continue
-        child_params = (_load(child_src).get("Parameters") or {})
+        child_params = _load(child_src).get("Parameters") or {}
         if "PermissionsBoundaryArn" not in child_params:
             continue  # child doesn't take the param -> nothing to forward
         passed = props.get("Parameters") or {}

--- a/lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py
+++ b/lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Static regression coverage for IAM Permissions Boundary propagation.
+
+Background
+----------
+Some customer accounts enforce a Service Control Policy (SCP) that *requires*
+every IAM role to be created with a Permissions Boundary. To support them, the
+templates take an optional ``PermissionsBoundaryArn`` parameter and, when set,
+attach it to every IAM role they create.
+
+A real customer bug prompted these tests: the Feature Platform nested stack
+(``feature-platform/main-stack-extensions``) neither declared the parameter nor
+put a boundary on its ``FeaturePlatformLambdaRole``, AND the main template
+didn't forward ``PermissionsBoundaryArn`` into that nested stack. In an
+SCP-enforced account, ``iam:CreateRole`` was denied and the nested stack rolled
+back on creation. Sibling feature templates had the same gap on their
+SAM-auto-role functions (``FeatureApiFunction`` / ``ClaimStatusHookFunction``).
+
+These tests fail loudly if any deployed-stack template regresses on three
+invariants:
+
+1. Every ``AWS::IAM::Role`` (and every ``AWS::Serverless::Function`` that relies
+   on a SAM-auto-generated role) sets ``PermissionsBoundary``.
+2. Every template that creates IAM roles declares the ``PermissionsBoundaryArn``
+   parameter and the ``HasPermissionsBoundary`` condition.
+3. Every nested ``AWS::CloudFormation::Stack`` forwards ``PermissionsBoundaryArn``
+   to any child template that declares that parameter.
+
+The check is deliberately static (no AWS, no deploy) so it runs in the fast
+unit gate and catches the regression at author time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+
+# --- CFN-aware YAML loader ----------------------------------------------------
+# CloudFormation templates use short intrinsic tags (!Ref, !If, !GetAtt, !Sub).
+# PyYAML's SafeLoader rejects them, so we register a no-op multi-constructor
+# that preserves the tag + value as a {"!Tag": value} dict. This keeps the
+# document structure inspectable while never enabling unsafe Python-object
+# construction (we subclass SafeLoader, NOT the default Loader).
+class _CFNLoader(yaml.SafeLoader):
+    pass
+
+
+def _cfn_multi_constructor(loader, tag_suffix, node):
+    tag = "!" + tag_suffix
+    if isinstance(node, yaml.ScalarNode):
+        value = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node)
+    else:
+        value = loader.construct_mapping(node)
+    return {tag: value}
+
+
+_CFNLoader.add_multi_constructor("!", _cfn_multi_constructor)
+
+
+def _repo_root() -> Path:
+    """Walk up until we find the repo root (contains the main template.yaml)."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "template.yaml").is_file() and (parent / "publish.py").is_file():
+            return parent
+    raise RuntimeError("Could not locate repo root containing template.yaml")
+
+
+# Every template that is part of a *deployed* stack (the main stack, its nested
+# stacks, and the feature-platform templates a customer installs). Bootstrap /
+# CI-only templates under scripts/ and iam-roles/ are intentionally excluded --
+# they are not deployed by the accelerator and have their own lifecycle.
+DEPLOYED_TEMPLATES = [
+    "template.yaml",
+    "patterns/unified/template.yaml",
+    "nested/bedrockkb/template.yaml",
+    "nested/multi-doc-discovery/template.yaml",
+    "nested/api-resolvers/template.yaml",
+    "feature-platform/main-stack-extensions/template.yaml",
+    "feature-platform/feature-template/template.yaml",
+    "feature-platform/sample-feature/template.yaml",
+    "feature-platform/sample-health-insurance-review/template.yaml",
+]
+
+
+def _load(rel_path: str) -> dict:
+    path = _repo_root() / rel_path
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.load(f, Loader=_CFNLoader) or {}
+
+
+def _resources(template: dict) -> dict:
+    return {
+        name: body
+        for name, body in (template.get("Resources") or {}).items()
+        if isinstance(body, dict)
+    }
+
+
+def _needs_boundary(body: dict) -> bool:
+    """True if this resource creates an IAM role that must carry a boundary.
+
+    - AWS::IAM::Role: always creates a role.
+    - AWS::Serverless::Function WITHOUT an explicit ``Role``: SAM generates an
+      execution role for it, so the ``PermissionsBoundary`` property must be set
+      on the function to flow onto that generated role. A function that points at
+      an explicit ``Role`` (!GetAtt SomeRole.Arn) inherits that role's boundary
+      and must NOT set its own.
+    """
+    rtype = body.get("Type")
+    props = body.get("Properties") or {}
+    if rtype == "AWS::IAM::Role":
+        return True
+    if rtype == "AWS::Serverless::Function":
+        return "Role" not in props
+    return False
+
+
+def test_deployed_templates_are_discoverable():
+    """Guard: every template we intend to check actually exists on disk."""
+    root = _repo_root()
+    missing = [t for t in DEPLOYED_TEMPLATES if not (root / t).is_file()]
+    assert not missing, (
+        "DEPLOYED_TEMPLATES lists templates that no longer exist: "
+        f"{missing}. Update this test's template list."
+    )
+
+
+@pytest.mark.parametrize("rel_path", DEPLOYED_TEMPLATES)
+def test_every_iam_role_sets_permissions_boundary(rel_path):
+    """Every role-creating resource attaches the optional permissions boundary."""
+    template = _load(rel_path)
+    offenders = []
+    for name, body in _resources(template).items():
+        if not _needs_boundary(body):
+            continue
+        props = body.get("Properties") or {}
+        if "PermissionsBoundary" not in props:
+            offenders.append(f"{name} ({body.get('Type')})")
+
+    assert not offenders, (
+        f"{rel_path}: these role-creating resources are missing a "
+        "'PermissionsBoundary' property. In SCP-enforced accounts their "
+        "IAM role creation is denied and the stack rolls back. Add:\n"
+        "    PermissionsBoundary: !If [HasPermissionsBoundary, "
+        "!Ref PermissionsBoundaryArn, !Ref AWS::NoValue]\n"
+        f"Offenders: {offenders}"
+    )
+
+
+@pytest.mark.parametrize("rel_path", DEPLOYED_TEMPLATES)
+def test_templates_with_roles_declare_boundary_plumbing(rel_path):
+    """A template that creates roles must declare the param + condition it uses."""
+    template = _load(rel_path)
+    creates_roles = any(
+        _needs_boundary(body) for name, body in _resources(template).items()
+    )
+    if not creates_roles:
+        pytest.skip(f"{rel_path} creates no IAM roles")
+
+    params = template.get("Parameters") or {}
+    conditions = template.get("Conditions") or {}
+    assert "PermissionsBoundaryArn" in params, (
+        f"{rel_path} creates IAM roles but does not declare the "
+        "'PermissionsBoundaryArn' parameter."
+    )
+    assert "HasPermissionsBoundary" in conditions, (
+        f"{rel_path} creates IAM roles but does not declare the "
+        "'HasPermissionsBoundary' condition guarding the boundary."
+    )
+
+
+def _template_url_to_source(url: str) -> str:
+    """Map a nested-stack TemplateURL to its committed source template.
+
+    Nested stacks reference the built artifact
+    (``./nested/foo/.aws-sam/packaged.yaml``); the committed source lives at
+    ``nested/foo/template.yaml``.
+    """
+    cleaned = url.replace("./", "", 1) if url.startswith("./") else url
+    base = cleaned.split("/.aws-sam/")[0]
+    return f"{base}/template.yaml"
+
+
+def test_nested_stacks_forward_permissions_boundary():
+    """Every nested stack forwards PermissionsBoundaryArn to children that need it.
+
+    This is the exact defect that broke FeaturePlatformStack: the child template
+    declared (or needed) the parameter, but the parent's
+    ``AWS::CloudFormation::Stack`` resource did not pass it through, so the child
+    silently got the empty-string default and created boundary-less roles.
+    """
+    root = _repo_root()
+    main = _load("template.yaml")
+    offenders = []
+    for name, body in _resources(main).items():
+        if body.get("Type") != "AWS::CloudFormation::Stack":
+            continue
+        props = body.get("Properties") or {}
+        url = props.get("TemplateURL")
+        if not isinstance(url, str):
+            continue
+        child_src = _template_url_to_source(url)
+        if not (root / child_src).is_file():
+            # Child template isn't a committed source we can introspect; skip.
+            continue
+        child_params = (_load(child_src).get("Parameters") or {})
+        if "PermissionsBoundaryArn" not in child_params:
+            continue  # child doesn't take the param -> nothing to forward
+        passed = props.get("Parameters") or {}
+        if "PermissionsBoundaryArn" not in passed:
+            offenders.append(f"{name} -> {child_src}")
+
+    assert not offenders, (
+        "These nested stacks accept a 'PermissionsBoundaryArn' parameter but the "
+        "parent template.yaml does not forward it (child gets the empty default "
+        "and creates boundary-less roles -> fails in SCP-enforced accounts). Add "
+        "'PermissionsBoundaryArn: !Ref PermissionsBoundaryArn' to the nested "
+        f"stack's Parameters. Offenders: {offenders}"
+    )

--- a/template.yaml
+++ b/template.yaml
@@ -1839,6 +1839,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: ShouldDeployBastionHost
     Properties:
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref AWS::NoValue]
       RoleName: !Sub '${AWS::StackName}BastionHost-Role'
       Description: 'Assumed by bastion host'
       AssumeRolePolicyDocument:
@@ -2135,6 +2136,10 @@ Resources:
     # checkov:skip=CKV_AWS_115: "Function does not require reserved concurrency as it scales based on demand"
     # checkov:skip=CKV_AWS_173: "Environment variables do not contain sensitive data - only configuration values like feature flags and non-sensitive settings"
     Properties:
+      # SAM auto-generates this function's execution role. Set the boundary on
+      # the function so it flows onto that generated role — otherwise creation
+      # fails in accounts whose SCP requires a boundary on every IAM role.
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref AWS::NoValue]
       FunctionName: !Sub "${AWS::StackName}-agentcore-mcp-handler"
       CodeUri: src/lambda/agentcore_mcp_handler/
       Handler: index.lambda_handler
@@ -2451,6 +2456,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: CreateAgentCoreLambda
     Properties:
+      PermissionsBoundary: !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref AWS::NoValue]
       RoleName: !Sub "${AWS::StackName}-AgentCoreGatewayExecutionRole"
       Description: Execution role for AgentCore Gateway
       AssumeRolePolicyDocument:
@@ -2922,6 +2928,12 @@ Resources:
         # read it at runtime — the catalog source, no artifacts-bucket dependency.
         ConfigurationBucketName: !Ref ConfigurationBucket
         LogLevel: !Ref LogLevel
+        # Forward the permissions boundary so the nested stack's IAM role
+        # (FeaturePlatformLambdaRole) is created with it. Without this,
+        # accounts with an SCP that requires a boundary on every role fail
+        # nested-stack creation and roll back. See the other nested stacks
+        # (bedrockkb, pattern, reporting, discovery) which all forward this.
+        PermissionsBoundaryArn: !Ref PermissionsBoundaryArn
   # === Feature Platform (optional) — END =================================
 
   CustomerManagedEncryptionKey:


### PR DESCRIPTION
## Summary

The Feature Platform nested stack (`feature-platform/main-stack-extensions`) **failed creation and rolled back** in a customer account whose SCP requires a permissions boundary on every IAM role. Two gaps combined:

1. The main `template.yaml` `FeaturePlatformStack` resource did **not** forward `PermissionsBoundaryArn` (unlike every other nested stack — bedrockkb, pattern, reporting, discovery — which all forward it).
2. The nested template neither declared the `PermissionsBoundaryArn` parameter nor attached a boundary to its `FeaturePlatformLambdaRole`.

Result: in an SCP-enforced account, `iam:CreateRole` is denied → the nested stack fails → fast rollback (hard to diagnose). Only triggers when `EnableFeaturePlatform=true` **and** the account enforces boundaries, so it slipped past normal testing.

While fixing this I found the same latent gap on other role-creating resources and fixed those too.

## Changes

- **`feature-platform/main-stack-extensions/template.yaml`** *(the reported bug)*: declare `PermissionsBoundaryArn` + `HasPermissionsBoundary` condition, attach the boundary to `FeaturePlatformLambdaRole`.
- **`template.yaml`**: forward `PermissionsBoundaryArn` into `FeaturePlatformStack`; also attach the boundary to the conditional `BastionRole`, `AgentCoreGatewayExecutionRole`, and `AgentCoreMCPHandlerFunction` (latent — behind optional conditions, not yet hit).
- **Installable feature templates** (`feature-template`, `sample-feature`, `sample-health-insurance-review`): attach the boundary to the SAM-auto-role functions `FeatureApiFunction` / `ClaimStatusHookFunction` so **feature installs** don't fail the same way. (A function with an explicit `Role:` inherits that role's boundary; only auto-role functions need the property.)

## Regression test

Adds `lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py` (fast unit gate, 20 cases) asserting, across all 9 deployed-stack templates, that:
1. every `AWS::IAM::Role` and every auto-role `AWS::Serverless::Function` attaches `PermissionsBoundary`;
2. every role-creating template declares the param + condition;
3. every nested `AWS::CloudFormation::Stack` forwards `PermissionsBoundaryArn` to children that accept it.

**Verified to fail on the pre-fix state** (reverting either facet of the fix turns it red), and passes now.

## Testing

- New test: 20 passed.
- Full `idp_sdk` non-integration suite: 207 passed.
- `cfn-lint` clean on all edited source templates. (The one `E3043` on `template.yaml` re: `PermissionsBoundaryArn` is a known false positive — cfn-lint reads a stale gitignored `.aws-sam/packaged.yaml`; `sam build` in `publish.py` regenerates it from source. Same class as the pre-existing APIRESOLVERSTACK E3043s.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)