### PR TITLE
fix: handle '#' in S3 object keys in getFileContents resolver and processresults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ SPDX-License-Identifier: MIT-0
 
 ### Fixed
 
+- **Documents with `#` in their name no longer break View Data / View Page Text and results metadata.** `urllib.parse.urlparse` treats `#` in an S3 URI as a URL-fragment delimiter, so keys like `Report_#2.pdf/pages/1/result.json` were silently truncated at the `#`, causing `NoSuchKey` errors ("No response from getFileContents" in the UI) and wrongly-named `.metadata.json` files. The `getFileContents`/`getFilePresignedUrl` resolver and the two processresults functions now parse S3 URIs with a plain string split (matching `idp_common.utils.parse_s3_uri`), preserving `#` in keys.
+
 - **Claude Sonnet 5 now appears in the UI model picker.** Sonnet 5 (`claude-sonnet-5` and the `:1m` extended-context variant) was present in pricing, model limits, and the Bedrock client routing — and is the system default extraction model — but was missing from the CloudFormation model enums in `patterns/unified/template.yaml` that feed the config schema, so it never showed in the config UI's model dropdown. Both variants are now registered across all three inference-profile prefixes (`us.`/`eu.`/`global.`). (#544)
 
 - **Addressed package vulnerabilities flagged by recent dependency scans.** Upgraded affected direct and transitive dependencies across the web UI (`src/ui`), the docs site, and the multi-doc-discovery and OCR-benchmark Lambdas to their patched versions.

--- a/nested/api-resolvers/src/lambda/get_file_contents_resolver/index.py
+++ b/nested/api-resolvers/src/lambda/get_file_contents_resolver/index.py
@@ -6,7 +6,6 @@ import json
 import logging
 import mimetypes
 import os
-from urllib.parse import urlparse
 
 import boto3
 from botocore.config import Config
@@ -140,11 +139,18 @@ def _parse_and_validate_uri(event):
     # form `s3://<bucket>/<key>`. We intentionally do NOT accept
     # virtual-hosted-style HTTPS URIs here because they require a
     # completely different parsing path.
-    parsed_uri = urlparse(s3_uri)
-    if parsed_uri.scheme != "s3" or not parsed_uri.netloc:
+    #
+    # Parse with a plain string split rather than urllib.parse.urlparse:
+    # object keys may contain '#' (e.g. "Borrowing_Notice_#2.pdf/pages/1/
+    # result.json"), which urlparse treats as a URL fragment delimiter and
+    # silently truncates, producing a wrong key and a NoSuchKey error.
+    if not s3_uri.startswith("s3://"):
         raise Exception("Invalid S3 URI: expected s3://<bucket>/<key>")
-    bucket = parsed_uri.netloc
-    key = parsed_uri.path.lstrip('/')  # Remove leading slash from path
+    # Strip scheme, then split once into bucket and key.
+    parts = s3_uri[len("s3://"):].split("/", 1)
+    if len(parts) < 2 or not parts[0]:
+        raise Exception("Invalid S3 URI: expected s3://<bucket>/<key>")
+    bucket, key = parts
     if not key:
         raise Exception("Invalid S3 URI: key is required")
 

--- a/nested/api-resolvers/src/lambda/get_file_contents_resolver/test_index.py
+++ b/nested/api-resolvers/src/lambda/get_file_contents_resolver/test_index.py
@@ -107,3 +107,50 @@ def test_invalid_uri_raises(resolver):
     index, _ = resolver
     with pytest.raises(Exception):
         index.handler(_event("getFilePresignedUrl", "not-an-s3-uri"), None)
+
+
+@pytest.mark.unit
+def test_uri_missing_key_raises(resolver):
+    index, _ = resolver
+    with pytest.raises(Exception, match="Invalid S3 URI"):
+        index.handler(_event("getFilePresignedUrl", f"s3://{OUTPUT_BUCKET}"), None)
+
+
+# Object keys may legitimately contain '#' (document ids like
+# "Report_#2.pdf"). urlparse-based parsing truncated the key at '#'
+# (fragment delimiter), yielding NoSuchKey; these tests pin the fix.
+HASH_KEY = "Report_#2.pdf/pages/1/result.json"
+
+
+@pytest.mark.unit
+def test_get_file_contents_key_with_hash(resolver):
+    index, s3 = resolver
+    s3.put_object(
+        Bucket=OUTPUT_BUCKET,
+        Key=HASH_KEY,
+        Body=b'{"page": 1}',
+        ContentType="application/json",
+    )
+    result = index.handler(
+        _event("getFileContents", f"s3://{OUTPUT_BUCKET}/{HASH_KEY}"),
+        None,
+    )
+    assert result["content"] == '{"page": 1}'
+    assert result["isBinary"] is False
+
+
+@pytest.mark.unit
+def test_get_file_presigned_url_key_with_hash(resolver):
+    index, s3 = resolver
+    s3.put_object(
+        Bucket=OUTPUT_BUCKET,
+        Key=HASH_KEY,
+        Body=b'{"page": 1}',
+        ContentType="application/json",
+    )
+    result = index.handler(
+        _event("getFilePresignedUrl", f"s3://{OUTPUT_BUCKET}/{HASH_KEY}"),
+        None,
+    )
+    assert result["presignedUrl"].startswith("https://")
+    assert result["size"] == len(b'{"page": 1}')

