### PR TITLE
docs(security): add 0.6.1.rc1 security test-results snapshot

### DIFF
--- a/security/test-results/0.6.1.rc1/MANIFEST.md
+++ b/security/test-results/0.6.1.rc1/MANIFEST.md
@@ -1,0 +1,23 @@
+# Security Test Snapshot — 0.6.1.rc1
+
+Auditable, public-safe summary of this release's security tests. Environment-specific identifiers (account IDs, pool IDs, API hostnames, request IDs, local paths) are redacted; raw reports live in gitignored `scratch/`/`.srt/` and are not published.
+
+## Provenance
+
+| Field | Value |
+|-------|-------|
+| Release version | `0.6.1.rc1` |
+| Git SHA | `e3f005969` |
+| Snapshot date | 2026-07-24 |
+| Curated by | `scripts/security/curate_results.py` |
+
+## Results
+
+| Test | Gate | Detail |
+|------|------|--------|
+| [SRT — SAST & deps](./srt.md) | PASS ✅ | 0 open HIGH of 8513 tracked |
+| [RBAC — static](./rbac-static.md) | PASS ✅ | 0 fail, 2 known-gap warn |
+| [RBAC — dynamic](./rbac-dynamic.md) | PASS ✅ | 496 checks, 0 hard fail |
+| [ZAP DAST](./zap-dast.md) | PASS ✅ | High=0 |
+
+See [`security/README.md`](../../README.md) for what each test covers and how to run it.

