### PR TITLE
fix(feature-platform): content-hash feature UI bundle paths so immutable caching survives same-version republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Extension UI pages no longer serve a stale bundle from the browser cache after a same-version republish.** Feature ui-deployers copied `ui-bundle.js` into the Web UI bucket at a version-only path (`features/<id>/v<ver>/`) with `Cache-Control: public,max-age=31536000,immutable` — so republishing the same feature version (dev iterations, reinstall after a rollback) left browsers serving the old bundle for up to a year without revalidating, since the URL never changed. The destination path now embeds a content hash of the bundle bytes (`features/<id>/v<ver>-<sha8>/`), so any byte change yields a new URL and immutable caching stays safe; uninstall cleans up every published copy (current, superseded, and old-layout keys) via a new prefix-scoped `s3:ListBucket` grant. Applies to all five bundled feature ui-deployers (pii-anonymizer, idp-data-generator, sample-feature, sample-health-insurance-review, feature-template).
+
 ## [0.6.2]
 
 ### Added

--- a/docs/feature-platform.md
+++ b/docs/feature-platform.md
@@ -363,7 +363,10 @@ The host contract a feature must satisfy:
   `src/ui/src/components/feature-page/feature-host-globals.ts`).
 - **CFN template** — registers itself via the `registerFeature` mutation from a
   custom resource on create, and uploads its UI bundle into
-  `WebUIBucket/features/<id>/v<ver>/`.
+  `WebUIBucket/features/<id>/v<ver>-<sha8>/` (the `<sha8>` is a content hash
+  of the bundle bytes — the bundle is served with `Cache-Control: immutable`,
+  so the path must change whenever the content changes, including when the
+  same version is republished during development).
 - **`feature.yaml` manifest** — validated against
   `lib/idp_feature_sdk/idp_feature_sdk/schemas/feature-manifest.schema.json`.
 

--- a/feature-platform/feature-template/template.yaml
+++ b/feature-platform/feature-template/template.yaml
@@ -218,6 +218,16 @@ Resources:
                 Resource: !Sub
                   - 'arn:${AWS::Partition}:s3:::${Bucket}/features/${FeatureId}/*'
                   - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+              # Cleanup lists the feature's own prefix to find every published
+              # bundle copy (current + superseded content-hashed dirs).
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
+                  - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+                Condition:
+                  StringLike:
+                    's3:prefix': !Sub 'features/${FeatureId}/*'
         - PolicyName: InvokeRegisterFeature
           PolicyDocument:
             Version: '2012-10-17'

--- a/feature-platform/feature-template/ui-deployer/handler.py
+++ b/feature-platform/feature-template/ui-deployer/handler.py
@@ -5,7 +5,9 @@
 
 On Create or Update:
   1. Copies s3://<FEATURE_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>/ui-bundle.js
-     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>/ui-bundle.js
+     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>-<sha8>/ui-bundle.js
+     (<sha8> = content hash — the bundle is served with Cache-Control:
+     immutable, so the URL must change whenever the bytes change)
   2. Directly invokes the host's registerFeature resolver Lambda to add a row
      to InstalledFeatures.
 
@@ -20,6 +22,7 @@ The Lambda's execution role carries the session tag `idp:feature-id=<FEATURE_ID>
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -83,15 +86,64 @@ def _artifact_prefix() -> str:
 # ---------------------------------------------------------------------------
 # UI bundle copy
 # ---------------------------------------------------------------------------
+_BUNDLE_PREFIX = f"features/{_FEATURE_ID}/"
+
+
+def _bundle_content_hash(src_key: str) -> str:
+    """First 8 hex chars of the sha256 of the bundle bytes.
+
+    The copied bundle is served with `Cache-Control: immutable`, which is only
+    safe if the URL changes whenever the content changes. The feature VERSION
+    alone is not enough: the same version can legitimately be republished
+    (dev iterations, a reinstall after a rollback), and browsers that cached
+    the old bytes under a version-only URL would keep serving them for a year
+    without revalidating.
+    """
+    resp = _s3.get_object(Bucket=_FEATURE_BUCKET, Key=src_key)
+    return hashlib.sha256(resp["Body"].read()).hexdigest()[:8]
+
+
+def _delete_bundle_objects() -> None:
+    """Delete ALL of this feature's objects under features/<id>/ on uninstall.
+
+    Listing the prefix (rather than deleting one computed key) removes every
+    published copy: current + superseded hashed dirs, and keys from the older
+    non-hashed layout (`v<version>/ui-bundle.js`). Superseded copies are
+    deliberately NOT pruned on Update — SPA sessions opened before the update
+    still hold the previous uiBundlePath and must keep loading until they
+    refresh. Best-effort: failures are logged, never raised.
+    """
+    try:
+        paginator = _s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=_WEBUI_BUCKET, Prefix=_BUNDLE_PREFIX):
+            keys = [
+                {"Key": k} for obj in page.get("Contents", []) if (k := obj.get("Key"))
+            ]
+            if keys:
+                _s3.delete_objects(
+                    Bucket=_WEBUI_BUCKET, Delete={"Objects": keys, "Quiet": True}
+                )
+                logger.info(
+                    "Deleted %d object(s) under s3://%s/%s",
+                    len(keys),
+                    _WEBUI_BUCKET,
+                    _BUNDLE_PREFIX,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("UI bundle cleanup failed (ignored): %s", exc)
+
+
 def _bundle_ui(request_type: str) -> str:
     """Return the uiBundlePath registered with the host (used for RegisterFeature)."""
     # Source is the published versioned artifact under the extension base;
     # destination is the host's canonical WebUIBucket layout that FeatureLoader
-    # fetches (features/<id>/v<ver>/ui-bundle.js).
+    # fetches (features/<id>/v<ver>-<sha8>/ui-bundle.js).
     src_key = f"{_artifact_prefix()}/ui-bundle.js"
-    dst_key = f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/ui-bundle.js"
 
     if request_type in ("Create", "Update"):
+        digest = _bundle_content_hash(src_key)
+        bundle_dir = f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}-{digest}"
+        dst_key = f"{bundle_dir}/ui-bundle.js"
         logger.info(
             "Copying s3://%s/%s -> s3://%s/%s",
             _FEATURE_BUCKET,
@@ -107,14 +159,12 @@ def _bundle_ui(request_type: str) -> str:
             ContentType="application/javascript",
             CacheControl="public,max-age=31536000,immutable",
         )
-    elif request_type == "Delete":
-        logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)
-        try:
-            _s3.delete_object(Bucket=_WEBUI_BUCKET, Key=dst_key)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("UI bundle delete failed (ignored): %s", exc)
+        return f"{bundle_dir}/"
 
