### PR TITLE
fix(extensions): health-insurance Rules Discovery uses host REST client, not Amplify GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sample: Health Insurance Review — Rules Discovery tab failed with "No GraphQL endpoint configured in `Amplify.configure()`" (v0.1.1).** The feature's Rules Discovery flow still called `aws-amplify/api`'s `generateClient().graphql()`, which stopped working when the host replaced AppSync with the REST dispatcher (Amplify now carries no GraphQL endpoint — it is configured for Cognito auth only). The feature now uses the host's REST-backed, GraphQL-shaped client exposed at `window.IdpFeatureHost.generateClient` (the same migration the PII Anonymization feature already made), so uploadDiscoveryDocument / listDiscoveryJobs / getConfigVersion go through the same transport as the host UI. Also, all feature ui-deployers (template + 4 bundled features) previously copied `ui-bundle.js` into the Web UI bucket with `Cache-Control: max-age=31536000,immutable`, which pinned a stale bundle in browsers for up to a year when the same feature version was republished (hotfixes); they now use `max-age=300`, matching the CloudFront distribution's own TTL, so an update propagates within minutes. (#568)
+
 ## [0.6.2]
 
 ### Added

--- a/feature-platform/feature-template/ui-deployer/handler.py
+++ b/feature-platform/feature-template/ui-deployer/handler.py
@@ -105,7 +105,14 @@ def _bundle_ui(request_type: str) -> str:
             Key=dst_key,
             MetadataDirective="REPLACE",
             ContentType="application/javascript",
-            CacheControl="public,max-age=31536000,immutable",
+            # Short TTL, NOT immutable: the destination key is version-addressed
+            # (v<FEATURE_VERSION>/), so version bumps already bust caches — but
+            # same-version republishes DO happen (hotfixes re-uploading an
+            # existing version), and a year-long immutable header would pin the
+            # stale bundle in browsers until the version changes. max-age=300
+            # bounds staleness to 5 minutes at negligible re-fetch cost,
+            # matching the CloudFront distribution's own MaxTTL.
+            CacheControl="public,max-age=300",
         )
     elif request_type == "Delete":
         logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)

--- a/feature-platform/idp-data-generator/ui-deployer/handler.py
+++ b/feature-platform/idp-data-generator/ui-deployer/handler.py
@@ -84,7 +84,14 @@ def _bundle_ui(request_type: str) -> str:
             Key=dst_key,
             MetadataDirective="REPLACE",
             ContentType="application/javascript",
-            CacheControl="public,max-age=31536000,immutable",
+            # Short TTL, NOT immutable: the destination key is version-addressed
+            # (v<FEATURE_VERSION>/), so version bumps already bust caches — but
+            # same-version republishes DO happen (hotfixes re-uploading an
+            # existing version), and a year-long immutable header would pin the
+            # stale bundle in browsers until the version changes. max-age=300
+            # bounds staleness to 5 minutes at negligible re-fetch cost,
+            # matching the CloudFront distribution's own MaxTTL.
+            CacheControl="public,max-age=300",
         )
     elif request_type == "Delete":
         logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)

--- a/feature-platform/pii-anonymizer/ui-deployer/handler.py
+++ b/feature-platform/pii-anonymizer/ui-deployer/handler.py
@@ -138,7 +138,14 @@ def _bundle_ui(request_type: str) -> str:
             Key=dst_key,
             MetadataDirective="REPLACE",
             ContentType="application/javascript",
-            CacheControl="public,max-age=31536000,immutable",
+            # Short TTL, NOT immutable: the destination key is version-addressed
+            # (v<FEATURE_VERSION>/), so version bumps already bust caches — but
+            # same-version republishes DO happen (hotfixes re-uploading an
+            # existing version), and a year-long immutable header would pin the
+            # stale bundle in browsers until the version changes. max-age=300
+            # bounds staleness to 5 minutes at negligible re-fetch cost,
+            # matching the CloudFront distribution's own MaxTTL.
+            CacheControl="public,max-age=300",
         )
     elif request_type == "Delete":
         logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)