--- a/security/test-results/0.6.1.rc1/rbac-dynamic.md
+++ b/security/test-results/0.6.1.rc1/rbac-dynamic.md
@@ -1,0 +1,137 @@
+# RBAC — Dynamic API Authorization Tests
+
+Live tests against a deployed stack: temporary Cognito users (one per group + a config-version-scoped Author + a second user for IDOR) exercise every API op across all roles, unauthenticated, and with malformed/expired tokens, plus the AppSec mandatory-cases checklist (IDOR, token lifecycle, TLS, input validation, deleted-resource).
+
+## Summary
+
+- **Gate (hard failures):** PASS ✅
+- **Checks:** 496 (495 passed, 0 hard fail, 1 known-gap warning)
+- **Ran against:** stack `<REDACTED>` in region `us-west-2` (account `<ACCOUNT_ID>`)
+- **Source git SHA:** `e3f005969`
+
+## Test suites executed
+
+Each suite maps to the AppSec "Minimum Mandatory Security Focused Test Cases for APIs" checklist item (see the [api-rbac-test skill](../../../.claude/skills/api-rbac-test.md)).
+
+| Suite | Checklist | Checks | Pass | Hard fail | Known-gap |
+|-------|:---------:|-------:|-----:|----------:|----------:|
+| Token negatives (missing/garbage/tampered/empty) | 1 | 4 | 4 | 0 ✅ | 0 |
+| Unauthenticated access denied | 1 | 94 | 94 | 0 ✅ | 0 |
+| IDOR / BOLA (cross-user resource access) | 2.1 | 2 | 2 | 0 ✅ | 0 |
+| Token lifecycle (expiry + logout revocation) | 2.3/2.4 | 2 | 1 | 0 ✅ | 1 |
+| Deleted-resource inaccessibility | 2.5 | 1 | 1 | 0 ✅ | 0 |
+| Authorization matrix (positive: role allowed) | 2/2.2 | 376 | 376 | 0 ✅ | 0 |
+| Config-version scope enforcement | 2/2.2 | 6 | 6 | 0 ✅ | 0 |
+| Input validation (malformed arguments) | 3 | 7 | 7 | 0 ✅ | 0 |
+| TLS protocol (1.0/1.1/cleartext refused, 1.2+ accepted) | 4 | 4 | 4 | 0 ✅ | 0 |
+
+## ⚠️ Known-gap findings (accepted risk)
+
+| Op | Principal | Status | Gap | Detail |
+|----|-----------|-------:|-----|--------|
+| `listDocuments` | token:post-logout | 200 | GAP-SEC-LOGOUT | SEC-2.4-LOGOUT-REVOCATION: token before-logout=200, after-logout=200. STILL ACCEPTED (stateless JWT — see gap) |
+
+## Authorization matrix — 94 operations × 5 roles
+
+<details><summary>Full op × role matrix (470 checks) — HTTP status, ✅ pass / ❌ fail</summary>
+
+| Operation | Admin | Author | Viewer | Reviewer | unauth |
+|-----------|---|---|---|---|---|
+| `abortTestRuns` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `abortWorkflow` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `addDocumentsToTestSet` | 500 ✅ | 500 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `addDocumentsToTestSetFromUpload` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `addTestSet` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `addTestSetFromUpload` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `autoDetectSections` | 500 ✅ | 500 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `calculateCapacity` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `checkFeatureEntitlement` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `claimReview` | 400 ✅ | 403 ✅ | 403 ✅ | 400 ✅ | 401 ✅ |
+| `compareDocumentVersions` | 400 ✅ | 400 ✅ | 400 ✅ | 400 ✅ | 401 ✅ |
+| `compareTestRuns` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `completeSectionReview` | 400 ✅ | 403 ✅ | 403 ✅ | 400 ✅ | 401 ✅ |
+| `copyToBaseline` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `createFinetuningJob` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `createUser` | 400 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteAgentJob` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `deleteChatSession` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `deleteConfigVersion` | 200 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteDiscoveryJob` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteDocument` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteDocumentVersion` | 400 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteFinetuningJob` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteTestSets` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteTests` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `deleteUser` | 400 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `getAgentJobStatus` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `getChatMessages` | 500 ✅ | 500 ✅ | 500 ✅ | 500 ✅ | 401 ✅ |
+| `getCircuitBreakerStatus` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getConfigVersion` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `getConfigVersions` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `getConfigurationLibraryFile` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `getDocument` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getDocumentCount` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getDocumentVersion` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getFeatureLaunchUrl` | 500 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `getFileContents` | 500 ✅ | 500 ✅ | 500 ✅ | 500 ✅ | 401 ✅ |
+| `getFilePresignedUrl` | 500 ✅ | 500 ✅ | 500 ✅ | 500 ✅ | 401 ✅ |
+| `getFinetuningJob` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getLatestPublishedVersion` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getModelConfigLimits` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `getMyProfile` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getPricing` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `getSampleDocumentUrl` | 400 ✅ | 400 ✅ | 400 ✅ | 403 ✅ | 401 ✅ |
+| `getStepFunctionExecution` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `getTestRun` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `getTestRunStatus` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `getTestRuns` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `getTestSetDocuments` | 500 ✅ | 500 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `getTestSets` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `listAgentJobs` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `listAvailableAgents` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `listBucketFiles` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `listCatalogFeatures` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listChatSessions` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listConfigurationLibrary` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `listDiscoveryJobs` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `listDocumentVersions` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listDocuments` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listDocumentsByDateRange` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listDocumentsDateHour` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listDocumentsDateShard` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listFinetuningJobs` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listInstalledFeatures` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `listSampleDocuments` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `listUsers` | 200 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `processChanges` | 200 ✅ | 403 ✅ | 403 ✅ | 200 ✅ | 401 ✅ |
+| `queryKnowledgeBase` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `releaseReview` | 400 ✅ | 403 ✅ | 403 ✅ | 400 ✅ | 401 ✅ |
+| `reprocessDocument` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `restoreDefaultModelConfigLimits` | 200 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `restoreDefaultPricing` | 200 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `sendAgentChatMessage` | SKIP ✅ | SKIP ✅ | SKIP ✅ | 403 ✅ | 401 ✅ |
+| `sendChatDocumentMessage` | 500 ✅ | 500 ✅ | 500 ✅ | 500 ✅ | 401 ✅ |
+| `setActiveVersion` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `skipAllSectionsReview` | 400 ✅ | 403 ✅ | 403 ✅ | 400 ✅ | 401 ✅ |
+| `startMultiDocDiscovery` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `startTestRun` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `submitAgentQuery` | 200 ✅ | 200 ✅ | 200 ✅ | 403 ✅ | 401 ✅ |
+| `subscribeFeature` | 500 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `syncBdaIdp` | 200 ✅ | 200 ✅ | 200 ✅ | 200 ✅ | 401 ✅ |
+| `unsubscribeFeature` | 500 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updateAgentJobStatus` | 403 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updateConfiguration` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updateDiscoveryJobStatus` | 403 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updateModelConfigLimits` | 200 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updatePricing` | 200 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updateTestSet` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `updateUser` | 400 ✅ | 403 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `uploadDiscoveryDocument` | 400 ✅ | 400 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `uploadDocument` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `uploadMultiDocDiscoveryZip` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `uploadSampleDocument` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+| `validateTestFileName` | 200 ✅ | 200 ✅ | 403 ✅ | 403 ✅ | 401 ✅ |
+
+</details>
+
+> The per-check **request IDs** stay in the gitignored raw report (`report.md`); they are environment-specific and not published. Everything above (gate, suites, failures, and the status matrix) is the auditable record.

