### PR TITLE
fix(ci): correct two fatal Step 14 bugs + align the hook Lambda runtime

### DIFF
--- a/scripts/sdlc/codebuild_deployment.py
+++ b/scripts/sdlc/codebuild_deployment.py
@@ -1474,6 +1474,25 @@ def _hook_iam_role(iam, role_name):
     return role_arn
 
 
+def _hook_lambda_runtime():
+    """Lambda runtime string matching the interpreter building the hook zip.
+
+    Falls back to python3.12 if the build interpreter is outside the range Lambda
+    supports, since a wrong-but-supported runtime at least fails with a clear
+    import error rather than an InvalidParameterValueException at create time.
+    """
+    import sys
+
+    minor = sys.version_info.minor
+    if sys.version_info.major == 3 and 9 <= minor <= 13:
+        return f"python3.{minor}"
+    print(
+        f"  ⚠️  build interpreter python3.{minor} has no matching Lambda runtime; "
+        f"falling back to python3.12"
+    )
+    return "python3.12"
+
+
 def _build_hook_zip(path):
     """Zip the hook source together with idp_common and its import-time deps.
 
@@ -1590,7 +1609,14 @@ def test_step14_pipeline_hooks(stack_name):
             try:
                 lam.create_function(
                     FunctionName=fn_name,
-                    Runtime="python3.12",
+                    # Match the runtime to the interpreter that BUILT the zip.
+                    # pydantic_core ships a compiled extension
+                    # (_pydantic_core.cpython-3XX-*.so), so a zip built on 3.12
+                    # and run on a 3.13 Lambda (or vice versa) fails at cold
+                    # start with an opaque ModuleNotFoundError. Hardcoding 3.12
+                    # happens to match today's buildspec, but would break
+                    # silently the day that buildspec's python is bumped.
+                    Runtime=_hook_lambda_runtime(),
                     Role=role_arn,
                     Handler="index.lambda_handler",
                     Code={"ZipFile": code},
@@ -1661,7 +1687,9 @@ def test_step14_pipeline_hooks(stack_name):
         for point in ("preprocessing", "postprocessing"):
             cfg[point] = {
                 "enabled": True,
-                "featureId": "ci-hook-test",
+                # Same id as the Lambda's idp:feature-id tag, so the config and
+                # the ABAC grant cannot drift apart.
+                "featureId": _HOOK_FEATURE_ID,
                 "arn": hook_arn,
                 # `continue` on BOTH points: a hook fault must not fail the
                 # document and turn a coverage test into a flaky gate. The
@@ -1705,9 +1733,13 @@ def test_step14_pipeline_hooks(stack_name):
         # --- 3. Process a document pinned to that version ------------------
         print("  Processing a document with the hook registered...")
         batch_id = "test-pipeline-hooks"
+        # `--dir` takes a DIRECTORY (file_okay=False) and run-inference has no
+        # short flags at all, so `-d <file>` is rejected outright. Select the one
+        # document with --file-pattern, exactly as Steps 6/8 do.
         run_command(
             f"idp-cli run-inference --stack-name {stack_name} "
-            f"-d samples/lending_package.pdf --batch-id {batch_id} "
+            f"--dir samples/ --file-pattern lending_package.pdf "
+            f"--batch-id {batch_id} "
             f"--config-version {config_version} --monitor",
             check=True,
             timeout=900,
@@ -1728,32 +1760,60 @@ def test_step14_pipeline_hooks(stack_name):
                 "error": "StateMachineArn missing from stack outputs",
             }
 
+        # Find OUR execution's dispatcher results. This must key off the config
+        # version, not just the hook point: Step 14 runs in the parallel pool, and
+        # Steps 3-11 push documents through this SAME state machine using configs
+        # with no hooks — so every one of their executions also emits
+        # `{hookPoint: preprocessing|postprocessing, invoked: 0}`. Matching on
+        # hook point alone would latch onto one of those, "find" both points at
+        # invoked=0, and report a false failure while our hook had run perfectly.
+        #
+        # Filtering on configVersion is exact (only our document is pinned to it)
+        # and doubles as the assertion that the dispatcher resolved the version we
+        # registered the hook in — the diagnostic that #599 lacked.
         sfn = boto3.client("stepfunctions", config=_THROTTLE_RETRY_CONFIG)
         found = {}
-        for ex in sfn.list_executions(
-            stateMachineArn=sm_arn, statusFilter="SUCCEEDED", maxResults=25
-        ).get("executions", []):
-            hist = sfn.get_execution_history(
-                executionArn=ex["executionArn"], reverseOrder=True, maxResults=200
-            ).get("events", [])
-            for event in hist:
-                det = event.get("taskSucceededEventDetails") or {}
-                out = det.get("output") or ""
-                if '"hookPoint"' not in out:
-                    continue
-                try:
-                    payload = json.loads(out).get("Payload") or {}
-                except (ValueError, TypeError):
-                    continue
-                point = payload.get("hookPoint")
-                if point in ("preprocessing", "postprocessing"):
-                    # Keep the richest record per point.
-                    if payload.get("invoked", 0) >= found.get(point, {}).get(
-                        "invoked", -1
-                    ):
-                        found[point] = payload
-            if len(found) == 2:
+        scanned = 0
+        next_token = None
+        # Cap the sweep: with ~10 parallel steps the target execution is near the
+        # front, but Step 6 alone submits several documents, so one page is not a
+        # safe assumption.
+        while scanned < 200 and len(found) < 2:
+            kwargs = {
+                "stateMachineArn": sm_arn,
+                "statusFilter": "SUCCEEDED",
+                "maxResults": 100,
+            }
+            if next_token:
+                kwargs["nextToken"] = next_token
+            page = sfn.list_executions(**kwargs)
+            for ex in page.get("executions", []):
+                scanned += 1
+                hist = sfn.get_execution_history(
+                    executionArn=ex["executionArn"], reverseOrder=True, maxResults=200
+                ).get("events", [])
+                for event in hist:
+                    det = event.get("taskSucceededEventDetails") or {}
+                    out = det.get("output") or ""
+                    if '"hookPoint"' not in out:
+                        continue
+                    try:
+                        payload = json.loads(out).get("Payload") or {}
+                    except (ValueError, TypeError):
+                        continue
+                    point = payload.get("hookPoint")
+                    if point not in ("preprocessing", "postprocessing"):
+                        continue
+                    # Only OUR document's execution counts.
+                    if payload.get("configVersion") != config_version:
+                        continue
+                    found[point] = payload
+                if len(found) == 2:
+                    break
+            next_token = page.get("nextToken")
+            if not next_token:
                 break
+        print(f"  (scanned {scanned} SUCCEEDED execution(s) for {config_version})")
 
         for point in ("preprocessing", "postprocessing"):
             payload = found.get(point)
@@ -1761,9 +1821,11 @@ def test_step14_pipeline_hooks(stack_name):
                 return {
                     "success": False,
                     "error": (
-                        f"No {point} dispatcher result found in any SUCCEEDED "
-                        f"execution — the hook state may not be wired into the "
-                        f"state machine"
+                        f"No {point} dispatcher result for configVersion "
+                        f"{config_version!r} in {scanned} scanned SUCCEEDED "
+                        f"execution(s) — either the {point} hook state is not "
+                        f"wired into the state machine, or our document's "
+                        f"execution did not resolve that config version"
                     ),
                 }
             if payload.get("invoked", 0) < 1:

--- a/scripts/sdlc/tests/test_pipeline_hook_step.py
+++ b/scripts/sdlc/tests/test_pipeline_hook_step.py
@@ -240,3 +240,81 @@ class TestStepRegistration:
             "dispatcher cannot invoke a function not named GENAIIDP-*"
         )
         assert "list_tags" in src, "the tag should be verified, not assumed"
+
+
+@pytest.mark.unit
+class TestStepInvocationCorrectness:
+    """Pins the three bugs found auditing Step 14 before its second pipeline run.
+
+    All three would have failed the step (or, worse, passed/failed it for the
+    wrong reason) and none are reachable without a live stack, so they are
+    asserted against the step's source.
+    """
+
+    def _src(self, cbd):
+        import inspect
+
+        return inspect.getsource(cbd.test_step14_pipeline_hooks)
+
+    def test_run_inference_uses_dir_plus_file_pattern(self, cbd):
+        """`run-inference` declares NO short flags and its `--dir` is
+        `file_okay=False`, so `-d samples/lending_package.pdf` is rejected twice
+        over: unknown option, and a file where a directory is required."""
+        src = self._src(cbd)
+        assert "--dir samples/" in src
+        assert "--file-pattern lending_package.pdf" in src
+        assert "-d samples/" not in src, "run-inference has no -d short flag"
+
+    def test_execution_scan_filters_on_config_version(self, cbd):
+        """Step 14 shares the state machine with the other parallel steps, whose
+        hook-less documents ALSO emit `{hookPoint: ..., invoked: 0}` at both
+        points. Without a configVersion filter the scan latches onto one of those
+        and reports a false failure."""
+        src = self._src(cbd)
+        assert 'payload.get("configVersion") != config_version' in src, (
+            "the scan must accept only OUR document's dispatcher results"
+        )
+
+    def test_execution_scan_does_not_stop_on_a_foreign_result(self, cbd):
+        """The original `if len(found) == 2: break` could satisfy itself with two
+        invoked=0 records from another step. With the configVersion filter a
+        `found` entry is by definition ours, so the break is safe — assert the
+        filter precedes it rather than the break being removed."""
+        src = self._src(cbd)
+        filter_at = src.index('payload.get("configVersion") != config_version')
+        break_at = src.index("if len(found) == 2:")
+        assert filter_at < break_at, (
+            "the configVersion filter must run before the early break"
+        )
+
+    def test_feature_id_is_shared_between_tag_and_config(self, cbd):
+        """The Lambda's idp:feature-id tag and the config section's featureId must
+        come from the same constant; drift would leave the ABAC grant and the
+        registered owner disagreeing."""
+        src = self._src(cbd)
+        assert '"featureId": _HOOK_FEATURE_ID' in src
+
+
+@pytest.mark.unit
+class TestLambdaRuntimeAlignment:
+    """pydantic_core is a COMPILED extension, so the zip and the Lambda runtime
+    must agree on the Python minor version or the hook dies at cold start."""
+
+    def test_runtime_matches_the_building_interpreter(self, cbd):
+        import sys
+
+        assert cbd._hook_lambda_runtime() == f"python3.{sys.version_info.minor}"
+
+    def test_runtime_is_a_supported_lambda_value(self, cbd):
+        assert cbd._hook_lambda_runtime() in {
+            f"python3.{m}" for m in range(9, 14)
+        }
+
+    def test_create_function_does_not_hardcode_a_runtime(self, cbd):
+        import inspect
+
+        src = inspect.getsource(cbd.test_step14_pipeline_hooks)
+        assert "Runtime=_hook_lambda_runtime()" in src
+        assert 'Runtime="python3.12"' not in src, (
+            "a hardcoded runtime silently breaks when the buildspec python moves"
+        )


### PR DESCRIPTION
## Why

The IAM fix (#614) was necessary but **not sufficient**. Rather than assume Step 14 would now pass, I audited it against the CLI and the state machine. It had **two more bugs, each fatal**, neither reachable without a live stack — so the next pipeline run would have failed again, ~70 minutes later.

## Bug 1 — the `run-inference` invocation was invalid twice over

The step called:

```
idp-cli run-inference ... -d samples/lending_package.pdf
```

Checked against `lib/idp_cli_pkg/idp_cli/cli.py`:

- `run-inference` declares **no short flags at all** → `-d` is an unknown option.
- Its `--dir` is `click.Path(exists=True, file_okay=False, dir_okay=True)` → a **file** path is rejected even with the long flag.

Now uses `--dir samples/ --file-pattern lending_package.pdf`, the form Steps 6 and 8 already use.

## Bug 2 — the execution scan could report a FALSE failure

Step 14 runs in the **parallel pool** and shares the state machine with Steps 3–11. `PreprocessingHook` is `StartAt` and `PostprocessingHook` is now on the shared tail, so **every execution in the stack emits both hook results** — for a hook-less config, as `invoked: 0`.

The old loop keyed only on hook point, with `if len(found) == 2: break`. It could therefore latch onto two `invoked: 0` records from another step's document, break immediately, and fail with *"dispatcher reported invoked=0"* — **while our hook had run perfectly**.

The scan now accepts a payload only when `payload["configVersion"] == config_version`. That's exact (only our document is pinned to that version) and doubles as the version assertion #599 lacked. It also paginates to 200 executions instead of trusting a single 25-item page, since Step 6 alone submits several documents.

## Plus one latent fragility

`Runtime` was hardcoded `"python3.12"` while the zip is built from whatever interpreter CodeBuild provides. `pydantic_core` ships a compiled `_pydantic_core.cpython-3XX-*.so`, so the day the buildspec's Python moves, the hook would die at cold start with an opaque `ModuleNotFoundError`. Runtime is now derived from the building interpreter via `_hook_lambda_runtime()`, with a supported-range guard and fallback.

(Concretely: this dev box builds `cpython-313`; CodeBuild builds `cp312` and I'd pinned 3.12 — aligned *today*, silently broken after a bump.)

Also de-duplicated the feature id: the config section's `featureId` now uses `_HOOK_FEATURE_ID`, the same constant as the Lambda's `idp:feature-id` tag, so the ABAC grant and the registered owner cannot drift apart.

## Testing

- **7 new tests** pin all four changes, asserted against the step's source since none are reachable offline — including that the `configVersion` filter *precedes* the early break, and that no hardcoded runtime creeps back.
- `scripts/sdlc/tests`: **205 passed** (was 198).
- `make lint-cicd` clean.
- Verified read-only that the deployed IDP1 stack has `EvaluationStep → PostprocessingHook`, so the hook states do land in a real stack from #611's template.

## Honest status

**Step 14 still has not completed a successful run.** I offered to dry-run it against a live stack for a definitive answer; that was declined to avoid interfering with in-progress testing, which is reasonable. So this fixes every defect I can find by static audit + CLI/state-machine verification, but cannot prove the step passes end-to-end.

Remaining untested surface, in rough order of risk: the zip build inside the CodeBuild venv; `config-upload` validation accepting the hook sections; and the tracking-table marker scan. Each fails with a message naming the failing call.

**Note on merging:** the deploy pipeline builds from **GitLab**, which does not auto-sync from GitHub — that's why #614 appeared to "still fail" (the pipeline was running pre-fix code). After merging here, `develop` must also be pushed to GitLab before a rerun will pick this up.

Follow-up to #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
