### PR TITLE
refactor(test-studio): define the EVALUATING badge rule once; drop a write from the status poll

### DIFF
--- a/lib/idp_common_pkg/tests/unit/test_results_resolver.py
+++ b/lib/idp_common_pkg/tests/unit/test_results_resolver.py
@@ -5,6 +5,7 @@
 import importlib.util
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -675,7 +676,9 @@ def test_aborted_run_without_metrics_does_not_requeue():
     mock_sqs.send_message.assert_not_called()
 
 
-def _status_table_for(test_run_id, files, stored_status, with_metrics=False):
+def _status_table_for(
+    test_run_id, files, stored_status, with_metrics=False, queued_at=None
+):
     """Mock tracking table where every file is fully processed and evaluated."""
     metadata = {
         "PK": f"testrun#{test_run_id}",
@@ -687,6 +690,8 @@ def _status_table_for(test_run_id, files, stored_status, with_metrics=False):
     }
     if with_metrics:
         metadata["testRunResult"] = {"overallAccuracy": 0.72}
+    if queued_at is not None:
+        metadata["CacheUpdateQueuedAt"] = queued_at
 
     def get_item(Key):
         if Key["PK"] == f"testrun#{test_run_id}":
@@ -826,3 +831,182 @@ def test_claim_cache_update_slot_denies_on_condition_failure():
         patch.object(index.dynamodb, "Table", return_value=mock_table),
     ):
         assert index._claim_cache_update_slot("run-1", 300) is False