--- a/security/test-results/0.6.1.rc1/rbac-static.md
+++ b/security/test-results/0.6.1.rc1/rbac-static.md
@@ -1,0 +1,34 @@
+# RBAC — Static Authorization Scan
+
+Offline cross-check (no AWS): reconciles the API op universe, the schema `@aws_cognito_user_pools` directives, and the expectations file (`scripts/api_rbac_expectations.yaml`) for drift and missing server-side checks. WARN entries are known/accepted authorization gaps (documented in the expectations file), not failures.
+
+## Summary
+
+- **Gate:** PASS ✅ (2 known-gap warnings)
+- **API operations covered:** 97
+- **Result:** 0 FAIL · 2 WARN (known gaps)
+
+## Checks executed
+
+The scan runs this fixed battery against every operation; the gate fails on any FAIL finding.
+
+| Check | What it verifies | Outcome |
+|-------|------------------|---------|
+| **S1** Manifest completeness | every routable op has an expectations entry and every entry maps to a real op (no stale rows) | PASS ✅ |
+| **S2** Schema ↔ expectations consistency | schema.graphql `@aws_cognito_user_pools` groups match expected groups (documented drift allowed via `schema_groups`/`known_gap`) | PASS ✅ |
+| **S3** Resolver enforcement | each op's `enforced_in` source contains a recognized enforcement pattern (group check, ownership, or IAM-only rejection); ANY-auth ops without one must carry a known_gap | PASS ✅ |
+| **S4** Scope enforcement | ops flagged `scope_checked`/`scope_filtered` reference allowedConfigVersions in their `enforced_in` file | PASS ✅ |
+| **S5** Template method auth | every API Gateway method is COGNITO_USER_POOLS except the allowlisted CORS (OPTIONS) and static-SPA (GET) routes | PASS ✅ |
+
+## Captured output (known gaps + result)
+
+```
+Running static API RBAC scan...
+<LOCAL_PATH> scripts/sdlc/scan_api_rbac.py 
+=== Static API RBAC scan ===
+  ⚠ [GAP] GAP-01: getStepFunctionExecution has no group or ownership check — affects: getStepFunctionExecution
+  ⚠ [GAP] GAP-02: queryKnowledgeBase has no group check — affects: queryKnowledgeBase
+
+0 FAIL, 2 WARN
+RBAC_STATIC_EXIT=0
+```

