### PR TITLE
chore(deps): bump brace-expansion from 2.1.0 to 2.1.2 in /src/ui (develop)

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -33,7 +33,7 @@
         "ajv-formats": "^2.1.1",
         "aws-amplify": "^6.16.2",
         "axios": "^1.18.0",
-        "brace-expansion": "^2.0.3",
+        "brace-expansion": "^2.1.2",
         "chart.js": "^4.5.0",
         "dompurify": "^3.4.11",
         "form-data": "^4.0.4",
@@ -9808,9 +9808,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -33,7 +33,7 @@
     "ajv-formats": "^2.1.1",
     "aws-amplify": "^6.16.2",
     "axios": "^1.18.0",
-    "brace-expansion": "^2.0.3",
+    "brace-expansion": "^2.1.2",
     "chart.js": "^4.5.0",
     "dompurify": "^3.4.11",
     "form-data": "^4.0.4",


### PR DESCRIPTION
Re-applies Dependabot PR #535 onto `develop`. The original merge landed on `main` because Dependabot's rebase silently reset the PR base back to `main` after it had been retargeted to `develop`.

Patch-level bump fixing CVE-2026-13149 (backport of the v5.0.6 fix). Lockfile regenerated with `npm install --package-lock-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)