### PR TITLE
fix(security): add # nosec B506 to SafeLoader-based yaml.load in permissions boundary test

### DIFF
--- a/lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py
+++ b/lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py
@@ -95,7 +95,10 @@ DEPLOYED_TEMPLATES = [
 def _load(rel_path: str) -> dict:
     path = _repo_root() / rel_path
     with open(path, "r", encoding="utf-8") as f:
-        return yaml.load(f, Loader=_CFNLoader) or {}
+        # Safe: _CFNLoader subclasses yaml.SafeLoader (see above); the multi-
+        # constructor only builds plain scalars/sequences/mappings for CFN
+        # intrinsic tags -- no Python-object construction is possible.
+        return yaml.load(f, Loader=_CFNLoader) or {}  # nosec B506
 
 
 def _resources(template: dict) -> dict:


### PR DESCRIPTION
## Summary

Resolves the AppSec **Unsafe YAML Load** finding on `lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py` (line 98) — the same false positive previously dispositioned as *Not_Useful / Tool Incorrect* on ticket V2265075686 (Jul 16).

The flagged `yaml.load` call is safe:
- `_CFNLoader` subclasses `yaml.SafeLoader`, not the unsafe default `Loader`.
- The only registered multi-constructor handles CloudFormation intrinsic tags (`!Ref`, `!Sub`, `!GetAtt`, …) and returns plain scalars/sequences/mappings.
- No `!!python/object/*` constructors are registered, so there is no RCE path.

This file was the one SafeLoader-based `yaml.load` call site in the repo missing a `# nosec B506` annotation; this PR adds it with a justification comment, matching the existing annotations in `lib/idp_sdk/idp_sdk/_core/publish.py` and `scripts/sdlc/validate_service_role_permissions.py`.

## Verification

- Repo-wide sweep: all `yaml.load` call sites use SafeLoader-derived loaders and are now annotated; no `unsafe_load`/`full_load` variants exist.
- `bandit -t B506` over all six call sites: **No issues identified**.
- `pytest lib/idp_sdk/tests/unit/test_permissions_boundary_coverage.py`: 20/20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)