+
+
+# ---------------------------------------------------------------------------
+# Follow-up to #619 review: the "terminal but no metrics -> EVALUATING" rule is
+# now defined once, and the throttle window is read from the item already in
+# hand rather than by attempting a conditional write on every 5-second poll.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "status,has_metrics,expected",
+    [
+        # Terminal and metrics missing -> the aggregation really is outstanding.
+        ("COMPLETE", False, "EVALUATING"),
+        ("PARTIAL_COMPLETE", False, "EVALUATING"),
+        # Metrics present -> report the true status.
+        ("COMPLETE", True, "COMPLETE"),
+        ("PARTIAL_COMPLETE", True, "PARTIAL_COMPLETE"),
+        # ABORTED is terminal but is NOT eligible for aggregation, so it must
+        # never be masked as EVALUATING however its metrics look.
+        ("ABORTED", False, "ABORTED"),
+        ("ABORTED", True, "ABORTED"),
+        # Non-terminal statuses pass straight through.
+        ("RUNNING", False, "RUNNING"),
+        ("QUEUED", False, "QUEUED"),
+    ],
+)
+def test_display_status_rule(status, has_metrics, expected):
+    """One truth table for the badge, shared by all three resolvers."""
+    item = {"testRunResult": {"overallAccuracy": 0.7}} if has_metrics else {}
+    assert index._display_status(item, status) == expected
+    assert index._awaiting_metrics(item, status) is (expected == "EVALUATING")
+
+
+@pytest.mark.unit
+def test_build_test_run_list_uses_shared_rule_but_does_not_enqueue():
+    """The list view shows EVALUATING but must not fan out an enqueue per row.
+
+    One list render covers an arbitrary number of runs; enqueueing for each stuck
+    row would turn a page load into a burst of multi-minute aggregations. The
+    per-row getTestRunStatus poll drives recovery instead.
+    """
+    items = [
+        {
+            "TestRunId": "stuck-1",
+            "Status": "COMPLETE",
+            "CreatedAt": "2026-08-13T13:25:01.571600Z",
+        },
+        {
+            "TestRunId": "stuck-2",
+            "Status": "PARTIAL_COMPLETE",
+            "CreatedAt": "2026-08-13T13:25:01.571600Z",
+        },
+        {
+            "TestRunId": "aborted-1",
+            "Status": "ABORTED",
+            "CreatedAt": "2026-08-13T13:25:01.571600Z",
+        },
+        {
+            "TestRunId": "good-1",
+            "Status": "COMPLETE",
+            "testRunResult": {"overallAccuracy": 0.72},
+            "CreatedAt": "2026-08-13T13:25:01.571600Z",
+        },
+    ]
+    mock_sqs = Mock()
+
+    with patch.object(index, "sqs", mock_sqs):
+        result = index._build_test_run_list(items)
+
+    by_id = {r["testRunId"]: r["status"] for r in result}
+    assert by_id["stuck-1"] == "EVALUATING"
+    assert by_id["stuck-2"] == "EVALUATING"
+    assert by_id["aborted-1"] == "ABORTED"
+    assert by_id["good-1"] == "COMPLETE"
+    # The regression this pins: rendering a list is not a write path.
+    mock_sqs.send_message.assert_not_called()
+
+
+@pytest.mark.unit
+def test_cache_update_recently_queued_window():
+    """Recent -> suppress; stale/absent/garbage -> fall through to the claim."""
+    now = datetime.now(timezone.utc)
+
+    # Inside the window.
+    assert index._cache_update_recently_queued(
+        {"CacheUpdateQueuedAt": (now - timedelta(seconds=30)).isoformat()}, 300
+    )
+    # Outside the window -> due for another attempt.
+    assert not index._cache_update_recently_queued(
+        {"CacheUpdateQueuedAt": (now - timedelta(seconds=301)).isoformat()}, 300
+    )
+    # Never queued.
+    assert not index._cache_update_recently_queued({}, 300)
+    # Throttling explicitly disabled.
+    assert not index._cache_update_recently_queued(
+        {"CacheUpdateQueuedAt": now.isoformat()}, 0
+    )
+    # Unreadable value must not silently suppress recovery.
+    assert not index._cache_update_recently_queued(
+        {"CacheUpdateQueuedAt": "not-a-timestamp"}, 300
+    )
+    assert not index._cache_update_recently_queued({"CacheUpdateQueuedAt": 12345}, 300)
+    # A naive timestamp is treated as UTC rather than raising on the subtraction.
+    assert index._cache_update_recently_queued(
+        {"CacheUpdateQueuedAt": now.replace(tzinfo=None).isoformat()}, 300
+    )
+    # A future timestamp (clock skew) is not treated as "recent" in a way that
+    # could suppress recovery forever -- negative age falls through.
+    assert not index._cache_update_recently_queued(
+        {"CacheUpdateQueuedAt": (now + timedelta(seconds=60)).isoformat()}, 300
+    )
+
+
+@pytest.mark.unit
+def test_status_poll_skips_conditional_write_when_recently_queued():
+    """The hot path: a 5-second poll on a stuck run must not write to DynamoDB.
+
+    A rejected conditional write still consumes write capacity, so with the
+    aggregation already in flight the poll should not attempt one at all.
+    """
+    files = [f"doc{i}.pdf" for i in range(10)]
+    recent = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+    mock_table = _status_table_for(
+        "in-flight-run", files, stored_status="COMPLETE", queued_at=recent
+    )
+    mock_sqs = Mock()
+    mock_claim = Mock(return_value=True)
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "TRACKING_TABLE": "tracking",
+                "TEST_RESULT_CACHE_UPDATE_QUEUE_URL": "https://sqs.test/q",
+            },
+        ),
+        patch.object(index.dynamodb, "Table", return_value=mock_table),
+        patch.object(index, "sqs", mock_sqs),
+        patch.object(index, "_claim_cache_update_slot", mock_claim),
+    ):
+        result = index.get_test_run_status("in-flight-run")
+
+    # Still reports the outstanding aggregation to the user...
+    assert result["status"] == "EVALUATING"
+    assert result["completedFiles"] == 10
+    # ...without a duplicate enqueue or the conditional write behind it.
+    mock_sqs.send_message.assert_not_called()
+    mock_claim.assert_not_called()
+    mock_table.update_item.assert_not_called()
+
+
+@pytest.mark.unit
+def test_status_poll_retries_once_throttle_window_expires():
+    """Convergence: after the window lapses, recovery is attempted again."""
+    files = [f"doc{i}.pdf" for i in range(10)]
+    stale = (datetime.now(timezone.utc) - timedelta(seconds=400)).isoformat()
+    mock_table = _status_table_for(
+        "stale-claim-run", files, stored_status="COMPLETE", queued_at=stale
+    )
+    mock_sqs = Mock()
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "TRACKING_TABLE": "tracking",
+                "TEST_RESULT_CACHE_UPDATE_QUEUE_URL": "https://sqs.test/q",
+            },
+        ),
+        patch.object(index.dynamodb, "Table", return_value=mock_table),
+        patch.object(index, "sqs", mock_sqs),
+        patch.object(index, "_claim_cache_update_slot", return_value=True),
+    ):
+        result = index.get_test_run_status("stale-claim-run")
+
+    assert result["status"] == "EVALUATING"
+    mock_sqs.send_message.assert_called_once()