-    return f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/"
+    if request_type == "Delete":
+        _delete_bundle_objects()
+
+    return f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}/"
 
 
 # ---------------------------------------------------------------------------

--- a/feature-platform/feature-template/ui-deployer/tests/test_bundle_cache_busting.py
+++ b/feature-platform/feature-template/ui-deployer/tests/test_bundle_cache_busting.py
@@ -1,0 +1,147 @@
+"""Unit tests for the ui-deployer's content-hashed bundle key (cache busting).
+
+The bundle is copied into the WebUIBucket with `Cache-Control: immutable`,
+which is only safe if the URL changes whenever the content changes. The dst
+key therefore embeds the first 8 hex chars of the sha256 of the bundle bytes:
+`features/<id>/v<version>-<sha8>/ui-bundle.js`. Republishing the same feature
+version with different bytes must yield a different key (and uiBundlePath), so
+browsers holding the old immutable copy fetch the new one.
+
+On Delete, cleanup lists the feature's whole `features/<id>/` prefix so every
+published copy is removed — current + superseded hashed dirs + keys from the
+older non-hashed layout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_HANDLER_DIR = Path(__file__).resolve().parents[1]
+
+_BUNDLE_BYTES = b"console.log('bundle v1');"
+_SHA8 = hashlib.sha256(_BUNDLE_BYTES).hexdigest()[:8]
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakePaginator:
+    def __init__(self, pages: list[dict[str, Any]]):
+        self._pages = pages
+
+    def paginate(self, **kwargs: Any):
+        self.paginate_kwargs = kwargs
+        return iter(self._pages)
+
+
+class _FakeS3:
+    """Just enough of the S3 client for _bundle_ui / _delete_bundle_objects."""
+
+    def __init__(self, bundle_bytes: bytes = _BUNDLE_BYTES, listed_keys=()):
+        self.bundle_bytes = bundle_bytes
+        self.listed_keys = list(listed_keys)
+        self.copy_calls: list[dict[str, Any]] = []
+        self.delete_batches: list[list[str]] = []
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        return {"Body": _FakeBody(self.bundle_bytes)}
+
+    def copy_object(self, **kwargs: Any) -> None:
+        self.copy_calls.append(kwargs)
+
+    def get_paginator(self, name: str) -> _FakePaginator:
+        assert name == "list_objects_v2"
+        contents = [{"Key": k} for k in self.listed_keys]
+        self.paginator = _FakePaginator([{"Contents": contents}] if contents else [{}])
+        return self.paginator
+
+    def delete_objects(self, Bucket: str, Delete: dict[str, Any]) -> None:
+        self.delete_batches.append([o["Key"] for o in Delete["Objects"]])
+
+
+@pytest.fixture
+def mod(monkeypatch):
+    """Import the ui-deployer handler with the env it reads at module load."""
+    monkeypatch.setenv("FEATURE_ID", "docs-by-status")
+    monkeypatch.setenv("FEATURE_DISPLAY_NAME", "Docs by Status")
+    monkeypatch.setenv("FEATURE_VERSION", "0.1.0")
+    monkeypatch.setenv("MAIN_STACK_NAME", "IDP")
+    monkeypatch.setenv("WEBUI_BUCKET", "webui")
+    monkeypatch.setenv("FEATURE_BUCKET", "artifacts")
+    monkeypatch.setenv("FEATURE_ARTIFACT_PREFIX", "idp-cli/extensions/f")
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeature",
+    )
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_HOOKS_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeatureHooks",
+    )
+    monkeypatch.setenv(
+        "APPLY_FEATURE_CONFIG_PRESET_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-ApplyFeatureConfigPreset",
+    )
+    monkeypatch.setenv("HOOK_FUNCTION_ARN", "arn:aws:lambda:us-west-2:1:function:H")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    sys.path.insert(0, str(_HANDLER_DIR))
+    sys.modules.pop("handler", None)
+    m = importlib.import_module("handler")
+    sys.path.remove(str(_HANDLER_DIR))
+    return m
+
+
+def test_create_copies_to_content_hashed_key(mod, monkeypatch):
+    fake = _FakeS3()
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Create")
+    assert path == f"features/docs-by-status/v0.1.0-{_SHA8}/"
+    (call,) = fake.copy_calls
+    assert call["Key"] == f"features/docs-by-status/v0.1.0-{_SHA8}/ui-bundle.js"
+    assert call["CacheControl"] == "public,max-age=31536000,immutable"
+    assert call["CopySource"]["Key"].endswith("/0.1.0/ui-bundle.js")
+
+
+def test_same_version_different_bytes_changes_path(mod, monkeypatch):
+    fake = _FakeS3(bundle_bytes=b"console.log('bundle v2');")
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Update")
+    assert path != f"features/docs-by-status/v0.1.0-{_SHA8}/"
+    assert path.startswith("features/docs-by-status/v0.1.0-")
+
+
+def test_delete_removes_all_copies_under_feature_prefix(mod, monkeypatch):
+    stale = [
+        # older non-hashed layout
+        "features/docs-by-status/v0.1.0/ui-bundle.js",
+        # superseded hashed copies
+        "features/docs-by-status/v0.1.0-deadbeef/ui-bundle.js",
+        f"features/docs-by-status/v0.1.0-{_SHA8}/ui-bundle.js",
+    ]
+    fake = _FakeS3(listed_keys=stale)
+    monkeypatch.setattr(mod, "_s3", fake)
+    mod._bundle_ui("Delete")
+    assert fake.paginator.paginate_kwargs["Prefix"] == "features/docs-by-status/"
+    (batch,) = fake.delete_batches
+    assert sorted(batch) == sorted(stale)
+
+
+def test_delete_cleanup_failure_is_swallowed(mod, monkeypatch):
+    """Teardown must never block stack delete."""
+
+    class _Boom:
+        def get_paginator(self, name):
+            raise RuntimeError("no ListBucket for you")
+
+    monkeypatch.setattr(mod, "_s3", _Boom())
+    mod._bundle_ui("Delete")  # must not raise

--- a/feature-platform/idp-data-generator/template.yaml
+++ b/feature-platform/idp-data-generator/template.yaml
@@ -768,6 +768,16 @@ Resources:
                 Resource: !Sub
                   - 'arn:${AWS::Partition}:s3:::${Bucket}/features/${FeatureId}/*'
                   - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+              # Cleanup lists the feature's own prefix to find every published
+              # bundle copy (current + superseded content-hashed dirs).
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
+                  - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+                Condition:
+                  StringLike:
+                    's3:prefix': !Sub 'features/${FeatureId}/*'
         - PolicyName: InvokeRegisterFeature
           PolicyDocument:
             Version: '2012-10-17'

--- a/feature-platform/idp-data-generator/ui-deployer/handler.py
+++ b/feature-platform/idp-data-generator/ui-deployer/handler.py
@@ -21,6 +21,7 @@ stack's WebUIBucketPolicy allows writes under `features/<FEATURE_ID>/*` only.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -65,12 +66,61 @@ def _artifact_prefix() -> str:
     return f"{_FEATURE_ARTIFACT_PREFIX}/{_FEATURE_VERSION}"
 
 
+_BUNDLE_PREFIX = f"features/{_FEATURE_ID}/"
+
+
+def _bundle_content_hash(src_key: str) -> str:
+    """First 8 hex chars of the sha256 of the bundle bytes.
+
+    The copied bundle is served with `Cache-Control: immutable`, which is only
+    safe if the URL changes whenever the content changes. The feature VERSION
+    alone is not enough: the same version can legitimately be republished
+    (dev iterations, a reinstall after a rollback), and browsers that cached
+    the old bytes under a version-only URL would keep serving them for a year
+    without revalidating.
+    """
+    resp = _s3.get_object(Bucket=_FEATURE_BUCKET, Key=src_key)
+    return hashlib.sha256(resp["Body"].read()).hexdigest()[:8]
+
+
+def _delete_bundle_objects() -> None:
+    """Delete ALL of this feature's objects under features/<id>/ on uninstall.
+
+    Listing the prefix (rather than deleting one computed key) removes every
+    published copy: current + superseded hashed dirs, and keys from the older
+    non-hashed layout (`v<version>/ui-bundle.js`). Superseded copies are
+    deliberately NOT pruned on Update — SPA sessions opened before the update
+    still hold the previous uiBundlePath and must keep loading until they
+    refresh. Best-effort: failures are logged, never raised.
+    """
+    try:
+        paginator = _s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=_WEBUI_BUCKET, Prefix=_BUNDLE_PREFIX):
+            keys = [
+                {"Key": k} for obj in page.get("Contents", []) if (k := obj.get("Key"))
+            ]
+            if keys:
+                _s3.delete_objects(
+                    Bucket=_WEBUI_BUCKET, Delete={"Objects": keys, "Quiet": True}
+                )
+                logger.info(
+                    "Deleted %d object(s) under s3://%s/%s",
+                    len(keys),
+                    _WEBUI_BUCKET,
+                    _BUNDLE_PREFIX,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("UI bundle cleanup failed (ignored): %s", exc)
+
+
 def _bundle_ui(request_type: str) -> str:
     """Copy/delete the UMD bundle; return the uiBundlePath registered with the host."""
     src_key = f"{_artifact_prefix()}/ui-bundle.js"
-    dst_key = f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/ui-bundle.js"
 
     if request_type in ("Create", "Update"):
+        digest = _bundle_content_hash(src_key)
+        bundle_dir = f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}-{digest}"
+        dst_key = f"{bundle_dir}/ui-bundle.js"
         logger.info(
             "Copying s3://%s/%s -> s3://%s/%s",
             _FEATURE_BUCKET,
@@ -86,14 +136,12 @@ def _bundle_ui(request_type: str) -> str:
             ContentType="application/javascript",
             CacheControl="public,max-age=31536000,immutable",
         )
-    elif request_type == "Delete":
-        logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)
-        try:
-            _s3.delete_object(Bucket=_WEBUI_BUCKET, Key=dst_key)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("UI bundle delete failed (ignored): %s", exc)
+        return f"{bundle_dir}/"
 
-    return f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/"
+    if request_type == "Delete":
+        _delete_bundle_objects()
+
+    return f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}/"
 
 
 # Feature registration — direct Lambda invoke of the host's registerFeature

--- a/feature-platform/pii-anonymizer/template.yaml
+++ b/feature-platform/pii-anonymizer/template.yaml
@@ -369,6 +369,16 @@ Resources:
                 Resource: !Sub
                   - 'arn:${AWS::Partition}:s3:::${Bucket}/features/${FeatureId}/*'
                   - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+              # Cleanup lists the feature's own prefix to find every published
+              # bundle copy (current + superseded content-hashed dirs).
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
+                  - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+                Condition:
+                  StringLike:
+                    's3:prefix': !Sub 'features/${FeatureId}/*'
         - PolicyName: InvokeHostResolvers
           PolicyDocument:
             Version: '2012-10-17'

--- a/feature-platform/pii-anonymizer/ui-deployer/handler.py
+++ b/feature-platform/pii-anonymizer/ui-deployer/handler.py
@@ -5,7 +5,10 @@
 
 On Create or Update:
   1. Copies s3://<FEATURE_BUCKET>/<FEATURE_ARTIFACT_PREFIX>/<FEATURE_VERSION>/ui-bundle.js
-     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>/ui-bundle.js
+     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>-<sha8>/ui-bundle.js
+     (<sha8> = content hash, so the browser-facing URL changes whenever the
+     bundle bytes change — required because the bundle is served with
+     Cache-Control: immutable)
   2. Directly invokes the host's `registerFeature` resolver Lambda to add a
      row to InstalledFeatures.
   3. Downloads the bundled config preset (config-preset/pii-preprocessing.yaml,
@@ -41,6 +44,7 @@ under `features/<FEATURE_ID>/*` only.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -119,12 +123,61 @@ def _artifact_prefix() -> str:
 # ---------------------------------------------------------------------------
 # UI bundle copy
 # ---------------------------------------------------------------------------
+_BUNDLE_PREFIX = f"features/{_FEATURE_ID}/"
+
+
+def _bundle_content_hash(src_key: str) -> str:
+    """First 8 hex chars of the sha256 of the bundle bytes.
+
+    The copied bundle is served with `Cache-Control: immutable`, which is only
+    safe if the URL changes whenever the content changes. The feature VERSION
+    alone is not enough: the same version can legitimately be republished
+    (dev iterations, a reinstall after a rollback), and browsers that cached
+    the old bytes under a version-only URL would keep serving them for a year
+    without revalidating.
+    """
+    resp = _s3.get_object(Bucket=_FEATURE_BUCKET, Key=src_key)
+    return hashlib.sha256(resp["Body"].read()).hexdigest()[:8]
+
+
+def _delete_bundle_objects() -> None:
+    """Delete ALL of this feature's objects under features/<id>/ on uninstall.
+
+    Listing the prefix (rather than deleting one computed key) removes every
+    published copy: current + superseded hashed dirs, and keys from the older
+    non-hashed layout (`v<version>/ui-bundle.js`). Superseded copies are
+    deliberately NOT pruned on Update — SPA sessions opened before the update
+    still hold the previous uiBundlePath and must keep loading until they
+    refresh. Best-effort: failures are logged, never raised.
+    """
+    try:
+        paginator = _s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=_WEBUI_BUCKET, Prefix=_BUNDLE_PREFIX):
+            keys = [
+                {"Key": k} for obj in page.get("Contents", []) if (k := obj.get("Key"))
+            ]
+            if keys:
+                _s3.delete_objects(
+                    Bucket=_WEBUI_BUCKET, Delete={"Objects": keys, "Quiet": True}
+                )
+                logger.info(
+                    "Deleted %d object(s) under s3://%s/%s",
+                    len(keys),
+                    _WEBUI_BUCKET,
+                    _BUNDLE_PREFIX,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("UI bundle cleanup failed (ignored): %s", exc)
+
+
 def _bundle_ui(request_type: str) -> str:
     """Return the uiBundlePath registered with the host (used for RegisterFeature)."""
     src_key = f"{_artifact_prefix()}/ui-bundle.js"
-    dst_key = f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/ui-bundle.js"
 
     if request_type in ("Create", "Update"):
+        digest = _bundle_content_hash(src_key)
+        bundle_dir = f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}-{digest}"
+        dst_key = f"{bundle_dir}/ui-bundle.js"
         logger.info(
             "Copying s3://%s/%s -> s3://%s/%s",
             _FEATURE_BUCKET,
@@ -140,14 +193,12 @@ def _bundle_ui(request_type: str) -> str:
             ContentType="application/javascript",
             CacheControl="public,max-age=31536000,immutable",
         )
-    elif request_type == "Delete":
-        logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)
-        try:
-            _s3.delete_object(Bucket=_WEBUI_BUCKET, Key=dst_key)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("UI bundle delete failed (ignored): %s", exc)
+        return f"{bundle_dir}/"
 
-    return f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/"
+    if request_type == "Delete":
+        _delete_bundle_objects()
+
+    return f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}/"
 
 
 # ---------------------------------------------------------------------------

--- a/feature-platform/pii-anonymizer/ui-deployer/tests/test_bundle_cache_busting.py
+++ b/feature-platform/pii-anonymizer/ui-deployer/tests/test_bundle_cache_busting.py
@@ -1,0 +1,147 @@
+"""Unit tests for the ui-deployer's content-hashed bundle key (cache busting).
+
+The bundle is copied into the WebUIBucket with `Cache-Control: immutable`,
+which is only safe if the URL changes whenever the content changes. The dst
+key therefore embeds the first 8 hex chars of the sha256 of the bundle bytes:
+`features/<id>/v<version>-<sha8>/ui-bundle.js`. Republishing the same feature
+version with different bytes must yield a different key (and uiBundlePath), so
+browsers holding the old immutable copy fetch the new one.
+
+On Delete, cleanup lists the feature's whole `features/<id>/` prefix so every
+published copy is removed — current + superseded hashed dirs + keys from the
+older non-hashed layout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_HANDLER_DIR = Path(__file__).resolve().parents[1]
+
+_BUNDLE_BYTES = b"console.log('bundle v1');"
+_SHA8 = hashlib.sha256(_BUNDLE_BYTES).hexdigest()[:8]
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakePaginator:
+    def __init__(self, pages: list[dict[str, Any]]):
+        self._pages = pages
+
+    def paginate(self, **kwargs: Any):
+        self.paginate_kwargs = kwargs
+        return iter(self._pages)
+
+
+class _FakeS3:
+    """Just enough of the S3 client for _bundle_ui / _delete_bundle_objects."""
+
+    def __init__(self, bundle_bytes: bytes = _BUNDLE_BYTES, listed_keys=()):
+        self.bundle_bytes = bundle_bytes
+        self.listed_keys = list(listed_keys)
+        self.copy_calls: list[dict[str, Any]] = []
+        self.delete_batches: list[list[str]] = []
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        return {"Body": _FakeBody(self.bundle_bytes)}
+
+    def copy_object(self, **kwargs: Any) -> None:
+        self.copy_calls.append(kwargs)
+
+    def get_paginator(self, name: str) -> _FakePaginator:
+        assert name == "list_objects_v2"
+        contents = [{"Key": k} for k in self.listed_keys]
+        self.paginator = _FakePaginator([{"Contents": contents}] if contents else [{}])
+        return self.paginator
+
+    def delete_objects(self, Bucket: str, Delete: dict[str, Any]) -> None:
+        self.delete_batches.append([o["Key"] for o in Delete["Objects"]])
+
+
+@pytest.fixture
+def mod(monkeypatch):
+    """Import the ui-deployer handler with the env it reads at module load."""
+    monkeypatch.setenv("FEATURE_ID", "pii-anonymizer")
+    monkeypatch.setenv("FEATURE_DISPLAY_NAME", "PII Anonymization")
+    monkeypatch.setenv("FEATURE_VERSION", "0.1.0")
+    monkeypatch.setenv("MAIN_STACK_NAME", "IDP")
+    monkeypatch.setenv("WEBUI_BUCKET", "webui")
+    monkeypatch.setenv("FEATURE_BUCKET", "artifacts")
+    monkeypatch.setenv("FEATURE_ARTIFACT_PREFIX", "idp-cli/extensions/f")
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeature",
+    )
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_HOOKS_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeatureHooks",
+    )
+    monkeypatch.setenv(
+        "APPLY_FEATURE_CONFIG_PRESET_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-ApplyFeatureConfigPreset",
+    )
+    monkeypatch.setenv("HOOK_FUNCTION_ARN", "arn:aws:lambda:us-west-2:1:function:H")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    sys.path.insert(0, str(_HANDLER_DIR))
+    sys.modules.pop("handler", None)
+    m = importlib.import_module("handler")
+    sys.path.remove(str(_HANDLER_DIR))
+    return m
+
+
+def test_create_copies_to_content_hashed_key(mod, monkeypatch):
+    fake = _FakeS3()
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Create")
+    assert path == f"features/pii-anonymizer/v0.1.0-{_SHA8}/"
+    (call,) = fake.copy_calls
+    assert call["Key"] == f"features/pii-anonymizer/v0.1.0-{_SHA8}/ui-bundle.js"
+    assert call["CacheControl"] == "public,max-age=31536000,immutable"
+    assert call["CopySource"]["Key"].endswith("/0.1.0/ui-bundle.js")
+
+
+def test_same_version_different_bytes_changes_path(mod, monkeypatch):
+    fake = _FakeS3(bundle_bytes=b"console.log('bundle v2');")
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Update")
+    assert path != f"features/pii-anonymizer/v0.1.0-{_SHA8}/"
+    assert path.startswith("features/pii-anonymizer/v0.1.0-")
+
+
+def test_delete_removes_all_copies_under_feature_prefix(mod, monkeypatch):
+    stale = [
+        # older non-hashed layout
+        "features/pii-anonymizer/v0.1.0/ui-bundle.js",
+        # superseded hashed copies
+        "features/pii-anonymizer/v0.1.0-deadbeef/ui-bundle.js",
+        f"features/pii-anonymizer/v0.1.0-{_SHA8}/ui-bundle.js",
+    ]
+    fake = _FakeS3(listed_keys=stale)
+    monkeypatch.setattr(mod, "_s3", fake)
+    mod._bundle_ui("Delete")
+    assert fake.paginator.paginate_kwargs["Prefix"] == "features/pii-anonymizer/"
+    (batch,) = fake.delete_batches
+    assert sorted(batch) == sorted(stale)
+
+
+def test_delete_cleanup_failure_is_swallowed(mod, monkeypatch):
+    """Teardown must never block stack delete."""
+
+    class _Boom:
+        def get_paginator(self, name):
+            raise RuntimeError("no ListBucket for you")
+
+    monkeypatch.setattr(mod, "_s3", _Boom())
+    mod._bundle_ui("Delete")  # must not raise