--- a/feature-platform/sample-feature/ui-deployer/handler.py
+++ b/feature-platform/sample-feature/ui-deployer/handler.py
@@ -103,7 +103,14 @@ def _bundle_ui(request_type: str) -> str:
             Key=dst_key,
             MetadataDirective="REPLACE",
             ContentType="application/javascript",
-            CacheControl="public,max-age=31536000,immutable",
+            # Short TTL, NOT immutable: the destination key is version-addressed
+            # (v<FEATURE_VERSION>/), so version bumps already bust caches — but
+            # same-version republishes DO happen (hotfixes re-uploading an
+            # existing version), and a year-long immutable header would pin the
+            # stale bundle in browsers until the version changes. max-age=300
+            # bounds staleness to 5 minutes at negligible re-fetch cost,
+            # matching the CloudFront distribution's own MaxTTL.
+            CacheControl="public,max-age=300",
         )
     elif request_type == "Delete":
         logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)

--- a/feature-platform/sample-health-insurance-review/feature-ui/package.json
+++ b/feature-platform/sample-health-insurance-review/feature-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "idp-sample-health-insurance-review-feature-ui",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/feature-platform/sample-health-insurance-review/feature-ui/src/hostGraphql.ts
+++ b/feature-platform/sample-health-insurance-review/feature-ui/src/hostGraphql.ts
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Calls the HOST's AppSync GraphQL API directly from the feature UI.
+ * Calls the HOST's API directly from the feature UI through the host's
+ * REST-backed, GraphQL-shaped client (`window.IdpFeatureHost.generateClient`).
  *
