### PR TITLE
fix(config-ui): shorten the Postprocessing schema description

### DIFF
--- a/patterns/unified/template.yaml
+++ b/patterns/unified/template.yaml
@@ -2232,17 +2232,15 @@ Resources:
             collapsible: true
             defaultExpanded: false
             sectionLabel: Postprocessing
+            # Kept to one line, parallel to the Preprocessing section above.
+            # The caveats that used to live here (in-workflow latency, and the
+            # EventBridge PostProcessingLambdaHookFunctionArn alternative for
+            # fire-and-forget delivery) belong in the docs, not a UI section
+            # header: see docs/post-processing-lambda-hook.md, which carries the
+            # full "which mechanism do I want?" comparison.
             description: >-
               A single generic postprocessing hook (Lambda ARN + args) that runs
-              LAST, after evaluation and before the workflow completes, in both
-              processing modes. The mirror image of Preprocessing. The hook
-              receives the finished document and may return an `updatedDocument`
-              — the last word on what gets persisted to the tracking table,
-              reporting/Athena, and the UI. It runs INSIDE the workflow, so a
-              slow hook adds directly to per-document latency; for
-              fire-and-forget downstream delivery prefer the separate
-              PostProcessingLambdaHookFunctionArn stack parameter (EventBridge,
-              asynchronous, cannot modify the document).
+              LAST, after evaluation, in both processing modes.
             properties:
               enabled:
                 type: boolean
@@ -2261,11 +2259,9 @@ Resources:
                 enum: ["continue", "fail"]
                 default: continue
                 description: >-
-                  Behavior when the hook errors. `continue` (recommended) keeps
-                  the fully-processed document and completes normally, logging
-                  the error in the execution history. `fail` marks the whole
-                  document FAILED even though every processing step succeeded —
-                  use it only when the hook genuinely gates delivery.
+                  Behavior when the hook errors. `fail` marks the document FAILED
+                  even though every processing step succeeded — use it only when
+                  the hook genuinely gates delivery.
                 order: 2
               args:
                 type: array


### PR DESCRIPTION
## Problem

Reported from the deployed UI: the **Postprocessing** section header rendered a 605-character wall of text, while **Preprocessing** was a tidy 122-character one-liner. I'd front-loaded caveats into the UI string that belong in the docs.

## Before / after

**Before** (605 chars):

> A single generic postprocessing hook (Lambda ARN + args) that runs LAST, after evaluation and before the workflow completes, in both processing modes. The mirror image of Preprocessing. The hook receives the finished document and may return an `updatedDocument` — the last word on what gets persisted to the tracking table, reporting/Athena, and the UI. It runs INSIDE the workflow, so a slow hook adds directly to per-document latency; for fire-and-forget downstream delivery prefer the separate PostProcessingLambdaHookFunctionArn stack parameter (EventBridge, asynchronous, cannot modify the document).

**After** (116 chars) — now parallel in wording to its counterpart:

> **Preprocessing**
> A single generic preprocessing hook (Lambda ARN + args) that runs FIRST, before OCR/BDA routing, in both processing modes.
>
> **Postprocessing**
> A single generic postprocessing hook (Lambda ARN + args) that runs LAST, after evaluation, in both processing modes.

Also trimmed the section's `onError` description, which had the same problem (295 → 161 chars, now shorter than Preprocessing's). Field-level lengths across the two sections are otherwise within ~40 chars of each other.

## Nothing is lost

All three removed caveats already live in the docs, verified by grep:

| Caveat | Where it lives |
|---|---|
| In-workflow latency / holds a concurrency slot | `docs/feature-platform.md:278`, `feature-platform-developer-guide.md:248` |
| EventBridge alternative for fire-and-forget delivery | the "which mechanism do I want?" table in `docs/post-processing-lambda-hook.md` |
| Mutation reaches the tracking row / reporting / UI | `docs/feature-platform.md` propagation table |

A comment on the section records where they went, so the text doesn't creep back in.

## Scope

Schema string only — **no behavior change**, no code touched. The `Schema` record is non-versioned and rewritten on every stack update, so the shorter text reaches existing stacks on the next deploy.

`cfn-lint` clean; `make check-arn-partitions` clean.

Follow-up to #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