--- a/security/test-results/0.6.1.rc1/srt.md
+++ b/security/test-results/0.6.1.rc1/srt.md
@@ -1,0 +1,102 @@
+# SRT — SAST & Dependency Scan
+
+Static analysis (Bandit, Semgrep, Checkov), dependency inventory (Syft), and the security-matrix review, aggregated by the [Sample Security Review Tool](https://github.com/aws-samples/sample-security-review-tool). The gate is **open HIGH** findings only; lower tiers are reported as counts (they are dominated by tracked third-party/vendored code).
+
+## Summary
+
+- **Gate (open HIGH findings):** PASS ✅
+- **CI-visible findings:** 8513
+- **Source:** live scan results (`.srt/issues.json`) — 88 git-ignored finding(s) excluded to match the CI view
+
+## Analyzers executed
+
+Each analyzer SRT ran, what it covers, and its contribution to the CI-visible findings.
+
+| Analyzer | Coverage | Findings | HIGH |
+|----------|----------|---------:|-----:|
+| Bandit | Python SAST | 8361 | 54 |
+| Checkov | IaC / CloudFormation misconfig | 104 | 2 |
+| Semgrep | multi-language SAST | 1 | 1 |
+| security-matrix | AWS security-control review (SRT rules) | 47 | 41 |
+
+## Findings by priority × status
+
+| Priority | Open | resolved | suppressed | Total |
+|----------|------:|------:|------:|------:|
+| HIGH | 0 | 60 | 38 | 98 |
+| MEDIUM | 58 | 0 | 0 | 58 |
+| LOW | 8354 | 0 | 0 | 8354 |
+| INFO | 3 | 0 | 0 | 3 |
+
+## HIGH findings by check (disposition)
+
+Every HIGH check-ID flagged, with how many are in each status. A green gate means all are resolved or suppressed (0 Open).
+
+| Source | Check | Open | resolved | suppressed |
+|--------|-------|--:|--:|--:|
+| Bandit | `B105` | 0 | 44 | 0 |
+| Bandit | `B106` | 0 | 5 | 0 |
+| Bandit | `B602` | 0 | 3 | 0 |
+| Bandit | `B701` | 0 | 2 | 0 |
+| Checkov | `CKV_AWS_192` | 0 | 2 | 0 |
+| Semgrep | `package_managers.npm.npm-missing-minimum-release-age.npm-missing-minimum-release-age` | 0 | 1 | 0 |
+| security-matrix | `API-GW-001` | 0 | 0 | 1 |
+| security-matrix | `API-GW-002` | 0 | 0 | 1 |
+| security-matrix | `API-GW-004` | 0 | 0 | 2 |
+| security-matrix | `API-GW-006` | 0 | 0 | 1 |
+| security-matrix | `DDB-002` | 0 | 1 | 15 |
+| security-matrix | `EC2-002` | 0 | 0 | 3 |
+| security-matrix | `IAM-009` | 0 | 0 | 1 |
+| security-matrix | `KMS-007` | 0 | 0 | 4 |
+| security-matrix | `LAMBDA-004` | 0 | 0 | 1 |
+| security-matrix | `LAMBDA-005` | 0 | 0 | 1 |
+| security-matrix | `LAMBDA-011` | 0 | 0 | 1 |
+| security-matrix | `LAMBDA-012` | 0 | 2 | 0 |
+| security-matrix | `S3-001` | 0 | 0 | 2 |
+| security-matrix | `S3-005` | 0 | 0 | 1 |
+| security-matrix | `S3-008` | 0 | 0 | 4 |
+
+## Suppressed HIGH findings (accepted risk / scanner limitation)
+
+Each carries a recorded justification; the authoritative register is `scripts/srt/issues.json`.
+
+| Source | Check | Path | Justification |
+|--------|-------|------|---------------|
+| security-matrix | `KMS-007` | `notebooks/examples/demo-lambda/template.yml` | Accepted: KMS key event monitoring (CloudTrail/EventBridge/alarms) is account-level infrastructure owned by the deploying customer, out of scope for the solution template. |
+| security-matrix | `DDB-002` | `patterns/unified/template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `EC2-002` | `scripts/sdlc/cfn/sdlc-iam-role.yml` | Accepted: BuilderRole is SDLC pipeline scaffolding for dev accounts and intentionally broad to build/publish all solution artifacts. |
+| security-matrix | `S3-001` | `scripts/sdlc/cfn/s3-sourcecode.yml` | Accepted: SDLC bootstrap scaffolding deployed in dev accounts; access logging omitted for short-lived pipeline source bucket. |
+| security-matrix | `S3-008` | `scripts/sdlc/cfn/s3-sourcecode.yml` | Accepted: SDLC pipeline scaffolding bucket in solution-builder dev accounts; retention of pipeline source/artifact objects is the pipeline owner's decision, and a lifecycle policy here is cost optimization rather than a security control. |
+| security-matrix | `KMS-007` | `scripts/sdlc/cfn/codepipeline-s3.yml` | Accepted: KMS key event monitoring (CloudTrail/EventBridge/alarms) is account-level infrastructure owned by the deploying customer, out of scope for the solution template. |
+| security-matrix | `IAM-009` | `scripts/sdlc/cfn/codepipeline-s3.yml` | Accepted: CodeBuild role in SDLC dev-account scaffolding; a permissions boundary is the account owner's policy decision, the template cannot assume one exists. |
+| security-matrix | `S3-001` | `scripts/sdlc/cfn/codepipeline-s3.yml` | Accepted: SDLC pipeline artifact bucket in dev accounts; access logging omitted for pipeline scaffolding. |
+| security-matrix | `S3-008` | `scripts/sdlc/cfn/codepipeline-s3.yml` | Accepted: SDLC pipeline scaffolding bucket in solution-builder dev accounts; retention of pipeline source/artifact objects is the pipeline owner's decision, and a lifecycle policy here is cost optimization rather than a security control. |
+| security-matrix | `KMS-007` | `template.yaml` | Accepted: KMS key event monitoring (CloudTrail/EventBridge/alarms) is account-level infrastructure owned by the deploying customer, out of scope for the solution template. |
+| security-matrix | `S3-008` | `template.yaml` | Accepted: bucket retention is a customer data-governance decision (evaluation baselines, working documents); imposing a lifecycle policy in the template risks deleting customer data. |
+| security-matrix | `S3-005` | `template.yaml` | False positive at scan time: WebUIBucket is fronted by CloudFront with an OriginAccessControl (sigv4, SigningBehavior always) plus a bucket policy conditioned on the distribution ARN when CloudFront hosting is enabled; the conditional resources cannot be evaluated statically. |
+| security-matrix | `S3-008` | `template.yaml` | Accepted: WebUIBucket holds only the current built web-app bundle, redeployed in full by CodeBuild on each update; there is no object accumulation to manage, and an expiry lifecycle rule could delete live UI assets. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `LAMBDA-004` | `nested/bedrockkb/template.yaml` | Accepted: X-Ray tracing intentionally omitted on helper/custom-resource Lambdas; enabling tracing is a customer deployment choice for this sample solution. |
+| security-matrix | `LAMBDA-011` | `nested/bedrockkb/template.yaml` | Accepted: CloudWatch alarms for helper/custom-resource Lambdas are intentionally omitted; failures surface via CloudFormation stack status. Alarm topology is a customer operations decision. |
+| security-matrix | `KMS-007` | `template.yaml` | Accepted: KMS key event monitoring (CloudTrail/EventBridge/alarms) is account-level infrastructure owned by the deploying customer, out of scope for the solution template. |
+| security-matrix | `EC2-002` | `template.yaml` | False positive: BastionRole (Condition ShouldDeployBastionHost, off by default) carries exactly the managed policy the finding's own fix recommends - AmazonSSMManagedInstanceCore - and nothing else; the instance profile attaches only that role. No excess privilege exists. |
+| security-matrix | `EC2-002` | `template.yaml` | False positive: BastionRole (Condition ShouldDeployBastionHost, off by default) carries exactly the managed policy the finding's own fix recommends - AmazonSSMManagedInstanceCore - and nothing else; the instance profile attaches only that role. No excess privilege exists. |
+| security-matrix | `DDB-002` | `feature-platform/main-stack-extensions/template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `feature-platform/sample-health-insurance-review/template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `DDB-002` | `nested/api-resolvers/template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. |
+| security-matrix | `API-GW-002` | `nested/api-resolvers/template.yaml` | Accepted: REST API in Lambda-proxy mode; the data-plane POST method is Cognito-authorized and the dispatcher Lambda validates each request body per-field, and the remaining method is the auth-less MOCK OPTIONS CORS preflight (static 200, no backend). API GW request validators add no value for opaque proxy payloads. |
+| security-matrix | `API-GW-004` | `nested/api-resolvers/template.yaml` | Accepted: intentional public static-asset route (enabled only when ServeWebUI=true). This GET serves the React SPA shell (index.html) from S3 to the browser BEFORE the user authenticates in-app; auth happens later against the Cognito-authorized /op POST. A JWT cannot be attached to the browser's initial document fetch, so AuthorizationType NONE is required, and only non-sensitive static UI files are exposed. Defense-in-depth: the stage-level WAFv2 IP allowlist (IsWafEnabled) and the PRIVATE-endpoint VPC policy (UsePrivateApi) still gate this route. |
+| security-matrix | `API-GW-004` | `nested/api-resolvers/template.yaml` | Accepted: intentional public static-asset route (enabled only when ServeWebUI=true). This GET /{proxy+} serves hashed SPA static assets (js/css/fonts/images) from S3 to the browser BEFORE the user authenticates in-app; auth happens later against the Cognito-authorized /op POST. A JWT cannot be attached to the browser's asset fetches, so AuthorizationType NONE is required, and only non-sensitive static UI files are exposed. Defense-in-depth: the stage-level WAFv2 IP allowlist (IsWafEnabled) and the PRIVATE-endpoint VPC policy (UsePrivateApi) still gate this route. |
+| security-matrix | `API-GW-001` | `nested/api-resolvers/template.yaml` | Accepted (scanner limitation): the stage DOES configure AccessLogSetting with both a DestinationArn (HttpApiAccessLogGroup, KMS-encrypted, RetentionInDays=LogRetentionDays) and a JSON Format, but they are wrapped in Fn::If [EnableApiAccessLogs] (on at LogLevel INFO/DEBUG). SRT's security-matrix cannot resolve Fn::If, so it does not see the DestinationArn/Format inside the conditional branch. Access logging is correctly implemented; the conditionality is intentional to avoid log costs at higher LogLevels. |
+| security-matrix | `API-GW-006` | `nested/api-resolvers/template.yaml` | Accepted (scanner limitation): the stage DOES set MethodSettings with LoggingLevel ERROR for ResourcePath '/*' HttpMethod '*', but wrapped in Fn::If [EnableApiAccessLogs]. SRT cannot resolve Fn::If and reads MethodSettings as a non-array, so it reports execution logging disabled. Execution logging is deliberately ERROR-only (INFO would echo full request/response payloads, incl. customer document data, into CloudWatch); JSON access logs cover request metadata. Logging is correctly implemented; the conditionality is intentional. |
+| security-matrix | `DDB-002` | `feature-platform/idp-data-generator/template.yaml` | Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. Consistent with all other DynamoDB tables in this solution. |
+| security-matrix | `LAMBDA-005` | `feature-platform/idp-data-generator/template.yaml` | Accepted: bedrock-agentcore:* on Resource '*' is required — CreateAgentRuntime transitively creates/deletes runtime endpoints and other sub-resources, so an action allow-list breaks create/delete; these control-plane APIs do not support resource-level permissions and the runtime ARN does not exist at create time. iam:PassRole/CreateServiceLinkedRole and logs are scoped. |

--- a/security/test-results/0.6.1.rc1/zap-dast.md
+++ b/security/test-results/0.6.1.rc1/zap-dast.md
@@ -1,0 +1,150 @@
+# ZAP DAST — Dynamic API Scan
+
+OWASP ZAP baseline/active scan of the deployed UI API (`POST /op/{field}`), seeded from a generated OpenAPI spec of every operation. Rules muted in `scripts/sdlc/zap-rules.conf` are excluded from the alert counts.
+
+## Summary
+
+- **Gate (High alerts):** PASS ✅
+- **Alerts:** High=0 Medium=1 Low=0 Info=0
+- **Rules exercised:** 118 (117 PASS · 1 WARN · 0 FAIL · 0 IGNORE)
+- **URLs scanned:** 100
+
+## Alerts (findings, most severe first)
+
+| Risk | Alert | Instances | Remediation |
+|------|-------|----------:|-------------|
+| Medium | Cross-Domain Misconfiguration | 5 | Ensure that sensitive data is not available in an unauthenticated manner (using IP address white-listing, for instance). Configure the "Access-Control-Allow-Ori |
+
+## Rules exercised (full outcome list)
+
+Every ZAP rule run against the seeded API, with its outcome. `WARN`/`FAIL` are actionable; `IGNORE` is muted in `scripts/sdlc/zap-rules.conf`; `PASS` means the rule ran and found nothing.
+
+### Non-PASS outcomes
+
+| Outcome | Rule | Plugin ID | Instances |
+|---------|------|-----------|----------:|
+| WARN-NEW | Cross-Domain Misconfiguration | `10098` | 17 |
+
+<details><summary>All PASS rules (117)</summary>
+
+| Rule | Plugin ID |
+|------|-----------|
+| Directory Browsing | `0` |
+| Vulnerable JS Library (Powered by Retire.js) | `10003` |
+| In Page Banner Information Leak | `10009` |
+| Cookie No HttpOnly Flag | `10010` |
+| Cookie Without Secure Flag | `10011` |
+| Re-examine Cache-control Directives | `10015` |
+| Cross-Domain JavaScript Source File Inclusion | `10017` |
+| Content-Type Header Missing | `10019` |
+| Anti-clickjacking Header | `10020` |
+| X-Content-Type-Options Header Missing | `10021` |
+| Information Disclosure - Debug Error Messages | `10023` |
+| Information Disclosure - Sensitive Information in URL | `10024` |
+| Information Disclosure - Sensitive Information in HTTP Referrer Header | `10025` |
+| HTTP Parameter Override | `10026` |
+| Information Disclosure - Suspicious Comments | `10027` |
+| Off-site Redirect | `10028` |
+| Cookie Poisoning | `10029` |
+| User Controllable Charset | `10030` |
+| User Controllable HTML Element Attribute (Potential XSS) | `10031` |
+| Viewstate | `10032` |
+| Directory Browsing | `10033` |
+| Heartbleed OpenSSL Vulnerability (Indicative) | `10034` |
+| Strict-Transport-Security Header | `10035` |
+| HTTP Server Response Header | `10036` |
+| Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s) | `10037` |
+| Content Security Policy (CSP) Header Not Set | `10038` |
+| X-Backend-Server Header Information Leak | `10039` |
+| Secure Pages Include Mixed Content | `10040` |
+| HTTP to HTTPS Insecure Transition in Form Post | `10041` |
+| HTTPS to HTTP Insecure Transition in Form Post | `10042` |
+| User Controllable JavaScript Event (XSS) | `10043` |
+| Big Redirect Detected (Potential Sensitive Information Leak) | `10044` |
+| Source Code Disclosure - /WEB-INF Folder | `10045` |
+| HTTPS Content Available via HTTP | `10047` |
+| Remote Code Execution - Shell Shock | `10048` |
+| Content Cacheability | `10049` |
+| Retrieved from Cache | `10050` |
+| X-ChromeLogger-Data (XCOLD) Header Information Leak | `10052` |
+| Cookie without SameSite Attribute | `10054` |
+| CSP | `10055` |
+| X-Debug-Token Information Leak | `10056` |
+| Username Hash Found | `10057` |
+| GET for POST | `10058` |
+| X-AspNet-Version Response Header | `10061` |
+| PII Disclosure | `10062` |
+| Permissions Policy Header Not Set | `10063` |
+| Timestamp Disclosure | `10096` |
+| Hash Disclosure | `10097` |
+| Source Code Disclosure | `10099` |
+| User Agent Fuzzer | `10104` |
+| Weak Authentication Method | `10105` |
+| HTTP Only Site | `10106` |
+| Reverse Tabnabbing | `10108` |
+| Modern Web Application | `10109` |
+| Dangerous JS Functions | `10110` |
+| Authentication Request Identified | `10111` |
+| Session Management Response Identified | `10112` |
+| Verification Request Identified | `10113` |
+| Script Served From Malicious Domain (polyfill) | `10115` |
+| ZAP is Out of Date | `10116` |
+| Absence of Anti-CSRF Tokens | `10202` |
+| Private IP Disclosure | `2` |
+| Heartbleed OpenSSL Vulnerability | `20015` |
+| Source Code Disclosure - CVE-2012-1823 | `20017` |
+| Remote Code Execution - CVE-2012-1823 | `20018` |
+| External Redirect | `20019` |
+| Session ID in URL Rewrite | `3` |
+| Buffer Overflow | `30001` |
+| Format String Error | `30002` |
+| CRLF Injection | `40003` |
+| Parameter Tampering | `40008` |
+| Server Side Include | `40009` |
+| Cross Site Scripting (Reflected) | `40012` |
+| Cross Site Scripting (Persistent) | `40014` |
+| Cross Site Scripting (Persistent) - Prime | `40016` |
+| Cross Site Scripting (Persistent) - Spider | `40017` |
+| SQL Injection | `40018` |
+| SQL Injection - MySQL (Time Based) | `40019` |
+| SQL Injection - Hypersonic SQL (Time Based) | `40020` |
+| SQL Injection - Oracle (Time Based) | `40021` |
+| SQL Injection - PostgreSQL (Time Based) | `40022` |
+| Cross Site Scripting (DOM Based) | `40026` |
+| SQL Injection - MsSQL (Time Based) | `40027` |
+| ELMAH Information Leak | `40028` |
+| Trace.axd Information Leak | `40029` |
+| .htaccess Information Leak | `40032` |
+| .env Information Leak | `40034` |
+| Hidden File Finder | `40035` |
+| Spring Actuator Information Leak | `40042` |
+| Log4Shell | `40043` |
+| Exponential Entity Expansion (Billion Laughs Attack) | `40044` |
+| Spring4Shell | `40045` |
+| Remote Code Execution (React2Shell) | `40048` |
+| Script Active Scan Rules | `50000` |
+| Script Passive Scan Rules | `50001` |
+| Path Traversal | `6` |
+| Remote File Inclusion | `7` |
+| Insecure JSF ViewState | `90001` |
+| Java Serialization Object | `90002` |
+| Sub Resource Integrity Attribute Missing | `90003` |
+| Insufficient Site Isolation Against Spectre Vulnerability | `90004` |
+| Charset Mismatch | `90011` |
+| XSLT Injection | `90017` |
+| Server Side Code Injection | `90019` |
+| Remote OS Command Injection | `90020` |
+| XPath Injection | `90021` |
+| Application Error Disclosure | `90022` |
+| XML External Entity Attack | `90023` |
+| Generic Padding Oracle | `90024` |
+| SOAP Action Spoofing | `90026` |
+| SOAP XML Injection | `90029` |
+| WSDL File Detection | `90030` |
+| Loosely Scoped Cookie | `90033` |
+| Cloud Metadata Potentially Exposed | `90034` |
+| Server Side Template Injection | `90035` |
+| Server Side Template Injection (Blind) | `90036` |
+| Remote OS Command Injection (Time Based) | `90037` |
+
+</details>