--- a/nested/api-resolvers/src/lambda/test_results_resolver/index.py
+++ b/nested/api-resolvers/src/lambda/test_results_resolver/index.py
@@ -218,12 +218,82 @@ def handler(event, context):
     raise ValueError(f"Unknown field: {field_name}")
 
 
+# Statuses that mean "processing is over" AND that aggregate metrics are
+# expected for. ABORTED is terminal too but is deliberately absent: an aborted
+# run is not eligible for aggregation, so it must keep reporting ABORTED rather
+# than being masked as EVALUATING.
+_METRICS_ELIGIBLE_STATUSES = ("COMPLETE", "PARTIAL_COMPLETE")
+
+
+def _awaiting_metrics(item, status):
+    """Is this run finished but still missing its cached aggregate metrics?
+
+    The single definition of the condition behind the ``EVALUATING`` badge. Three
+    resolvers surface that badge — ``_build_test_run_list`` (the Executions
+    list), ``get_test_run_status`` (the per-row poll) and ``get_test_results``
+    (the results page) — and they previously each spelled the rule out inline.
+    Issue #619 was diagnosed through the resulting confusion: the badge said
+    EVALUATING while the file counts said every document was processed and none
+    was evaluating, because "terminal but no metrics" and "actually evaluating"
+    render identically. Keep the rule here so the three sites cannot drift.
+    """
+    return status in _METRICS_ELIGIBLE_STATUSES and not item.get("testRunResult")
+
+
+def _display_status(item, status):
+    """Map a true run status to the status reported to the UI.
+
+    A finished run with no cached metrics reports ``EVALUATING``, because the
+    aggregation genuinely is still outstanding — but note the caller is
+    responsible for making sure something will actually *do* that aggregation.
+    ``get_test_run_status`` and ``get_test_results`` pair this with
+    ``_queue_cache_update``; ``_build_test_run_list`` deliberately does not (see
+    its own comment), since it renders many runs at once.
+    """
+    return "EVALUATING" if _awaiting_metrics(item, status) else status
+
+
 # How long one enqueued cache update suppresses further enqueues for the same
 # run. Aggregation re-reads every document's results.json from S3, so it can take
 # minutes on a large run; this window keeps concurrent readers (and repeat visits
 # to the results page) from stacking up redundant duplicate work, while still
 # letting a run whose aggregation genuinely failed retry on a later view.
 _CACHE_UPDATE_THROTTLE_SECONDS = 300
+
+
+def _cache_update_recently_queued(
+    item, throttle_seconds=_CACHE_UPDATE_THROTTLE_SECONDS
+):
+    """Cheap in-memory read of the throttle window from an already-fetched item.
+
+    ``_claim_cache_update_slot`` remains the authoritative guard — only its
+    conditional write is atomic against concurrent invocations. This is purely an
+    optimisation for the common case: ``get_test_run_status`` is polled every 5
+    seconds per in-progress run by the UI, and for a run that is stuck awaiting
+    metrics every one of those polls would otherwise issue a conditional
+    ``update_item`` that is almost always rejected — and a rejected conditional
+    write still consumes write capacity. Callers that already hold the metadata
+    item can skip that write entirely.
+
+    Returns False whenever the answer is not clearly "yes" (no timestamp,
+    unparseable timestamp), so an unreadable value degrades to attempting the
+    authoritative claim rather than silently suppressing recovery.
+    """
+    queued_at = item.get("CacheUpdateQueuedAt")
+    if not queued_at or not throttle_seconds:
+        return False
+    try:
+        parsed = datetime.fromisoformat(queued_at)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Unparseable CacheUpdateQueuedAt {queued_at!r}; "
+            "falling through to the conditional claim"
+        )
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - parsed).total_seconds()
+    return 0 <= age < throttle_seconds
 
 
 def _claim_cache_update_slot(test_run_id, throttle_seconds):
