### PR TITLE
test(gate): register orphaned queue_sender suite + prune scratch/

### DIFF
--- a/scripts/run_all_tests.py
+++ b/scripts/run_all_tests.py
@@ -43,6 +43,9 @@ PRUNE_DIR_MARKERS = (
     "/site-packages/",
     "/.git/",
     "/.pytest_cache/",
+    # scratch/ is gitignored (local benchmarks, cloned tools, throwaway work);
+    # never part of the gate. CI never sees it, so prune it locally too.
+    "/scratch/",
     # idp_common ships fixture-style helper "tests" that are not a suite.
     "/idp_common/agents/testing/",
 )
@@ -83,6 +86,7 @@ RUN_ROOTS = [
     "src/lambda/external_idp_group_mapping",
     "src/lambda/job_tracker",
     "src/lambda/queue_processor",
+    "src/lambda/queue_sender",
     "src/lambda/save_reporting_data",
     "src/lambda/version_check_resolver",
     "src/lambda/workflow_tracker",


### PR DESCRIPTION
## Summary

The full-test gate (`scripts/run_all_tests.py`) discovers every `test_*.py` directory and hard-errors if one is in neither `RUN_ROOTS` nor `QUARANTINE` — a guard that exists so new test dirs are never silently skipped. Two dirs currently trip it:

1. **`src/lambda/queue_sender/test_index.py`** — a committed, passing 2-test suite that was **never registered in `RUN_ROOTS`**, so it has been silently absent from the gate. This is exactly the drift the guard is meant to catch. → added to `RUN_ROOTS`; it now runs and passes.
2. **`scratch/…/test_*.py`** — the gitignored `scratch/` tree (local benchmarks, cloned tools) trips the guard locally, though CI never sees it. The guard already prunes the other gitignored dirs (`.venv/`, `node_modules/`, `.aws-sam/`, …) but not `scratch/`. → added `/scratch/` to `PRUNE_DIR_MARKERS`.

## Effect

`make test` goes from **erroring at the guard** to **running all 38 test roots green**, with the previously-orphaned `queue_sender` suite now actually gated.

## Change

4 lines in one file (`scripts/run_all_tests.py`): one `PRUNE_DIR_MARKERS` entry + one `RUN_ROOTS` entry, each with a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)