### PR DESCRIPTION
## Summary

Adds the curated, public-safe security test-results snapshot for **0.6.1.rc1** under `security/test-results/0.6.1.rc1/`. All four gates **PASS**.

| Test | Gate | Detail |
|------|------|--------|
| SRT — SAST & deps | PASS ✅ | 0 open HIGH of 8513 tracked |
| RBAC — static | PASS ✅ | 0 fail, 2 known-gap warns |
| RBAC — dynamic | PASS ✅ | 496 checks, 0 hard fail, 1 documented GAP-SEC-LOGOUT warn |
| ZAP DAST | PASS ✅ | High=0, 117 rules PASS / 0 FAIL |

## How it was run

- **Offline** (SRT, RBAC static) run on `develop` @ `e3f005969`.
- **Live** (RBAC dynamic, ZAP DAST) run against a stack deployed from the **immutable** `idp-main_0.6.1.rc1.yaml` template.
- The **GAP-03 fix** (Reviewer excluded from Agent Chat) is verified live: `listAvailableAgents` / `sendAgentChatMessage` return **403** for a Reviewer principal.
- Environment-specific identifiers (account IDs, pool IDs, API hostnames, request IDs, local paths) are redacted by `scripts/security/curate_results.py` — public-safe by construction.

## Files

`security/test-results/0.6.1.rc1/`: `MANIFEST.md`, `srt.md`, `rbac-static.md`, `rbac-dynamic.md`, `zap-dast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)