--- a/feature-platform/sample-feature/template.yaml
+++ b/feature-platform/sample-feature/template.yaml
@@ -235,6 +235,16 @@ Resources:
                 Resource: !Sub
                   - 'arn:${AWS::Partition}:s3:::${Bucket}/features/${FeatureId}/*'
                   - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+              # Cleanup lists the feature's own prefix to find every published
+              # bundle copy (current + superseded content-hashed dirs).
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
+                  - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+                Condition:
+                  StringLike:
+                    's3:prefix': !Sub 'features/${FeatureId}/*'
         - PolicyName: InvokeRegisterFeature
           PolicyDocument:
             Version: '2012-10-17'

--- a/feature-platform/sample-feature/ui-deployer/handler.py
+++ b/feature-platform/sample-feature/ui-deployer/handler.py
@@ -5,7 +5,9 @@
 
 On Create or Update:
   1. Copies s3://<FEATURE_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>/ui-bundle.js
-     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>/ui-bundle.js
+     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>-<sha8>/ui-bundle.js
+     (<sha8> = content hash — the bundle is served with Cache-Control:
+     immutable, so the URL must change whenever the bytes change)
   2. Directly invokes the host's registerFeature resolver Lambda to add a row
      to InstalledFeatures.
 
@@ -20,6 +22,7 @@ The Lambda's execution role carries the session tag `idp:feature-id=<FEATURE_ID>
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -81,15 +84,64 @@ def _artifact_prefix() -> str:
 # ---------------------------------------------------------------------------
 # UI bundle copy
 # ---------------------------------------------------------------------------