@@ -545,7 +615,10 @@ def get_test_results(test_run_id):
             # document's results.json from S3 and can take minutes on a large
             # run — far longer than the API's read timeout — so doing it
             # inline here would turn a stale cache into a timed-out query.
-            _queue_cache_update(test_run_id)
+            # Skip when one is already in flight, using the metadata in hand so
+            # revisiting the page doesn't cost a rejected conditional write.
+            if not _cache_update_recently_queued(metadata):
+                _queue_cache_update(test_run_id)
 
         # For ABORTED status, count completed files on first call and persist to DB
         completed_files_count = metadata.get("CompletedFiles", 0)
@@ -627,8 +700,10 @@ def get_test_results(test_run_id):
             # aggregation attempt failed used to stay metric-less forever, which
             # the UI renders as a permanent EVALUATING badge alongside a fully
             # processed file count (issue #619). Throttled, so repeat visits to
-            # the results page don't stack up duplicate aggregations.
-            _queue_cache_update(test_run_id)
+            # the results page don't stack up duplicate aggregations — checked
+            # against the metadata already in hand to avoid a write per visit.
+            if not _cache_update_recently_queued(metadata):
+                _queue_cache_update(test_run_id)
 
         return {
             "testRunId": test_run_id,
@@ -726,12 +801,15 @@ def _build_test_run_list(items):
     test_runs = []
 
     for item in items:
-        display_status = item.get("Status")
-        # Show EVALUATING for completed tests without metrics, but keep ABORTED as-is
-        if display_status in ["COMPLETE", "PARTIAL_COMPLETE"] and not item.get(
-            "testRunResult"
-        ):
-            display_status = "EVALUATING"
+        # Show EVALUATING for completed tests without metrics, but keep ABORTED
+        # as-is. Display only: unlike the two single-run resolvers, this does NOT
+        # enqueue the missing aggregation, because one list render covers an
+        # arbitrary number of runs and fanning out an enqueue per stuck row would
+        # turn a page load into a burst of multi-minute Lambda invocations. The
+        # per-row poll (getTestRunStatus) drives recovery instead, and the UI
+        # renders TestRunnerStatus for every row — so a run visible here is
+        # already being healed by the resolver that can afford to do it.
+        display_status = _display_status(item, item.get("Status"))
 
         test_runs.append(
             {
@@ -962,9 +1040,7 @@ def get_test_run_status(test_run_id):
                 )
 
                 # Queue metric calculation for completed test runs
-                if overall_status in ["COMPLETE", "PARTIAL_COMPLETE"] and not item.get(
-                    "testRunResult"
-                ):
+                if _awaiting_metrics(item, overall_status):
                     _queue_cache_update(test_run_id)
 
             except Exception as e:
@@ -973,19 +1049,23 @@ def get_test_run_status(test_run_id):
                 )
 
         # Report EVALUATING to caller until cached metrics are available
-        display_status = overall_status
-        if display_status in ["COMPLETE", "PARTIAL_COMPLETE"] and not item.get(
-            "testRunResult"
-        ):
-            display_status = "EVALUATING"
+        display_status = _display_status(item, overall_status)
+        if _awaiting_metrics(item, overall_status):
             # Self-heal when the status did NOT change on this call — i.e. the
             # transition enqueue above didn't fire, because the run reached its
             # terminal status on an earlier call whose aggregation then failed.
             # Without this the run reports EVALUATING forever while showing every
-            # file processed and zero evaluating (issue #619). The throttle caps
-            # this at one aggregation per window even though the UI polls
-            # getTestRunStatus every 5 seconds.
-            if overall_status == stored_status:
+            # file processed and zero evaluating (issue #619).
+            #
+            # The UI polls this resolver every 5 seconds per in-progress run, so
+            # the throttle window is read from the item already in hand rather
+            # than by attempting the conditional write on every poll — the write
+            # would be rejected almost every time, and a rejected conditional
+            # write still costs write capacity. _queue_cache_update re-checks
+            # atomically, so this shortcut can only skip work, never duplicate it.
+            if overall_status == stored_status and not _cache_update_recently_queued(
+                item
+            ):
                 _queue_cache_update(test_run_id)
 
         progress = (


### PR DESCRIPTION
Follow-up to the two 🟡 review findings on #620. No behavior change to the #619 fix itself — the existing 24 tests from #620 pass unmodified, which is the point.

## 1. The EVALUATING badge rule was defined in three places (`index.py:729` finding)

"Terminal but no cached metrics → report `EVALUATING`" was spelled out inline at three sites — `_build_test_run_list` (Executions list), `get_test_run_status` (per-row poll), `get_test_results` (results page) — and #620 added self-heal to only two of them.

That divergence worked only *incidentally*: recovery for rows in the Executions list depends on the per-row `getTestRunStatus` poll rather than on the list query itself. Fine today, but a triplicated rule with divergent behavior is how the next bug of this exact class gets written — and it's worth remembering that #619 was hard to diagnose precisely *because* "terminal but no metrics" and "actually evaluating" render identically.

The rule is now one helper pair used by all three sites:

```python
_METRICS_ELIGIBLE_STATUSES = ("COMPLETE", "PARTIAL_COMPLETE")

def _awaiting_metrics(item, status): ...
def _display_status(item, status): ...
```

`_build_test_run_list` still does **not** enqueue — one list render covers arbitrarily many runs, and fanning out an enqueue per stuck row would turn a page load into a burst of multi-minute aggregations. The difference is that this is now a documented decision at the call site rather than an omission. `ABORTED`'s exclusion (terminal, but not eligible for aggregation, so it must never be masked as EVALUATING) is likewise stated once, in `_METRICS_ELIGIBLE_STATUSES`.

## 2. A DynamoDB write on every 5-second poll (`index.py:229-247` finding)

`get_test_run_status` is polled every 5 seconds per in-progress run by `TestRunnerStatus`. For a run stuck awaiting metrics, every one of those polls issued a conditional `update_item` that is almost always rejected — and a rejected conditional write still consumes write capacity.

Callers already hold the metadata item, so the throttle window is now read from it in memory via `_cache_update_recently_queued()` before attempting the authoritative claim. `_claim_cache_update_slot` remains the **only** atomic guard, so this shortcut can only skip work, never duplicate it. Applied to all three call sites that hold the item, including the stale-cache re-aggregation path.

The helper returns `False` whenever the answer is not clearly "yes" — absent, unparseable, or future-dated (clock skew) timestamps all fall through to the authoritative claim — so an unreadable value can never suppress recovery permanently. That direction matters: the failure mode of #619 was recovery never happening, and this optimisation must not be able to reintroduce it.

## Testing

12 tests added (36 total in the file, up from 24):

- `_display_status` / `_awaiting_metrics` truth table — 8 parametrised cases, pinning that `ABORTED` is never masked and that non-terminal statuses pass through
- the list view shows `EVALUATING` for stuck rows **without** enqueueing (asserts `send_message` not called) — pins that rendering a list is not a write path
- the throttle window's boundaries: inside, outside, absent, disabled, unparseable, non-string, naive-timestamp-treated-as-UTC, and future-dated
- the poll skips the conditional write while an aggregation is in flight (asserts `_claim_cache_update_slot` and `update_item` both untouched), and retries once the window lapses

Results:
- `tests/unit/test_results_resolver.py` — 36 passed
- all five test files touching the changed functions — 117 passed
- full `idp_common_pkg` unit suite — **2775 passed, 55 skipped, 0 failed**
- `ruff check` clean; test file `ruff format` clean

## Still deferred from the #620 review

The 🟢 items are deliberately not in scope here: `attribute_exists(PK)` on the claim's condition expression (unreachable footgun), `exc_info=True` on the new warning logs, an attempt cap/backoff for a permanently-failing aggregation, a comment at the Athena fallback site, and an end-to-end test through `handle_cache_update_request`. Happy to fold any of them in if you'd rather not leave them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
