### PR TITLE
fix(deps): bump brace-expansion to 2.1.4 in src/ui (supersedes #592)

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -33,7 +33,7 @@
         "ajv-formats": "^2.1.1",
         "aws-amplify": "^6.16.2",
         "axios": "^1.18.0",
-        "brace-expansion": "^2.1.3",
+        "brace-expansion": "^2.1.4",
         "chart.js": "^4.5.0",
         "dompurify": "^3.4.12",
         "form-data": "^4.0.4",
@@ -8516,16 +8516,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -9808,9 +9808,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -11536,16 +11536,16 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
@@ -12518,16 +12518,16 @@
       }
     },
     "node_modules/graphql-config/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/graphql-config/node_modules/cosmiconfig": {
@@ -15567,9 +15567,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -33,7 +33,7 @@
     "ajv-formats": "^2.1.1",
     "aws-amplify": "^6.16.2",
     "axios": "^1.18.0",
-    "brace-expansion": "^2.1.3",
+    "brace-expansion": "^2.1.4",
     "chart.js": "^4.5.0",
     "dompurify": "^3.4.12",
     "form-data": "^4.0.4",


### PR DESCRIPTION
## Summary

Replaces Dependabot PR #592. Fixes **GHSA-rgw5-rvv9-x895** (high) — DoS via
unbounded intermediate arrays, which bypasses the mitigation for the earlier
GHSA-mh99-v99m-4gvg.

`develop` was already at 2.1.3, which patches only the *earlier* advisory, and
its nested copies were still on the vulnerable 5.0.7 / 1.1.14.

## Why not just merge #592?

Dependabot diffs and rebases against `main`, which does not have `develop`'s
existing 2.1.3 bump — so its head conflicts irreconcilably with `develop` in
both `package.json` and `package-lock.json`. Each `@dependabot rebase` also
reset the PR base back to `main`, undoing the retarget. This branch reproduces
the identical end state directly on top of `develop`.

**#592 should be closed in favor of this PR.**

## Changes

| Path | Before | After |
|---|---|---|
| `node_modules/brace-expansion` | 2.1.3 | 2.1.4 |
| `@typescript-eslint/typescript-estree/…/brace-expansion` | 5.0.7 | 5.0.9 |
| `eslint-plugin-import-x/…/brace-expansion` | 5.0.7 | 5.0.9 |
| `graphql-config/…/brace-expansion` | 5.0.7 | 5.0.9 |
| `minimatch/node_modules/brace-expansion` | 1.1.14 | 1.1.18 |

Direct-dependency pin moved `^2.1.3` → `^2.1.4`. The diff is limited to
`brace-expansion`/`balanced-match` version metadata; no other dependency churn.

## Risk

Patch-level only. `brace-expansion` is not imported anywhere in `src/ui/src/` —
it is a direct dependency purely as a version pin to force the transitive fix.
5.0.9 drops Node 18 from its `engines` field, a no-op here since `src/ui`
already requires `node >=22.12.0`.

## Testing

- `make ui-build` ✅ (installed version confirmed 2.1.4)
- `make ui-lint` ✅ (eslint + `tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)