+_BUNDLE_PREFIX = f"features/{_FEATURE_ID}/"
+
+
+def _bundle_content_hash(src_key: str) -> str:
+    """First 8 hex chars of the sha256 of the bundle bytes.
+
+    The copied bundle is served with `Cache-Control: immutable`, which is only
+    safe if the URL changes whenever the content changes. The feature VERSION
+    alone is not enough: the same version can legitimately be republished
+    (dev iterations, a reinstall after a rollback), and browsers that cached
+    the old bytes under a version-only URL would keep serving them for a year
+    without revalidating.
+    """
+    resp = _s3.get_object(Bucket=_FEATURE_BUCKET, Key=src_key)
+    return hashlib.sha256(resp["Body"].read()).hexdigest()[:8]
+
+
+def _delete_bundle_objects() -> None:
+    """Delete ALL of this feature's objects under features/<id>/ on uninstall.
+
+    Listing the prefix (rather than deleting one computed key) removes every
+    published copy: current + superseded hashed dirs, and keys from the older
+    non-hashed layout (`v<version>/ui-bundle.js`). Superseded copies are
+    deliberately NOT pruned on Update — SPA sessions opened before the update
+    still hold the previous uiBundlePath and must keep loading until they
+    refresh. Best-effort: failures are logged, never raised.
+    """
+    try:
+        paginator = _s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=_WEBUI_BUCKET, Prefix=_BUNDLE_PREFIX):
+            keys = [
+                {"Key": k} for obj in page.get("Contents", []) if (k := obj.get("Key"))
+            ]
+            if keys:
+                _s3.delete_objects(
+                    Bucket=_WEBUI_BUCKET, Delete={"Objects": keys, "Quiet": True}
+                )
+                logger.info(
+                    "Deleted %d object(s) under s3://%s/%s",
+                    len(keys),
+                    _WEBUI_BUCKET,
+                    _BUNDLE_PREFIX,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("UI bundle cleanup failed (ignored): %s", exc)
+
+
 def _bundle_ui(request_type: str) -> str:
     """Return the uiBundlePath registered with the host (used for RegisterFeature)."""
     # Source is the published versioned artifact under the extension base in the
     # artifacts bucket; destination is the host's canonical WebUIBucket layout
     # that FeatureLoader fetches.
     src_key = f"{_artifact_prefix()}/ui-bundle.js"
-    dst_key = f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/ui-bundle.js"
 
     if request_type in ("Create", "Update"):
+        digest = _bundle_content_hash(src_key)
+        bundle_dir = f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}-{digest}"
+        dst_key = f"{bundle_dir}/ui-bundle.js"
         logger.info(
             "Copying s3://%s/%s -> s3://%s/%s",
             _FEATURE_BUCKET,
@@ -105,14 +157,12 @@ def _bundle_ui(request_type: str) -> str:
             ContentType="application/javascript",
             CacheControl="public,max-age=31536000,immutable",
         )
