### PR TITLE
chore(deps): bump postcss from 8.5.10 to 8.5.22 in /src/ui

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -44,7 +44,7 @@
         "lodash-es": "^4.18.1",
         "mammoth": "^1.9.1",
         "pdfjs-dist": "^4.10.38",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.22",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1",
@@ -15617,9 +15617,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -16242,9 +16242,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16261,7 +16261,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -44,7 +44,7 @@
     "lodash-es": "^4.18.1",
     "mammoth": "^1.9.1",
     "pdfjs-dist": "^4.10.38",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.22",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
Applies Dependabot's postcss bump (#555) directly on `develop`.

Dependabot opened #555 against `main`; its branch conflicted with `develop`'s newer `axios`/`dompurify`/`js-yaml` pins (and Dependabot's rebase kept resetting the base back to `main`), so this re-applies the same bump cleanly on `develop`.

- `postcss` 8.5.10 → 8.5.22 (patch)
- transitive: `nanoid` 3.3.11 → 3.3.16

Both used only by the UI build toolchain (Vite/PostCSS); no direct app imports. UI build verified locally (`make ui-build`).

Closes #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)