- * This works because the host installs `window.awsAmplify` (see
- * src/ui/src/components/feature-page/feature-host-globals.ts) — the SAME
- * configured, signed-in Amplify instance the host UI uses. `generateClient()`
- * therefore inherits the user's Cognito session and talks to the host's
- * GraphQL endpoint with the user's own JWT and group memberships. No extra
- * configuration is needed in the feature.
+ * AppSync was removed from the accelerator — the host UI now POSTs operations
+ * to a REST dispatcher (`/op/<field>`). The host exposes its shim client as a
+ * window global (see src/ui/src/components/feature-page/feature-host-globals.ts)
+ * so features use the SAME transport, carrying the user's Cognito token and
+ * group memberships. (Calling `aws-amplify/api`'s generateClient().graphql()
+ * here instead throws "No GraphQL endpoint configured in Amplify.configure()".)
  *
  * We use this for the Rules Discovery flow, which is built entirely on host
  * mutations/queries (uploadDiscoveryDocument, listDiscoveryJobs,
@@ -17,16 +18,13 @@
  * discovery pipeline and the config it writes to.
  *
  * NOTE on auth: uploadDiscoveryDocument is restricted to the Admin/Author
- * Cognito groups (see schema.graphql). A Reviewer-role user will get an
- * authorization error — the RulesDiscoveryView surfaces that as a friendly
- * "needs Admin or Author" message rather than a raw GraphQL error.
+ * Cognito groups (enforced server-side in the host's resolvers). A
+ * Reviewer-role user will get an authorization error — the RulesDiscoveryView
+ * surfaces that as a friendly "needs Admin or Author" message rather than a
+ * raw GraphQL error.
  */
 
-import { generateClient } from 'aws-amplify/api';
-
-// Minimal structural type for the bits of the Amplify client we use. We avoid
-// `ReturnType<typeof generateClient>` because that generic recurses deeply on
-// the schema-less form and trips TS2321 "Excessive stack depth" at build time.
+// Minimal structural type for the bits of the host client we use.
 interface GraphqlClient {
   graphql: (operation: {
     query: string;
@@ -34,22 +32,30 @@ interface GraphqlClient {
   }) => Promise<unknown>;
 }
 
+interface FeatureHostWindow {
+  IdpFeatureHost?: { generateClient?: () => GraphqlClient };
+}
+
 /**
- * Lazily create the GraphQL client on first use — NOT at module-eval time.
+ * Lazily create the host client on first use — NOT at module-eval time.
  *
  * This UMD bundle is injected via a <script> tag; its top-level code can run
- * before the host has finished `Amplify.configure()`. Calling
- * `generateClient()` at module scope then throws "Amplify has not been
- * configured. Please call Amplify.configure() before using this service."
- * — which Amplify rejects as a plain object, surfacing in the UI as
- * `[object Object]`. By deferring to first call (always inside a user-driven
- * handler or a mounted-component effect), the host's Amplify instance is
- * guaranteed to be configured. The client is memoised after the first call.
+ * before the host has installed its `window.IdpFeatureHost` globals. By
+ * deferring to first call (always inside a user-driven handler or a
+ * mounted-component effect), the host globals are guaranteed to be present.
+ * The client is memoised after the first call.
  */
 let _client: GraphqlClient | null = null;
 function getClient(): GraphqlClient {
   if (!_client) {
-    _client = generateClient() as unknown as GraphqlClient;
+    const host = (window as unknown as FeatureHostWindow).IdpFeatureHost;
+    if (!host?.generateClient) {
+      throw new Error(
+        'Host API client not available (window.IdpFeatureHost.generateClient). ' +
+          'The host UI may be older than the version that exposes it.',
+      );
+    }
+    _client = host.generateClient();
   }
   return _client;
 }

--- a/feature-platform/sample-health-insurance-review/feature-ui/vite.config.ts
+++ b/feature-platform/sample-health-insurance-review/feature-ui/vite.config.ts
@@ -9,9 +9,11 @@ import react from '@vitejs/plugin-react';
  * IDP Feature UI — Vite config.
  *
  * Produces a single UMD bundle at `dist/ui-bundle.js`. React, ReactDOM,
- * Cloudscape, aws-amplify, and react-router-dom are ALL externalised so the
- * feature bundle is small and shares the host's library instances (avoiding
- * the classic "two copies of React" crashes).
+ * Cloudscape, and react-router-dom are ALL externalised so the feature
+ * bundle is small and shares the host's library instances (avoiding the
+ * classic "two copies of React" crashes). Host API calls go through
+ * `window.IdpFeatureHost.generateClient` (see src/hostGraphql.ts), so
+ * aws-amplify is no longer imported or externalised.
  *
  * When the bundle is loaded in the host, these externals are resolved via
  * `window.*` globals set up by the main IDP UI's build.
@@ -107,7 +109,6 @@ export default defineConfig({
         'react-dom/client',
         'react-router-dom',
         /^@cloudscape-design\/.*/,
-        /^aws-amplify(\/.*)?$/,
       ],
       output: {
         globals: {
@@ -115,13 +116,6 @@ export default defineConfig({
           'react-dom': 'ReactDOM',
           'react-dom/client': 'ReactDOM',
           'react-router-dom': 'ReactRouterDOM',
-          'aws-amplify': 'awsAmplify',
-          // `generateClient` lives in the aws-amplify/api subpath; the host
-          // exposes it as its own `awsAmplifyApi` global (see
-          // src/ui/src/components/feature-page/feature-host-globals.ts).
-          // Without this mapping rollup warns and guesses the global name
-          // "api", which the host does not define.
-          'aws-amplify/api': 'awsAmplifyApi',
           '@cloudscape-design/components': 'CloudscapeComponents',
           '@cloudscape-design/design-tokens': 'CloudscapeDesignTokens',
         },

--- a/feature-platform/sample-health-insurance-review/feature.yaml
+++ b/feature-platform/sample-health-insurance-review/feature.yaml
@@ -7,7 +7,7 @@
 # feature API backed by the feature's own DynamoDB table.
 featureId: sample-health-insurance-review
 displayName: "Sample: Health Insurance Review"
-version: 0.1.0
+version: 0.1.1
 description: |
   Illustrative lightweight health insurance claims review vertical built on the IDP 
   Accelerator rule validation pipeline. Ships a prior-authorization config preset,

--- a/feature-platform/sample-health-insurance-review/ui-deployer/handler.py
+++ b/feature-platform/sample-health-insurance-review/ui-deployer/handler.py
@@ -139,7 +139,14 @@ def _bundle_ui(request_type: str) -> str:
             Key=dst_key,
             MetadataDirective="REPLACE",
             ContentType="application/javascript",
-            CacheControl="public,max-age=31536000,immutable",
+            # Short TTL, NOT immutable: the destination key is version-addressed
+            # (v<FEATURE_VERSION>/), so version bumps already bust caches — but
+            # same-version republishes DO happen (hotfixes re-uploading an
+            # existing version), and a year-long immutable header would pin the
+            # stale bundle in browsers until the version changes. max-age=300
+            # bounds staleness to 5 minutes at negligible re-fetch cost
+            # (~15 KB), matching the CloudFront distribution's own MaxTTL.
+            CacheControl="public,max-age=300",
         )
     elif request_type == "Delete":
         logger.info("Deleting s3://%s/%s", _WEBUI_BUCKET, dst_key)


### PR DESCRIPTION
Fixes #568

## Problem

The **Rules Discovery** tab of the `sample-health-insurance-review` extension failed immediately with:

> No GraphQL endpoint configured in `Amplify.configure()`.

The feature's `hostGraphql.ts` still called `aws-amplify/api`'s `generateClient().graphql()`. That worked when the host UI used AWS AppSync, but AppSync was removed — the host now talks to an API Gateway REST dispatcher via a GraphQL-shaped shim, and Amplify is configured for Cognito auth only (no GraphQL endpoint). The Claims Dashboard tab was unaffected (it uses the feature's own REST API).

## Fix

1. **`hostGraphql.ts`** — obtain the client from `window.IdpFeatureHost.generateClient` (the host's REST-backed, GraphQL-shaped client factory, installed by `feature-host-globals.ts` exactly for this purpose), instead of Amplify's `generateClient`. Same lazy-memoised pattern and identical `.graphql({query, variables})` call sites — this is the same migration `pii-anonymizer` already made. Clear error if the host is too old to expose the global.
2. **`vite.config.ts`** — drop the now-unused `aws-amplify` externals/globals; update stale comments.
3. **`feature.yaml` / `package.json`** — bump the feature to **v0.1.1** so subscribed stacks see the update (version-addressed bundle path busts caches on update).
4. **Cache-busting hardening (all 5 ui-deployers: template + 4 bundled features)** — the deployers copied `ui-bundle.js` into the Web UI bucket with `Cache-Control: public,max-age=31536000,immutable`. The destination key is version-addressed, so version bumps bust caches — but a *same-version* republish (hotfix) would leave browsers pinned to the stale bundle for up to a year. Changed to `public,max-age=300`, matching the CloudFront distribution's own `MaxTTL` (900s), so any update propagates within minutes at negligible re-fetch cost (~15 KB).
5. **CHANGELOG** — Unreleased → Fixed entry.

## Testing

- `npm run build` (tsc + vite) — clean; bundle no longer references `awsAmplifyApi` and registers as v0.1.1.
- `ruff check` / `ruff format` — clean; all ui-deployer unit tests pass (11 + 4 + 10 + 4).
- **Verified live on a deployed stack (IDP1, us-west-2):** uploaded the rebuilt bundle under `features/sample-health-insurance-review/v0.1.1/`, updated the InstalledFeatures record, and confirmed in the browser (browsermcp) that the Rules Discovery tab now renders its upload form, jobs table, and discovered-rules panel with **no** GraphQL endpoint error and a clean console.

## Notes for reviewers

- The `discoveryType` field-selection caveat and Admin/Author auth behavior are unchanged — only the transport moved.
- `sample-feature` (docs-by-status) and `idp-data-generator` don't call host GraphQL, so they only get the cache-header fix.
- The deployed stack's feature CFN stack still has `FEATURE_VERSION=0.1.0` baked; the next `publish.py` run + stack update will roll it forward through the normal path. The live edit above was a verification hotfix only.