-    elif request_type == "Delete":
-        logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)
-        try:
-            _s3.delete_object(Bucket=_WEBUI_BUCKET, Key=dst_key)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("UI bundle delete failed (ignored): %s", exc)
+        return f"{bundle_dir}/"
 
-    return f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/"
+    if request_type == "Delete":
+        _delete_bundle_objects()
+
+    return f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}/"
 
 
 # ---------------------------------------------------------------------------

--- a/feature-platform/sample-feature/ui-deployer/tests/test_bundle_cache_busting.py
+++ b/feature-platform/sample-feature/ui-deployer/tests/test_bundle_cache_busting.py
@@ -1,0 +1,147 @@
+"""Unit tests for the ui-deployer's content-hashed bundle key (cache busting).
+
+The bundle is copied into the WebUIBucket with `Cache-Control: immutable`,
+which is only safe if the URL changes whenever the content changes. The dst
+key therefore embeds the first 8 hex chars of the sha256 of the bundle bytes:
+`features/<id>/v<version>-<sha8>/ui-bundle.js`. Republishing the same feature
+version with different bytes must yield a different key (and uiBundlePath), so
+browsers holding the old immutable copy fetch the new one.
+
+On Delete, cleanup lists the feature's whole `features/<id>/` prefix so every
+published copy is removed — current + superseded hashed dirs + keys from the
+older non-hashed layout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_HANDLER_DIR = Path(__file__).resolve().parents[1]
+
+_BUNDLE_BYTES = b"console.log('bundle v1');"
+_SHA8 = hashlib.sha256(_BUNDLE_BYTES).hexdigest()[:8]
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakePaginator:
+    def __init__(self, pages: list[dict[str, Any]]):
+        self._pages = pages
+
+    def paginate(self, **kwargs: Any):
+        self.paginate_kwargs = kwargs
+        return iter(self._pages)
+
+
+class _FakeS3:
+    """Just enough of the S3 client for _bundle_ui / _delete_bundle_objects."""
+
+    def __init__(self, bundle_bytes: bytes = _BUNDLE_BYTES, listed_keys=()):
+        self.bundle_bytes = bundle_bytes
+        self.listed_keys = list(listed_keys)
+        self.copy_calls: list[dict[str, Any]] = []
+        self.delete_batches: list[list[str]] = []
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        return {"Body": _FakeBody(self.bundle_bytes)}
+
+    def copy_object(self, **kwargs: Any) -> None:
+        self.copy_calls.append(kwargs)
+
+    def get_paginator(self, name: str) -> _FakePaginator:
+        assert name == "list_objects_v2"
+        contents = [{"Key": k} for k in self.listed_keys]
+        self.paginator = _FakePaginator([{"Contents": contents}] if contents else [{}])
+        return self.paginator
+
+    def delete_objects(self, Bucket: str, Delete: dict[str, Any]) -> None:
+        self.delete_batches.append([o["Key"] for o in Delete["Objects"]])
+
+
+@pytest.fixture
+def mod(monkeypatch):
+    """Import the ui-deployer handler with the env it reads at module load."""
+    monkeypatch.setenv("FEATURE_ID", "docs-by-status")
+    monkeypatch.setenv("FEATURE_DISPLAY_NAME", "Docs by Status")
+    monkeypatch.setenv("FEATURE_VERSION", "0.1.0")
+    monkeypatch.setenv("MAIN_STACK_NAME", "IDP")
+    monkeypatch.setenv("WEBUI_BUCKET", "webui")
+    monkeypatch.setenv("FEATURE_BUCKET", "artifacts")
+    monkeypatch.setenv("FEATURE_ARTIFACT_PREFIX", "idp-cli/extensions/f")
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeature",
+    )
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_HOOKS_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeatureHooks",
+    )
+    monkeypatch.setenv(
+        "APPLY_FEATURE_CONFIG_PRESET_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-ApplyFeatureConfigPreset",
+    )
+    monkeypatch.setenv("HOOK_FUNCTION_ARN", "arn:aws:lambda:us-west-2:1:function:H")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    sys.path.insert(0, str(_HANDLER_DIR))
+    sys.modules.pop("handler", None)
+    m = importlib.import_module("handler")
+    sys.path.remove(str(_HANDLER_DIR))
+    return m
+
+
+def test_create_copies_to_content_hashed_key(mod, monkeypatch):
+    fake = _FakeS3()
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Create")
+    assert path == f"features/docs-by-status/v0.1.0-{_SHA8}/"
+    (call,) = fake.copy_calls
+    assert call["Key"] == f"features/docs-by-status/v0.1.0-{_SHA8}/ui-bundle.js"
+    assert call["CacheControl"] == "public,max-age=31536000,immutable"
+    assert call["CopySource"]["Key"].endswith("/0.1.0/ui-bundle.js")
+
+
+def test_same_version_different_bytes_changes_path(mod, monkeypatch):
+    fake = _FakeS3(bundle_bytes=b"console.log('bundle v2');")
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Update")
+    assert path != f"features/docs-by-status/v0.1.0-{_SHA8}/"
+    assert path.startswith("features/docs-by-status/v0.1.0-")
+
+
+def test_delete_removes_all_copies_under_feature_prefix(mod, monkeypatch):
+    stale = [
+        # older non-hashed layout
+        "features/docs-by-status/v0.1.0/ui-bundle.js",
+        # superseded hashed copies
+        "features/docs-by-status/v0.1.0-deadbeef/ui-bundle.js",
+        f"features/docs-by-status/v0.1.0-{_SHA8}/ui-bundle.js",
+    ]
+    fake = _FakeS3(listed_keys=stale)
+    monkeypatch.setattr(mod, "_s3", fake)
+    mod._bundle_ui("Delete")
+    assert fake.paginator.paginate_kwargs["Prefix"] == "features/docs-by-status/"
+    (batch,) = fake.delete_batches
+    assert sorted(batch) == sorted(stale)
+
+
+def test_delete_cleanup_failure_is_swallowed(mod, monkeypatch):
+    """Teardown must never block stack delete."""
+
+    class _Boom:
+        def get_paginator(self, name):
+            raise RuntimeError("no ListBucket for you")
+
+    monkeypatch.setattr(mod, "_s3", _Boom())
+    mod._bundle_ui("Delete")  # must not raise

--- a/feature-platform/sample-health-insurance-review/template.yaml
+++ b/feature-platform/sample-health-insurance-review/template.yaml
@@ -328,6 +328,16 @@ Resources:
                 Resource: !Sub
                   - 'arn:${AWS::Partition}:s3:::${Bucket}/features/${FeatureId}/*'
                   - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+              # Cleanup lists the feature's own prefix to find every published
+              # bundle copy (current + superseded content-hashed dirs).
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub
+                  - 'arn:${AWS::Partition}:s3:::${Bucket}'
+                  - Bucket: { 'Fn::ImportValue': !Sub '${MainStackName}-WebUIBucketName' }
+                Condition:
+                  StringLike:
+                    's3:prefix': !Sub 'features/${FeatureId}/*'
         - PolicyName: InvokeHostResolvers
           PolicyDocument:
             Version: '2012-10-17'

--- a/feature-platform/sample-health-insurance-review/ui-deployer/handler.py
+++ b/feature-platform/sample-health-insurance-review/ui-deployer/handler.py
@@ -8,7 +8,9 @@ registrations the Claims Review sample demonstrates:
 
 On Create or Update:
   1. Copies s3://<FEATURE_BUCKET>/<FEATURE_ARTIFACT_PREFIX>/<FEATURE_VERSION>/ui-bundle.js
-     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>/ui-bundle.js
+     into s3://<WEBUI_BUCKET>/features/<FEATURE_ID>/v<FEATURE_VERSION>-<sha8>/ui-bundle.js
+     (<sha8> = content hash — the bundle is served with Cache-Control:
+     immutable, so the URL must change whenever the bytes change)
   2. Directly invokes the host's `registerFeature` resolver Lambda to add a
      row to InstalledFeatures.
   3. Downloads the bundled config preset (config-preset/claims-config.yaml,
@@ -42,6 +44,7 @@ under `features/<FEATURE_ID>/*` only.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -120,12 +123,61 @@ def _artifact_prefix() -> str:
 # ---------------------------------------------------------------------------
 # UI bundle copy
 # ---------------------------------------------------------------------------
+_BUNDLE_PREFIX = f"features/{_FEATURE_ID}/"
+
+
+def _bundle_content_hash(src_key: str) -> str:
+    """First 8 hex chars of the sha256 of the bundle bytes.
+
+    The copied bundle is served with `Cache-Control: immutable`, which is only
+    safe if the URL changes whenever the content changes. The feature VERSION
+    alone is not enough: the same version can legitimately be republished
+    (dev iterations, a reinstall after a rollback), and browsers that cached
+    the old bytes under a version-only URL would keep serving them for a year
+    without revalidating.
+    """
+    resp = _s3.get_object(Bucket=_FEATURE_BUCKET, Key=src_key)
+    return hashlib.sha256(resp["Body"].read()).hexdigest()[:8]
+
+
+def _delete_bundle_objects() -> None:
+    """Delete ALL of this feature's objects under features/<id>/ on uninstall.
+
+    Listing the prefix (rather than deleting one computed key) removes every
+    published copy: current + superseded hashed dirs, and keys from the older
+    non-hashed layout (`v<version>/ui-bundle.js`). Superseded copies are
+    deliberately NOT pruned on Update — SPA sessions opened before the update
+    still hold the previous uiBundlePath and must keep loading until they
+    refresh. Best-effort: failures are logged, never raised.
+    """
+    try:
+        paginator = _s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=_WEBUI_BUCKET, Prefix=_BUNDLE_PREFIX):
+            keys = [
+                {"Key": k} for obj in page.get("Contents", []) if (k := obj.get("Key"))
+            ]
+            if keys:
+                _s3.delete_objects(
+                    Bucket=_WEBUI_BUCKET, Delete={"Objects": keys, "Quiet": True}
+                )
+                logger.info(
+                    "Deleted %d object(s) under s3://%s/%s",
+                    len(keys),
+                    _WEBUI_BUCKET,
+                    _BUNDLE_PREFIX,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("UI bundle cleanup failed (ignored): %s", exc)
+
+
 def _bundle_ui(request_type: str) -> str:
     """Return the uiBundlePath registered with the host (used for RegisterFeature)."""
     src_key = f"{_artifact_prefix()}/ui-bundle.js"
-    dst_key = f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/ui-bundle.js"
 
     if request_type in ("Create", "Update"):
+        digest = _bundle_content_hash(src_key)
+        bundle_dir = f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}-{digest}"
+        dst_key = f"{bundle_dir}/ui-bundle.js"
         logger.info(
             "Copying s3://%s/%s -> s3://%s/%s",
             _FEATURE_BUCKET,
@@ -141,14 +193,12 @@ def _bundle_ui(request_type: str) -> str:
             ContentType="application/javascript",
             CacheControl="public,max-age=31536000,immutable",
         )
-    elif request_type == "Delete":
-        logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)
-        try:
-            _s3.delete_object(Bucket=_WEBUI_BUCKET, Key=dst_key)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("UI bundle delete failed (ignored): %s", exc)
+        return f"{bundle_dir}/"
 
-    return f"features/{_FEATURE_ID}/v{_FEATURE_VERSION}/"
+    if request_type == "Delete":
+        _delete_bundle_objects()
+
+    return f"{_BUNDLE_PREFIX}v{_FEATURE_VERSION}/"
 
 
 # ---------------------------------------------------------------------------

--- a/feature-platform/sample-health-insurance-review/ui-deployer/tests/test_bundle_cache_busting.py
+++ b/feature-platform/sample-health-insurance-review/ui-deployer/tests/test_bundle_cache_busting.py
@@ -1,0 +1,153 @@
+"""Unit tests for the ui-deployer's content-hashed bundle key (cache busting).
+
+The bundle is copied into the WebUIBucket with `Cache-Control: immutable`,
+which is only safe if the URL changes whenever the content changes. The dst
+key therefore embeds the first 8 hex chars of the sha256 of the bundle bytes:
+`features/<id>/v<version>-<sha8>/ui-bundle.js`. Republishing the same feature
+version with different bytes must yield a different key (and uiBundlePath), so
+browsers holding the old immutable copy fetch the new one.
+
+On Delete, cleanup lists the feature's whole `features/<id>/` prefix so every
+published copy is removed — current + superseded hashed dirs + keys from the
+older non-hashed layout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_HANDLER_DIR = Path(__file__).resolve().parents[1]
+
+_BUNDLE_BYTES = b"console.log('bundle v1');"
+_SHA8 = hashlib.sha256(_BUNDLE_BYTES).hexdigest()[:8]
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakePaginator:
+    def __init__(self, pages: list[dict[str, Any]]):
+        self._pages = pages
+
+    def paginate(self, **kwargs: Any):
+        self.paginate_kwargs = kwargs
+        return iter(self._pages)
+
+
+class _FakeS3:
+    """Just enough of the S3 client for _bundle_ui / _delete_bundle_objects."""
+
+    def __init__(self, bundle_bytes: bytes = _BUNDLE_BYTES, listed_keys=()):
+        self.bundle_bytes = bundle_bytes
+        self.listed_keys = list(listed_keys)
+        self.copy_calls: list[dict[str, Any]] = []
+        self.delete_batches: list[list[str]] = []
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        return {"Body": _FakeBody(self.bundle_bytes)}
+
+    def copy_object(self, **kwargs: Any) -> None:
+        self.copy_calls.append(kwargs)
+
+    def get_paginator(self, name: str) -> _FakePaginator:
+        assert name == "list_objects_v2"
+        contents = [{"Key": k} for k in self.listed_keys]
+        self.paginator = _FakePaginator([{"Contents": contents}] if contents else [{}])
+        return self.paginator
+
+    def delete_objects(self, Bucket: str, Delete: dict[str, Any]) -> None:
+        self.delete_batches.append([o["Key"] for o in Delete["Objects"]])
+
+
+@pytest.fixture
+def mod(monkeypatch):
+    """Import the ui-deployer handler with the env it reads at module load."""
+    monkeypatch.setenv("FEATURE_ID", "sample-health-insurance-review")
+    monkeypatch.setenv("FEATURE_DISPLAY_NAME", "Sample: Health Insurance Review")
+    monkeypatch.setenv("FEATURE_VERSION", "0.1.0")
+    monkeypatch.setenv("MAIN_STACK_NAME", "IDP")
+    monkeypatch.setenv("WEBUI_BUCKET", "webui")
+    monkeypatch.setenv("FEATURE_BUCKET", "artifacts")
+    monkeypatch.setenv("FEATURE_ARTIFACT_PREFIX", "idp-cli/extensions/f")
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeature",
+    )
+    monkeypatch.setenv(
+        "REGISTER_FEATURE_HOOKS_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-RegisterFeatureHooks",
+    )
+    monkeypatch.setenv(
+        "APPLY_FEATURE_CONFIG_PRESET_FUNCTION_ARN",
+        "arn:aws:lambda:us-west-2:123456789012:function:IDP-ApplyFeatureConfigPreset",
+    )
+    monkeypatch.setenv("HOOK_FUNCTION_ARN", "arn:aws:lambda:us-west-2:1:function:H")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    sys.path.insert(0, str(_HANDLER_DIR))
+    sys.modules.pop("handler", None)
+    m = importlib.import_module("handler")
+    sys.path.remove(str(_HANDLER_DIR))
+    return m
+
+
+def test_create_copies_to_content_hashed_key(mod, monkeypatch):
+    fake = _FakeS3()
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Create")
+    assert path == f"features/sample-health-insurance-review/v0.1.0-{_SHA8}/"
+    (call,) = fake.copy_calls
+    assert (
+        call["Key"]
+        == f"features/sample-health-insurance-review/v0.1.0-{_SHA8}/ui-bundle.js"
+    )
+    assert call["CacheControl"] == "public,max-age=31536000,immutable"
+    assert call["CopySource"]["Key"].endswith("/0.1.0/ui-bundle.js")
+
+
+def test_same_version_different_bytes_changes_path(mod, monkeypatch):
+    fake = _FakeS3(bundle_bytes=b"console.log('bundle v2');")
+    monkeypatch.setattr(mod, "_s3", fake)
+    path = mod._bundle_ui("Update")
+    assert path != f"features/sample-health-insurance-review/v0.1.0-{_SHA8}/"
+    assert path.startswith("features/sample-health-insurance-review/v0.1.0-")
+
+
+def test_delete_removes_all_copies_under_feature_prefix(mod, monkeypatch):
+    stale = [
+        # older non-hashed layout
+        "features/sample-health-insurance-review/v0.1.0/ui-bundle.js",
+        # superseded hashed copies
+        "features/sample-health-insurance-review/v0.1.0-deadbeef/ui-bundle.js",
+        f"features/sample-health-insurance-review/v0.1.0-{_SHA8}/ui-bundle.js",
+    ]
+    fake = _FakeS3(listed_keys=stale)
+    monkeypatch.setattr(mod, "_s3", fake)
+    mod._bundle_ui("Delete")
+    assert (
+        fake.paginator.paginate_kwargs["Prefix"]
+        == "features/sample-health-insurance-review/"
+    )
+    (batch,) = fake.delete_batches
+    assert sorted(batch) == sorted(stale)
+
+
+def test_delete_cleanup_failure_is_swallowed(mod, monkeypatch):
+    """Teardown must never block stack delete."""
+
+    class _Boom:
+        def get_paginator(self, name):
+            raise RuntimeError("no ListBucket for you")
+
+    monkeypatch.setattr(mod, "_s3", _Boom())
+    mod._bundle_ui("Delete")  # must not raise


