### PR TITLE
chore(deps): bump dompurify, immutable, fast-uri in src/ui

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -35,7 +35,7 @@
         "axios": "^1.18.0",
         "brace-expansion": "^2.1.2",
         "chart.js": "^4.5.0",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "form-data": "^4.0.4",
         "immer": "^10.1.3",
         "js-yaml": "^4.3.0",
@@ -10997,9 +10997,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11951,9 +11951,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -13019,9 +13019,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -35,7 +35,7 @@
     "axios": "^1.18.0",
     "brace-expansion": "^2.1.2",
     "chart.js": "^4.5.0",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "form-data": "^4.0.4",
     "immer": "^10.1.3",
     "js-yaml": "^4.3.0",


### PR DESCRIPTION
Consolidates three Dependabot npm bumps that targeted \`main\` and could not merge cleanly to \`develop\` (lockfile divergence + Dependabot's rebase resetting the base back to \`main\` each cycle). Applied directly against \`develop\` with npm regenerating the lockfile so transitive deps stay transitive.

| Dependency | Old → New | Type | Supersedes |
|---|---|---|---|
| dompurify | 3.4.11 → 3.4.12 | direct prod (XSS sanitizer) | #540 |
| immutable | 5.1.5 → 5.1.9 | transitive/dev | #542 |
| fast-uri | 3.1.2 → 3.1.4 | transitive | #539 |

All three are patch bumps with no breaking changes affecting our usage. package.json changes are limited to the single direct dep (dompurify); the lockfile diff is exactly the three version/integrity updates (10 lines).

Validation: \`npm run build\` ✅ and \`npm run lint\` ✅ locally.

Note: svgo bump (#538) was closed as redundant — develop already has 4.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)