--- a/patterns/unified/src/bda_processresults_function/index.py
+++ b/patterns/unified/src/bda_processresults_function/index.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 from decimal import Decimal
-from urllib.parse import urlparse
 
 import boto3
 import pypdfium2 as pdfium
@@ -17,7 +16,7 @@ from idp_common.config import get_config
 from idp_common.docs_service import create_document_service
 from idp_common.models import Document, HitlMetadata, Page, Section, Status
 from idp_common.s3 import get_s3_client, write_content
-from idp_common.utils import build_s3_uri
+from idp_common.utils import build_s3_uri, parse_s3_uri
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -73,10 +72,11 @@ def create_metadata_file(file_uri, class_type, file_type=None):
         file_type (str, optional): Type of file ('section' or 'page')
     """
     try:
-        # Parse the S3 URI to get bucket and key
-        parsed_uri = urlparse(file_uri)
-        bucket = parsed_uri.netloc
-        key = parsed_uri.path.lstrip("/")
+        # Parse the S3 URI to get bucket and key. Use parse_s3_uri (plain
+        # string split) rather than urllib.parse.urlparse: object keys may
+        # contain '#', which urlparse treats as a URL fragment delimiter and
+        # silently truncates, producing a wrong metadata key.
+        bucket, key = parse_s3_uri(file_uri)
 
         # Create the metadata key by adding '.metadata.json' to the original key
         metadata_key = f"{key}.metadata.json"
@@ -805,9 +805,12 @@ def process_bda_pages(
 
 
 def parse_s3_path(s3_uri: str) -> (str, str):
-    """Extract bucket and key from s3:// URI."""
-    parsed = urlparse(s3_uri)
-    return parsed.netloc, parsed.path.lstrip("/")
+    """Extract bucket and key from s3:// URI.
+
+    Delegates to idp_common.utils.parse_s3_uri, which splits on '/' instead of
+    urlparse so keys containing '#' are not truncated at the fragment marker.
+    """
+    return parse_s3_uri(s3_uri)
 
 
 def download_json(bucket: str, key: str) -> dict:

--- a/patterns/unified/src/processresults_function/index.py
+++ b/patterns/unified/src/processresults_function/index.py
@@ -5,7 +5,6 @@ import datetime
 import json
 import logging
 import os
-from urllib.parse import urlparse
 
 import boto3
 from idp_common import s3, utils
@@ -219,10 +218,11 @@ def create_metadata_file(file_uri, class_type, file_type=None):
     Creates a metadata file alongside the given URI file with the same name plus '.metadata.json'
     """
     try:
-        # Parse the S3 URI to get bucket and key
-        parsed_uri = urlparse(file_uri)
-        bucket = parsed_uri.netloc
-        key = parsed_uri.path.lstrip("/")
+        # Parse the S3 URI to get bucket and key. Use parse_s3_uri (plain
+        # string split) rather than urllib.parse.urlparse: object keys may
+        # contain '#', which urlparse treats as a URL fragment delimiter and
+        # silently truncates, producing a wrong metadata key.
+        bucket, key = utils.parse_s3_uri(file_uri)
 
         # Create the metadata key by adding '.metadata.json' to the original key
         metadata_key = f"{key}.metadata.json"


### PR DESCRIPTION
## Problem

`urllib.parse.urlparse` treats `#` in an S3 URI as a URL-fragment delimiter and silently truncates the key. Object keys legitimately contain `#` (e.g. `Report_#2.pdf/pages/1/result.json`), so `urlparse`-based parsing yields a wrong key and `NoSuchKey` downstream:

- The UI's **View Data / View Page Text** actions fail with *"No response from getFileContents"* for any document whose name contains `#` — the URI `s3://…/Report_#2.pdf/pages/1/result.json` is parsed to key `Report_` (truncated at `#`).
- The processresults functions write `.metadata.json` files under truncated keys.

The library-level fixes for this bug class already landed via `idp_common.utils.parse_s3_uri` (used by `s3util`, `reporting`, and `models.decompress`); this PR ports the remaining Lambda-level cases.

## Changes

- **`nested/api-resolvers/src/lambda/get_file_contents_resolver/index.py`** — parse the `s3://` URI with a plain string split (strip scheme, split once on `/`) so `#` is preserved. Inline rather than `parse_s3_uri` because this Lambda has no `idp_common` dependency. Validation behavior (scheme check, empty-key check, bucket allow-list) is unchanged.
- **`patterns/unified/src/processresults_function/index.py`** / **`patterns/unified/src/bda_processresults_function/index.py`** — replace `urlparse`-based S3 URI parsing (`create_metadata_file`, `parse_s3_path`) with `idp_common.utils.parse_s3_uri`. Non-S3 `urlparse` uses: none remained; the `urlparse` imports are dropped.

## Testing

- New resolver unit tests pin `#`-in-key round-trips for both the inline-contents and presigned-URL branches, plus a missing-key validation case (`nested/api-resolvers/src/lambda/get_file_contents_resolver/test_index.py` — 8/8 pass).
- `lib/idp_common_pkg` unit tests for `s3util`/`lambdas` pass; `ruff check` and `ruff format --check` clean.