### PR DESCRIPTION
## Problem

Feature ui-deployers copy `ui-bundle.js` into the Web UI bucket at a **version-only** path (`features/<id>/v<ver>/ui-bundle.js`) with `Cache-Control: public,max-age=31536000,immutable`. Republishing the same feature version (dev iterations, or a reinstall after resetting a feature version for release) reuses the identical URL — so browsers holding the old immutable copy serve the stale bundle for up to a year without ever revalidating. Symptom: the old extension UI page renders in a normal browser profile while an incognito tab shows the newly deployed one. There is also no CloudFront invalidation on feature install (the `/*` invalidation only runs for main-UI CodeBuild deploys), and reinstalling the extension doesn't help because nothing about the URL changes.

## Fix

The `immutable` header is only safe if the URL changes whenever the content changes, so the destination path now embeds a content hash of the bundle bytes:

```
features/<id>/v<ver>-<sha8>/ui-bundle.js     (sha8 = first 8 hex chars of sha256)
```

- The hashed dir is what gets registered as `uiBundlePath`, so `FeatureLoader` picks up the new URL from the registry with **no UI changes**.
- On **Delete**, cleanup lists the feature's whole `features/<id>/` prefix, removing every published copy: current, superseded hashed dirs, and keys from the old non-hashed layout. Superseded copies are deliberately kept on **Update** so SPA sessions opened before the update keep loading until refreshed.
- The ui-deployer roles gain `s3:ListBucket` on the Web UI bucket, scoped with an `s3:prefix` condition to `features/<id>/*` (writes remain restricted to the feature's own prefix as before).

Applies to all five bundled feature ui-deployers: `pii-anonymizer`, `idp-data-generator`, `sample-feature`, `sample-health-insurance-review`, and `feature-template` (so third-party features scaffolded from the template inherit the fix).

## Testing

- New `test_bundle_cache_busting.py` in all four registered ui-deployer test roots: hashed-key copy + immutable header preserved, same-version-different-bytes yields a different path, Delete removes all copies under the feature prefix (including old-layout keys), and cleanup failures never block stack delete.
- All 11 feature-platform test suites pass (191 tests).
- `cfn-lint` clean on the five modified templates; `ruff check` / `ruff format` clean.

## Notes for reviewers

- `registerFeature` runs on every Create/Update and overwrites `uiBundlePath`, so the registry row always points at the latest hashed dir.
- The `uiBundlePath` API field is a plain string (no format validation), so the `v<ver>-<sha8>` shape needs no schema change.
- Existing installs migrate on their next feature stack update: the deployer writes the new hashed key and registers it; the old `v<ver>/ui-bundle.js` key remains until uninstall (harmless, and still cleaned up by the prefix-wide delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)