### PR TITLE
fix(seller-service): make the service deployable, verifiable, and SRT-clean

### DIFF
--- a/.claude/skills/run-stack-tests.md
+++ b/.claude/skills/run-stack-tests.md
@@ -21,6 +21,7 @@ limit) and caused flaky failures unrelated to the code under test.
 | `make stacktest-waf` | WAF IP-allow-list WebACL association | stack or self-deploy |
 | `make stacktest-hosting-private` | PRIVATE (VPC) API hosting | **VPC** + stack/self-deploy |
 | `make stacktest-jobsapi` | Jobs REST API (`EnableJobsApi`) | **VPC** + stack/self-deploy |
+| `make stacktest-seller` | Seller Entitlement Service e2e (deploys + tears down its own stack) | seller-account creds; **no** listing needed |
 | `make stacktest-benchmark` | Release-vs-release benchmark audit (alias) | see run-benchmarks |
 | `make stacktest-upgrade` | In-place upgrade test pointer | see test-upgrade |
 

--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,23 @@ stacktest-hosting-private: ## APIGateway PRIVATE (VPC) hosting variant (needs VP
 stacktest-jobsapi: ## Jobs API (VPC) variant (needs VPC_ID=...)
 	$(PYTHON) scripts/sdlc/run_stacktest.py jobsapi $(_STACKTEST_ARGS)
 
+# Seller Entitlement Service e2e. Not a main-stack variant, so it does not go
+# through run_stacktest.py: it deploys its own standalone stack (into a seller
+# account) and tears it down again.
+#
+# This is the guard for deploy-time defects, which the offline suites structurally
+# cannot see. Both real failures in this service so far — SAM's CALLER_CREDENTIALS
+# default conflicting with the resource policy, and the missing account-level API
+# Gateway CloudWatch role — were caught only by attempting a deploy.
+#
+# Needs no real Marketplace listing: every assertion is a refusal, so it registers
+# a synthetic product id and skips the ownership check.
+stacktest-seller: ## Seller Entitlement Service e2e: deploy throwaway stack, probe live API, teardown
+	feature-platform/seller-entitlement-service/tests/stacktest.sh \
+	    $(if $(STACK_NAME),--stack-name $(STACK_NAME)) \
+	    $(if $(REGION),--region $(REGION)) \
+	    $(if $(NO_TEARDOWN),--no-teardown)
+
 # Release-vs-release benchmark audit (alias to benchmark-release).
 stacktest-benchmark: benchmark-release ## Release benchmark audit (alias: benchmark-release)
 

--- a/feature-platform/seller-entitlement-service/README.md
+++ b/feature-platform/seller-entitlement-service/README.md
@@ -79,6 +79,35 @@ aws marketplace-discovery get-listing --listing-id prodview-XXXX --region us-eas
   --query 'associatedEntities[0].product.productId' --output text
 ```
 
+The deploy ends by reading the product registry back off the deployed Lambda and
+failing if it did not arrive intact. That check is not paranoia: a mangled registry
+produces an endpoint that deploys clean, answers every request, and refuses every
+activation as an unknown product — which this service deliberately makes
+byte-identical to "not subscribed", so neither a smoke test nor
+`tests/dynamic_activation_test.py` can tell the two apart. Registry problems have
+to be caught at deploy time or not at all.
+
+> **Pass the registry through the CLI, not `sam deploy` by hand.** SAM re-tokenizes
+> `--parameter-overrides` with its own quote-aware parser and silently truncates an
+> unquoted value at the first `"`, so a hand-rolled
+> `sam deploy --parameter-overrides ProductRegistryJson={"prod-…":…}` delivers a
+> registry of exactly `{`. The CLI compacts the JSON and single-quotes it.
+
+### Two account-level prerequisites the template handles for you
+
+Worth knowing about, because both are account-global rather than stack-local:
+
+- **API Gateway CloudWatch role.** A REST stage with access logging is rejected
+  outright unless the account-level role is set, so the stack creates
+  `AWS::ApiGateway::Account` — a per-account, per-region singleton. It is
+  `DeletionPolicy: Retain`, so deleting this stack will *not* clear the setting out
+  from under other APIs in the account; the corollary is that a teardown leaves the
+  role behind by design.
+- **`InvokeRole: NONE`.** SAM would otherwise default the `AWS_IAM` authorizer to
+  invoking the Lambda with *caller* credentials, which both conflicts with the
+  resource policy (the deployment 400s) and could never work cross-account, since
+  buyers do not hold `lambda:InvokeFunction` on your function.
+
 Then note the stack outputs:
 
 ```bash
@@ -112,14 +141,124 @@ admits any AWS principal. API Gateway verifies the caller's SigV4 signature
   buyers need no credentials from the seller. This is what makes it work for an
   arbitrary, unknown set of customers.
 
+## The endpoint URL is indirected — do not hard-code it alone
+
+`ActivationEndpoint` contains the API-Gateway-assigned REST API id
+(`https://<apiId>.execute-api.<region>.amazonaws.com/prod/activate`). If that API
+is ever replaced — a stack rebuild, a region move, an account migration — the id
+changes. Installed extensions are running in **customer** accounts you cannot
+reach to update, so a baked-in URL would be permanent in the worst way: the day
+you need to move, every paying customer breaks at once.
+
+So the endpoint is published as a small pointer object beside `latest.json`, in
+every region the extension is offered in (an extension reads from its own regional
+bucket):
+
+```bash
+idp-feature-cli seller-service publish-endpoint \
+  --feature-id idp-auto-optimizer \
+  --bucket-basename aws-ml-blog \
+  --artifact-regions us-east-1,us-west-2,eu-central-1 \
+  --prefix artifacts/genai-idp-mp
+```
+
+Writes `…/extensions/<featureId>/activation.json`:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "activationEndpoint": "https://xxxx.execute-api.us-east-1.amazonaws.com/prod/activate",
+  "signingKeyId": "arn:aws:kms:us-east-1:…:key/…",
+  "serviceVersion": "0.6.5.dev1",
+  "publishedAt": "2026-08-20T…Z"
+}
+```
+
+Re-run it after any change that replaces the API. Run it **before first publish**
+— indirection added later cannot help bundles already shipped.
+
+### Getting the values to bake in
+
+Extension authors should not copy the endpoint or the key out of a console. One
+command emits everything a release needs to embed:
+
+```bash
+idp-feature-cli seller-service export-trust-bundle --output-dir ./trust
+# -> trust/activation-trust.json, trust/activation-public-key.pem
+```
+
+```json
+{
+  "schemaVersion": "1.0",
+  "activationEndpoint": "https://xxxx.execute-api.us-east-1.amazonaws.com/prod/activate",
+  "kid": "arn:aws:kms:us-east-1:…:key/…",
+  "signingAlgorithm": "RSASSA_PSS_SHA_256",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\n…",
+  "serviceVersion": "0.6.5.dev1",
+  "exportedAt": "…"
+}
+```
+
+`kid` is the signing key **ARN** — an identifier, not the key itself. It is
+byte-identical to the token's `kid` claim, which is what lets a verifier pick the
+right embedded key when two are trusted during a rotation. Omit `--output-dir` to
+print the JSON to stdout for a release script to consume. It reads the endpoint and
+key ARN from the stack and the public key from KMS, so a stale value cannot be
+baked in by accident; it needs `kms:GetPublicKey` under the seller's own
+credentials, which the activation Lambda deliberately does not have.
+
+So the per-release order is:
+
+1. `seller-service export-trust-bundle` → embed the endpoint, `kid`, and public key.
+2. `idp-feature-cli publish` → upload the extension artifacts and `latest.json`.
+3. `seller-service publish-endpoint` → publish/refresh `activation.json`.
+
+### It carries no key material, on purpose
+
+The public verification key stays **embedded in the extension**. It is deliberately
+not in the pointer, and `publish_activation_pointer` refuses to write a document
+containing key material.
+
+The reason is the trust model. If the pointer carried the key, then whoever can
+write to the artifact bucket could substitute a hostile endpoint *and* the key that
+validates its tokens — the bucket would become a forgery trust root and the whole
+gate would be worthless. With key material excluded, a tampered pointer can only
+redirect the request somewhere that cannot produce a signature verifying against
+the embedded key, so the activation **fails closed** and the buyer-side grace
+period absorbs it. Worst case is denial of service, not free access.
+
+`signingKeyId` is a **hint only** — for choosing among keys the extension already
+embeds during a rotation (the token's `kid` claim is the other half of that). Never
+treat it as a key, and never fetch a key from it.
+
+### Why not CloudFront or a custom domain?
+
+A CloudFront distribution in front of this API does not work cleanly: the API uses
+`AWS_IAM`, SigV4 signs the `Host` header, and a client signing for the CloudFront
+domain is rejected by API Gateway because it does not own that hostname — while
+signing for the `execute-api` host puts the API id straight back into the client.
+The CloudFront domain is also itself an AWS-assigned identifier, so it relocates
+the permanence problem rather than removing it.
+
+A **custom domain** (`AWS::ApiGateway::DomainName` + `BasePathMapping`) *is* the
+better end state — fully transparent to installed clients, no client-side logic —
+but it needs a domain delegated to the seller account plus an ACM certificate. When
+one is available, add it and simply publish the domain URL in the pointer; the
+extension side never changes, which is exactly what makes the pointer the migration
+lever for that cutover.
+
 ## Buyer-side integration contract
 
 In your published extension template:
 
 1. Grant the extension's Lambda role `execute-api:Invoke` on the activation
-   endpoint (see the `RequiredBuyerPermission` output).
-2. On startup, and on a schedule shorter than `TokenTtlSeconds`, POST
-   `{"productId": "prod-…"}` to `ActivationEndpoint` with SigV4.
+   endpoint (see the `RequiredBuyerPermission` output). Grant it on the **API id
+   wildcard** rather than one literal id if you can, so a repointed endpoint does
+   not also need an IAM change in the customer's account.
+2. Resolve the endpoint from `activation.json` (above), cache it, and fall back to
+   the URL compiled into the bundle if the pointer is unreachable. Then, on startup
+   and on a schedule shorter than `TokenTtlSeconds`, POST `{"productId": "prod-…"}`
+   to it with SigV4.
 3. Verify the returned token with the embedded **public** key, and check
    `buyerAccountId` matches the account you are running in and `exp` is in the
    future.
@@ -145,8 +284,15 @@ In your published extension template:
 
 Claims: `{productId, buyerAccountId, freeTier, iat, exp}`.
 
-Failures: `403 not_entitled` (no active agreement), `404 unknown product`,
+Failures: `403 not_entitled`, `400` (malformed body), `413` (body over 4 KB),
 `401 unauthenticated` (API misconfigured — should be impossible with `AWS_IAM`).
+
+Note there is **no distinct status for an unregistered product**: "unknown
+product" returns the same `403` and the same body as "no active agreement", on
+purpose, so the endpoint is not a product-existence oracle for anyone with an AWS
+account. Do not branch on it — you will never see it. The corollary is that a
+misconfigured registry is indistinguishable from an unsubscribed customer from
+out here, which is why the registry is verified at deploy time instead.
 
 ## Who has activated? (visibility)
 

--- a/feature-platform/seller-entitlement-service/template.yaml
+++ b/feature-platform/seller-entitlement-service/template.yaml
@@ -199,12 +199,19 @@ Resources:
             Effect: Allow
             Principal:
               Service: !Sub 'logs.${AWS::Region}.${AWS::URLSuffix}'
+            # The exact actions CloudWatch Logs needs for a CMK-encrypted log
+            # group — NOT kms:Encrypt* / kms:Decrypt* / kms:Describe*. Those
+            # trailing wildcards read as equivalent but are strictly broader
+            # (kms:DescribeCustomKeyStores, future Decrypt* verbs, …), and this
+            # narrow list is the form used by the main stack's
+            # CustomerManagedEncryptionKey. Only GenerateDataKey* and ReEncrypt*
+            # are genuinely needed as wildcards.
             Action:
-              - kms:Encrypt*
-              - kms:Decrypt*
+              - kms:Encrypt
+              - kms:Decrypt
               - kms:ReEncrypt*
               - kms:GenerateDataKey*
-              - kms:Describe*
+              - kms:DescribeKey
             Resource: '*'
             # Scoped to log groups in THIS account/region, so the grant to the
             # Logs service principal cannot be used from elsewhere.
@@ -384,6 +391,32 @@ Resources:
       # Reject unsigned/unauthorized calls at the edge.
       Auth:
         DefaultAuthorizer: AWS_IAM
+        # MUST be NONE, for two independent reasons.
+        #
+        # SAM defaults InvokeRole to CALLER_CREDENTIALS whenever the authorizer is
+        # AWS_IAM, which sets the integration's Credentials to the "pass the
+        # caller's identity through and invoke the backend as them" sentinel (an
+        # iam::*:user/* wildcard ARN). That is wrong here twice over:
+        #
+        #  1. It is incompatible with a resource policy. API Gateway rejects the
+        #     deployment outright: CreateDeployment returns 400 "Caller provided
+        #     credentials not allowed when resource policy is set", so the stack
+        #     fails on AWS::ApiGateway::Deployment and rolls back. See
+        #     aws/serverless-application-model#1708 (open).
+        #  2. Even if it deployed, it could never work. Invoking as the caller
+        #     would require every BUYER account to hold lambda:InvokeFunction on
+        #     the seller's function — which no buyer has, and which we must never
+        #     grant. Activation is inherently cross-account.
+        #
+        # NONE leaves Credentials null, which means "use resource-based
+        # permissions": the AWS::Lambda::Permission that SAM generates for this
+        # method, scoped by SourceArn to this API/stage/POST /activate.
+        #
+        # This does NOT weaken authentication. DefaultAuthorizer stays AWS_IAM, so
+        # callers must still SigV4-sign and requestContext.identity.accountId is
+        # still a verified account. InvokeRole governs only how API Gateway calls
+        # the Lambda, not who may call API Gateway.
+        InvokeRole: NONE
         ResourcePolicy:
           CustomStatements:
             - Effect: Allow
@@ -405,10 +438,64 @@ Resources:
         # attempts, including refusals.
         Format: '{"requestId":"$context.requestId","callerAccount":"$context.identity.accountId","status":"$context.status","path":"$context.path","time":"$context.requestTime"}'
 
+  # REST API stages (unlike HTTP APIs) reject AccessLogSetting unless the
+  # account-level API Gateway CloudWatch role is set ("CloudWatch Logs role ARN
+  # must be set in account settings to enable logging"). A fresh seller account
+  # has never had it set, so without these two resources this template fails on
+  # first deploy into exactly the account it is meant for. Same fix, and same
+  # reasoning, as nested/api-resolvers/template.yaml.
+  #
+  # AWS::ApiGateway::Account is a PER-ACCOUNT PER-REGION singleton: multiple
+  # stacks that declare it overwrite each other (last writer wins), which is
+  # harmless because every writer grants the same managed policy. Retain on
+  # delete so tearing down this stack does not clear the account setting out from
+  # under other APIs in the seller's account (the role is retained for the same
+  # reason) — note this means a teardown leaves the role behind by design.
+  ApiGatewayCloudWatchRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      PermissionsBoundary:
+        !If [HasPermissionsBoundary, !Ref PermissionsBoundaryArn, !Ref 'AWS::NoValue']
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub 'apigateway.${AWS::URLSuffix}'
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'
+
+  ApiGatewayAccount:
+    Type: AWS::ApiGateway::Account
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      CloudWatchRoleArn: !GetAtt ApiGatewayCloudWatchRole.Arn
+
+  # DependsOn is what orders the account setting before the stage: the stage
+  # reaches this log group by !GetAtt, so account -> log group -> stage.
   ActivationApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
+    DependsOn: ApiGatewayAccount
     Properties:
       LogGroupName: !Sub '/aws/apigateway/${AWS::StackName}-activation'
+      RetentionInDays: !Ref LogRetentionInDays
+      KmsKeyId: !GetAtt LogEncryptionKey.Arn
+
+  # Execution logs (MethodSettings LoggingLevel above) go to a log group whose
+  # name API Gateway hardcodes: API-Gateway-Execution-Logs_<restApiId>/<stageName>.
+  # Pre-declaring it is the only way to get retention + CMK encryption on it —
+  # otherwise API Gateway auto-creates it with no retention and no KMS key, which
+  # would leave buyer account ids sitting in a plaintext log group forever, and
+  # contradict this service's own CMK-everywhere posture.
+  ActivationApiExecutionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: ApiGatewayAccount
+    Properties:
+      LogGroupName: !Sub 'API-Gateway-Execution-Logs_${ActivationApi}/prod'
       RetentionInDays: !Ref LogRetentionInDays
       KmsKeyId: !GetAtt LogEncryptionKey.Arn
 
@@ -447,9 +534,12 @@ Outputs:
 
   TokenPublicKeyCommand:
     Description: >-
-      Run this to fetch the PUBLIC key your extension uses to verify activation
-      tokens. Safe to embed in the published (public-read) extension artifacts —
-      it can verify tokens but not mint them.
+      Raw fetch of the PUBLIC key your extension uses to verify activation tokens.
+      Safe to embed in the published (public-read) extension artifacts — it can
+      verify tokens but not mint them. Prefer
+      `idp-feature-cli seller-service export-trust-bundle`, which returns this key
+      as PEM alongside the endpoint and the matching `kid`; this output is the
+      no-CLI fallback and returns base64 DER.
     Value: !Sub 'aws kms get-public-key --key-id ${TokenSigningKey.Arn} --region ${AWS::Region} --query PublicKey --output text'
 
   TokenSigningKeyArn:

--- a/feature-platform/seller-entitlement-service/tests/dynamic_activation_test.py
+++ b/feature-platform/seller-entitlement-service/tests/dynamic_activation_test.py
@@ -30,6 +30,23 @@ What it checks
                                                 the calling account, carries `kid`,
                                                 and expires in the future
 
+What it CANNOT check
+--------------------
+Whether the service is actually configured to serve your product. Check (3) is the
+reason: "unknown product" is deliberately byte-identical to "not entitled", so a
+service whose product registry is empty or mangled passes every check here
+perfectly while refusing every paying customer. That happened for real — SAM
+truncated the registry parameter to `{` — and this suite reported all-green
+against a completely non-functional endpoint.
+
+The registry is therefore verified where it can be seen rather than inferred:
+`idp-feature-cli seller-service deploy` reads it back off the deployed function
+and fails the deploy if it did not survive (`verify_deployed_registry`). A useful
+second signal is the roster — a *known* product that is merely unsubscribed gets
+recorded with reason "no active agreement", whereas an unknown product is refused
+before anything is written, so `seller-service activations` staying empty after a
+real attempt means the product is not registered.
+
 Usage:
     # (2)-(5) with credentials for an UNSUBSCRIBED account:
     python dynamic_activation_test.py \\

--- a/feature-platform/seller-entitlement-service/tests/stacktest.sh
+++ b/feature-platform/seller-entitlement-service/tests/stacktest.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# End-to-end stack-test for the Seller Entitlement Service: deploy a throwaway
+# stack, prove the deployed API actually behaves, tear it down.
+#
+# Why this exists
+# ---------------
+# The static suite (`tests/test_template_security.py`) asserts what the template
+# *says*. It cannot assert that the template *deploys* — and that is where this
+# service has actually broken. Two real defects were both deploy-time failures
+# that every offline test passed straight through:
+#
+#   1. SAM defaults InvokeRole to CALLER_CREDENTIALS under an AWS_IAM authorizer,
+#      which API Gateway refuses to deploy alongside a resource policy
+#      ("Caller provided credentials not allowed when resource policy is set").
+#   2. A REST stage with access logging is rejected unless the account-level
+#      API Gateway CloudWatch role exists — which it does not in a fresh seller
+#      account, i.e. exactly the account this service is meant for.
+#
+# Both would have been caught by one deploy. Hence this.
+#
+# No real Marketplace product is required
+# ---------------------------------------
+# Every assertion here is a *refusal*, and a refusal looks the same whether the
+# product exists or not (that is deliberate — see the no-oracle design). So the
+# test registers a synthetic `prod-…` id and passes --skip-ownership-check. That
+# means this runs in any account with the necessary permissions, not only in a
+# real seller account with a real listing.
+#
+# What it does NOT cover: the positive path. Issuing a verifiable token needs a
+# genuinely subscribed buyer account, which cannot be created on demand. Run
+# `dynamic_activation_test.py --entitled-profile …` by hand for that.
+#
+# Usage:
+#   tests/stacktest.sh [--stack-name idp-seller-entitlement-citest]
+#                      [--region us-east-1] [--no-teardown]
+
+set -uo pipefail
+
+STACK_NAME="idp-seller-entitlement-citest"
+REGION="us-east-1"
+NO_TEARDOWN=0
+# Synthetic, and deliberately not a real product id: the point is to exercise the
+# refusal paths, and a real id would make the run depend on live subscription
+# state.
+SYNTHETIC_PRODUCT="prod-citestsynthetic"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack-name) STACK_NAME="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --no-teardown) NO_TEARDOWN=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+info() { echo -e "${CYAN}→${NC} $*"; }
+warn() { echo -e "${YELLOW}!${NC} $*"; }
+die()  { echo -e "${RED}✗ $*${NC}" >&2; exit 1; }
+
+# teardown_test_stack.sh refuses names that don't look disposable, so fail early
+# and clearly rather than after a deploy we then cannot clean up.
+case "$STACK_NAME" in
+  *test*|*citest*|*ci-*|*-tmp|*scratch*) ;;
+  *) die "--stack-name '$STACK_NAME' does not look disposable. This test DELETES
+  the stack it deploys; use a name containing 'test', 'citest', 'ci-', '-tmp' or
+  'scratch' so the teardown script will accept it." ;;
+esac
+
+command -v sam >/dev/null 2>&1 || die "the AWS SAM CLI is required"
+ACCOUNT="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)" \
+  || die "could not resolve AWS credentials"
+
+# Resolve an interpreter that actually has boto3 (the dynamic probe signs its own
+# requests with botocore). A bare `python3` is often the system one, which does
+# not — so prefer an active virtualenv, then fall back.
+PYTHON="${PYTHON:-}"
+if [[ -z "$PYTHON" ]]; then
+  for candidate in "${VIRTUAL_ENV:-}/bin/python" python3 python; do
+    [[ -n "$candidate" ]] || continue
+    if command -v "$candidate" >/dev/null 2>&1 && \
+       "$candidate" -c 'import boto3' >/dev/null 2>&1; then
+      PYTHON="$candidate"; break
+    fi
+  done
+fi
+[[ -n "$PYTHON" ]] || die "no Python with boto3 found. Activate your virtualenv, or
+  set PYTHON=/path/to/python. (\`make setup\` / \`make setup-venv\` installs it.)"
+
+CLI=(idp-feature-cli)
+command -v idp-feature-cli >/dev/null 2>&1 || CLI=("$PYTHON" -m idp_feature_sdk.cli)
+
+echo "Account: $ACCOUNT"
+echo "Region:  $REGION"
+echo "Stack:   $STACK_NAME  (will be deleted)"
+echo
+
+teardown() {
+  if [[ $NO_TEARDOWN -eq 1 ]]; then
+    warn "--no-teardown: leaving $STACK_NAME up. Clean up with:
+  tests/teardown_test_stack.sh --stack-name $STACK_NAME --region $REGION --yes"
+    return
+  fi
+  echo
+  info "tearing down $STACK_NAME (including retained key + table)"
+  "$HERE/teardown_test_stack.sh" --stack-name "$STACK_NAME" --region "$REGION" --yes \
+    || warn "teardown reported a problem — check for leftover resources"
+}
+trap teardown EXIT
+
+REGISTRY="{\"$SYNTHETIC_PRODUCT\":{\"productCode\":\"citest\",\"allowFreeTier\":false}}"
+
+# The deploy itself is assertion #1: it fails on either of the two defects above.
+# It also reads the registry back off the deployed function and fails if it did
+# not survive SAM's parameter-override parsing, which is assertion #2.
+info "deploying (this is the regression test for the deploy-time defects)"
+"${CLI[@]}" seller-service deploy \
+  --product-registry "$REGISTRY" \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --skip-ownership-check \
+  --yes || die "deploy failed — see the error above"
+ok "deployed, and the product registry survived deployment"
+
+ENDPOINT="$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='ActivationEndpoint'].OutputValue" \
+  --output text 2>/dev/null)"
+[[ -n "$ENDPOINT" && "$ENDPOINT" != "None" ]] || die "no ActivationEndpoint output"
+info "endpoint: $ENDPOINT"
+
+# Assertion #3: the live stage really enforces SigV4, refuses cleanly, and never
+# 5xxes on hostile input.
+info "running the live security probe"
+"$PYTHON" "$HERE/dynamic_activation_test.py" \
+  --endpoint "$ENDPOINT" --product-id "$SYNTHETIC_PRODUCT" \
+  || die "live security probe failed"
+
+echo
+ok "seller-service stack-test passed"

--- a/feature-platform/seller-entitlement-service/tests/test_payload_robustness.py
+++ b/feature-platform/seller-entitlement-service/tests/test_payload_robustness.py
@@ -142,9 +142,15 @@ _HOSTILE_IDS = {
     "jinja template": "{{ 7*7 }}",
     "xss": "<script>alert(1)</script>",
     "xxe": '<!DOCTYPE x [<!ENTITY e SYSTEM "file:///etc/passwd">]>',
-    "unicode rtl override": "prod-‮gnimda",
-    "zero width": "prod-​paid",
-    "homoglyph": "prod-раid",  # Cyrillic а/р
+    # The invisible/confusable payloads are written as escapes rather than literal
+    # characters. The runtime string is byte-identical, but the source stays
+    # readable and honest: a literal U+202E makes the file *display* differently
+    # from how it executes ("Trojan Source"), which is a hazard for whoever reviews
+    # this corpus next and is flagged as HIGH by Bandit B613. Escaping is the fix,
+    # not a suppression.
+    "unicode rtl override": "prod-\u202egnimda",  # RIGHT-TO-LEFT OVERRIDE
+    "zero width": "prod-\u200bpaid",  # ZERO WIDTH SPACE
+    "homoglyph": "prod-\u0440\u0430id",  # Cyrillic er/a, confusable with p/a
     # Long, but under the 4 KB body cap — otherwise this exercises the size
     # guard (413) instead of the productId path it is meant to test.
     "long": "prod-" + "a" * 2000,

--- a/feature-platform/seller-entitlement-service/tests/test_template_security.py
+++ b/feature-platform/seller-entitlement-service/tests/test_template_security.py
@@ -90,6 +90,29 @@ def test_no_method_disables_authorization(template):
         assert needle not in raw, f"found {needle!r} — that makes the API anonymous"
 
 
+def test_api_does_not_invoke_the_backend_with_caller_credentials(resources):
+    """`InvokeRole: NONE` is load-bearing, in two ways.
+
+    SAM defaults `InvokeRole` to `CALLER_CREDENTIALS` whenever the authorizer is
+    `AWS_IAM`, setting the integration credentials to `arn:aws:iam::*:user/*`.
+    That combination is (a) rejected by API Gateway at deploy time when a resource
+    policy is also set — `CreateDeployment` 400s with "Caller provided credentials
+    not allowed when resource policy is set", rolling the whole stack back — and
+    (b) unworkable regardless, because invoking as the caller would require every
+    buyer account to hold `lambda:InvokeFunction` on the seller's function.
+
+    Both failures are silent in review and neither is visible to a handler unit
+    test, so assert the property directly. See
+    aws/serverless-application-model#1708.
+    """
+    auth = resources["ActivationApi"]["Properties"]["Auth"]
+    assert auth.get("InvokeRole") == "NONE", (
+        "InvokeRole must be NONE. Omitting it makes SAM pass caller credentials to "
+        "the integration, which fails the deployment (resource policy conflict) and "
+        "would require buyers to hold lambda:InvokeFunction on the seller's function"
+    )
+
+
 def test_resource_policy_is_scoped_to_the_activate_method_only(resources):
     """`Principal: '*'` is intended (any AWS account may *attempt* activation),
     but the Resource must pin it to POST /activate. A wildcard resource would
@@ -285,7 +308,13 @@ def test_log_groups_are_cmk_encrypted(resources):
     """These logs carry buyer AWS account ids and caller role ARNs — customer-
     identifying data for a seller — and CMK-encrypted log groups are the repo
     standard (115 of 135 elsewhere)."""
-    for name in ("ActivateFunctionLogGroup", "ActivationApiAccessLogGroup"):
+    for name in (
+        "ActivateFunctionLogGroup",
+        "ActivationApiAccessLogGroup",
+        # Pre-declared precisely so it is encrypted and expires; API Gateway would
+        # otherwise auto-create it in plaintext with no retention.
+        "ActivationApiExecutionLogGroup",
+    ):
         props = resources[name]["Properties"]
         assert "KmsKeyId" in props, f"{name} is not KMS-encrypted"
         assert "LogEncryptionKey" in str(props["KmsKeyId"])
@@ -308,6 +337,58 @@ def test_log_key_grants_cloudwatch_logs_narrowly(resources):
         assert "kms:EncryptionContext:aws:logs:arn" in str(condition), (
             "grant is not scoped by log-group encryption context"
         )
+
+
+def test_account_cloudwatch_role_is_present_and_retained(resources):
+    """Without the account-level API Gateway CloudWatch role, a REST stage with
+    AccessLogSetting is rejected outright — "CloudWatch Logs role ARN must be set
+    in account settings" — so a fresh seller account cannot deploy this template
+    at all. It must also be Retain: AWS::ApiGateway::Account is an account/region
+    singleton, and deleting this stack would otherwise clear the setting out from
+    under any other API in the seller's account."""
+    account = resources["ApiGatewayAccount"]
+    assert account["Type"] == "AWS::ApiGateway::Account"
+    assert account["DeletionPolicy"] == "Retain", (
+        "deleting this stack would disable access logging for every other API "
+        "Gateway API in the seller's account"
+    )
+    role = resources["ApiGatewayCloudWatchRole"]
+    assert role["DeletionPolicy"] == "Retain"
+    assert "PermissionsBoundary" in role["Properties"]
+    assert "AmazonAPIGatewayPushToCloudWatchLogs" in str(
+        role["Properties"]["ManagedPolicyArns"]
+    )
+
+
+def test_kms_key_policies_use_no_overly_broad_wildcard_actions(resources):
+    """Trailing-wildcard KMS actions grant more than they appear to.
+
+    `kms:Decrypt*` / `kms:Encrypt*` / `kms:Describe*` read as if they mean the one
+    obvious verb, but they also match every current and FUTURE action with that
+    prefix — `kms:DescribeCustomKeyStores`, for instance. Only `GenerateDataKey*`
+    and `ReEncrypt*` need to be wildcards (they have real variant forms that
+    CloudWatch Logs uses).
+
+    A sole `kms:*` for the account root is exempt: AWS explicitly warns against
+    key policies that do not grant root full access, because it can permanently
+    orphan the key.
+    """
+    allowed_wildcards = {"kms:GenerateDataKey*", "kms:ReEncrypt*", "kms:GenerateDataKeyPair*"}
+    for name in ("TokenSigningKey", "LogEncryptionKey"):
+        for stmt in resources[name]["Properties"]["KeyPolicy"]["Statement"]:
+            if stmt.get("Effect") != "Allow":
+                continue
+            actions = _actions(stmt)
+            principal = stmt.get("Principal") or {}
+            is_root = "root" in str(principal.get("AWS", ""))
+            if is_root and actions == ["kms:*"]:
+                continue
+            for action in actions:
+                assert "*" not in action or action in allowed_wildcards, (
+                    f"{name} statement {stmt.get('Sid')!r} grants {action!r} — a "
+                    "trailing wildcard that is broader than intended; name the "
+                    "exact action instead"
+                )
 
 
 def test_log_key_is_separate_from_the_signing_key(resources):

--- a/lib/idp_feature_sdk/idp_feature_sdk/cli.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/cli.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from importlib.resources import files
 from pathlib import Path
@@ -19,14 +20,20 @@ from .scaffold import ScaffoldError, ScaffoldOptions, scaffold_feature
 from .seller_service import (
     DEFAULT_MARKETPLACE_REGION,
     SellerServiceError,
+    build_activation_pointer,
     build_sam_deploy_command,
+    build_trust_bundle,
     fetch_activations,
+    fetch_signing_public_key,
     find_seller_service_dir,
     parse_product_registry,
     preflight,
+    publish_activation_pointer,
     read_service_version,
     resolve_stack_output,
     run_command,
+    utc_now_iso,
+    verify_deployed_registry,
 )
 
 console = Console()
@@ -1302,6 +1309,21 @@ def seller_service_deploy_cmd(
             ),
             cwd=service_dir,
         )
+
+        # Verify the registry actually reached the function. A mangled registry
+        # produces an endpoint that looks healthy and refuses every customer.
+        import boto3
+
+        deployed = verify_deployed_registry(
+            cfn_client=boto3.client("cloudformation", region_name=region),
+            lambda_client=boto3.client("lambda", region_name=region),
+            stack_name=stack_name,
+            expected_product_ids=result.product_ids,
+        )
+        console.print(
+            f"[green]✓[/green] Deployed registry serves "
+            f"{len(deployed)} product(s): {', '.join(sorted(deployed))}"
+        )
     except SellerServiceError as exc:
         console.print(f"[red]✗ {exc}[/red]")
         sys.exit(1)
@@ -1319,6 +1341,193 @@ def seller_service_deploy_cmd(
     console.print(
         "    # feature-platform/seller-entitlement-service/README.md "
         "'Buyer-side integration contract'"
+    )
+
+
+@seller_service_group.command("export-trust-bundle")
+@_mp_region_option
+@click.option(
+    "--stack-name",
+    default="idp-seller-entitlement",
+    show_default=True,
+    help="Seller-service stack to export from.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Write activation-trust.json + activation-public-key.pem here. Omit to "
+    "print the JSON to stdout.",
+)
+def seller_service_export_trust_bundle_cmd(
+    region: str,
+    stack_name: str,
+    output_dir: Optional[Path],
+) -> None:
+    """Export the material an extension bakes in at build time.
+
+    Emits the activation endpoint, the `kid` (the signing key ARN — byte-identical
+    to the token's `kid` claim), the signing algorithm, and the **public**
+    verification key as PEM.
+
+    Run this once per extension release and embed the result. The public key is
+    safe to ship in public artifacts: it verifies tokens, it cannot mint them. It
+    belongs embedded rather than fetched at runtime — a key fetched from the
+    artifact bucket would make that bucket a forgery trust root, which is exactly
+    why `activation.json` carries the endpoint and nothing else.
+    """
+    try:
+        import boto3
+
+        cfn = boto3.client("cloudformation", region_name=region)
+        endpoint = resolve_stack_output(cfn, stack_name, "ActivationEndpoint")
+        key_arn = resolve_stack_output(cfn, stack_name, "TokenSigningKeyArn")
+        try:
+            service_version = resolve_stack_output(cfn, stack_name, "ServiceVersion")
+        except SellerServiceError:
+            service_version = ""
+
+        der = fetch_signing_public_key(boto3.client("kms", region_name=region), key_arn)
+        bundle = build_trust_bundle(
+            activation_endpoint=endpoint,
+            kid=key_arn,
+            public_key_der=der,
+            service_version=service_version,
+            exported_at=utc_now_iso(),
+        )
+    except SellerServiceError as exc:
+        console.print(f"[red]✗ {exc}[/red]")
+        sys.exit(1)
+
+    if output_dir is None:
+        # Plain print, not console.print: this is machine-readable output that a
+        # release script will pipe, so it must not pick up Rich markup or wrapping.
+        print(json.dumps(bundle, indent=2, sort_keys=True))
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = output_dir / "activation-trust.json"
+    pem_path = output_dir / "activation-public-key.pem"
+    bundle_path.write_text(
+        json.dumps(bundle, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    pem_path.write_text(bundle["publicKeyPem"], encoding="utf-8")
+    console.print(f"[green]✓[/green] {bundle_path}")
+    console.print(f"[green]✓[/green] {pem_path}")
+    console.print(f"  endpoint {bundle['activationEndpoint']}")
+    console.print(f"  kid      {bundle['kid']}")
+    console.print(f"  alg      {bundle['signingAlgorithm']}")
+
+
+@seller_service_group.command("publish-endpoint")
+@_mp_region_option
+@click.option(
+    "--stack-name",
+    default="idp-seller-entitlement",
+    show_default=True,
+    help="Seller-service stack to read the ActivationEndpoint from.",
+)
+@click.option(
+    "--feature-id",
+    "feature_ids",
+    multiple=True,
+    required=True,
+    help="Extension featureId to publish the pointer for. Repeatable — pass every "
+    "extension served by this endpoint.",
+)
+@click.option(
+    "--bucket-basename",
+    required=True,
+    help="Artifact bucket basename; the region is appended, matching "
+    "`idp-feature-cli publish` (e.g. 'aws-ml-blog' -> 'aws-ml-blog-us-east-1').",
+)
+@click.option(
+    "--artifact-regions",
+    required=True,
+    help="Comma-separated regions to publish into — EVERY region the extension is "
+    "offered in, since an extension reads the pointer from its own regional bucket.",
+)
+@click.option(
+    "--prefix",
+    "s3_prefix",
+    default="",
+    help="S3 key prefix under the bucket, matching the catalog's templateKey "
+    "(e.g. 'artifacts/genai-idp-mp').",
+)
+@click.option(
+    "--private",
+    is_flag=True,
+    help="Do NOT set public-read. The pointer is read by extensions in arbitrary "
+    "buyer accounts, so it normally must be public — like the template beside it.",
+)
+def seller_service_publish_endpoint_cmd(
+    region: str,
+    stack_name: str,
+    feature_ids: tuple,
+    bucket_basename: str,
+    artifact_regions: str,
+    s3_prefix: str,
+    private: bool,
+) -> None:
+    """Publish the activation endpoint as a pointer file next to latest.json.
+
+    This is the indirection layer for the endpoint URL. The URL embeds an
+    API-Gateway-assigned API id, so replacing the API would otherwise
+    permanently break every already-installed extension — those run in customer
+    accounts the seller cannot reach. Extensions read this pointer instead.
+
+    Carries no key material by design: the public verification key stays embedded
+    in the extension, so a tampered pointer can only cause a fail-closed
+    activation, never a forged entitlement.
+    """
+    try:
+        import boto3
+
+        cfn = boto3.client("cloudformation", region_name=region)
+        endpoint = resolve_stack_output(cfn, stack_name, "ActivationEndpoint")
+        try:
+            key_id = resolve_stack_output(cfn, stack_name, "TokenSigningKeyArn")
+        except SellerServiceError:
+            key_id = ""
+        try:
+            service_version = resolve_stack_output(cfn, stack_name, "ServiceVersion")
+        except SellerServiceError:
+            service_version = ""
+
+        document = build_activation_pointer(
+            activation_endpoint=endpoint,
+            signing_key_id=key_id,
+            service_version=service_version,
+            published_at=utc_now_iso(),
+        )
+
+        targets = [r.strip() for r in artifact_regions.split(",") if r.strip()]
+        if not targets:
+            raise SellerServiceError("--artifact-regions listed no regions")
+
+        console.print(f"  endpoint: {endpoint}")
+        console.print(f"  features: {', '.join(feature_ids)}")
+        console.print()
+        for artifact_region in targets:
+            bucket = f"{bucket_basename}-{artifact_region}"
+            written = publish_activation_pointer(
+                s3_client=boto3.client("s3", region_name=artifact_region),
+                bucket=bucket,
+                feature_ids=list(feature_ids),
+                document=document,
+                s3_prefix=s3_prefix,
+                make_public=not private,
+            )
+            for key in written:
+                console.print(f"[green]✓[/green] s3://{bucket}/{key}")
+    except SellerServiceError as exc:
+        console.print(f"[red]✗ {exc}[/red]")
+        sys.exit(1)
+
+    console.print()
+    console.print(
+        "[green]✓ Activation pointer published.[/green] Extensions should read it "
+        "at activation time and fall back to their embedded default if unreachable."
     )
 
 

--- a/lib/idp_feature_sdk/idp_feature_sdk/seller_service.py
+++ b/lib/idp_feature_sdk/idp_feature_sdk/seller_service.py
@@ -210,6 +210,32 @@ def preflight(
     return result
 
 
+def _sam_override(key: str, value: str) -> str:
+    """One ``Key=Value`` element for ``sam deploy --parameter-overrides``.
+
+    SAM does **not** take each argv element literally. It re-tokenizes the string
+    with its own quote-aware parser, and an *unquoted* value is truncated at the
+    first double quote. Passing raw JSON therefore delivered a product registry of
+    exactly ``{`` — and nothing surfaced it: the endpoint deployed clean, every
+    activation was refused as "unknown product", and the service deliberately makes
+    "unknown product" byte-identical to "not entitled" so as not to leak an
+    existence oracle. A fully non-functional deployment looked perfectly healthy,
+    including to the live security test.
+
+    Wrapping in single quotes makes SAM take the value verbatim (verified against
+    SAM CLI 1.142.1 by reading back the parsed overrides). The equally-effective
+    alternative — escaping every inner ``"`` — is not used because it corrupts any
+    value that legitimately contains an escaped quote.
+    """
+    if "'" in value:
+        raise SellerServiceError(
+            f"{key} contains a single quote, which cannot be passed through "
+            "`sam deploy --parameter-overrides` safely. Remove it.\n"
+            f"  value: {value}"
+        )
+    return f"{key}='{value}'"
+
+
 def build_sam_deploy_command(
     *,
     service_dir: Path,
@@ -222,12 +248,26 @@ def build_sam_deploy_command(
     extra_args: Optional[list[str]] = None,
 ) -> list[str]:
     """The `sam deploy` argv. Separated out so tests can assert it without AWS."""
-    overrides = [f"ProductRegistryJson={product_registry_json}"]
+    # Compact the registry before quoting it. Two reasons: SAM's override parser
+    # splits on whitespace, so a pretty-printed / multi-line JSON blob (an obvious
+    # thing for an operator to paste when registering a second product) would be
+    # shredded; and canonicalising here means the deployed value is byte-comparable
+    # with what we read back after deploy.
+    try:
+        compact_registry = json.dumps(
+            json.loads(product_registry_json), separators=(",", ":"), sort_keys=True
+        )
+    except ValueError as exc:
+        raise SellerServiceError(
+            f"--product-registry is not valid JSON: {exc}"
+        ) from exc
+
+    overrides = [_sam_override("ProductRegistryJson", compact_registry)]
     if allowed_accounts:
-        overrides.append(f"AllowedAccounts={allowed_accounts}")
+        overrides.append(_sam_override("AllowedAccounts", allowed_accounts))
     if token_ttl_seconds is not None:
-        overrides.append(f"TokenTtlSeconds={token_ttl_seconds}")
-    overrides.append(f"MarketplaceAgreementRegion={region}")
+        overrides.append(_sam_override("TokenTtlSeconds", str(token_ttl_seconds)))
+    overrides.append(_sam_override("MarketplaceAgreementRegion", region))
 
     cmd = [
         "sam",
@@ -271,6 +311,285 @@ def run_command(cmd: list[str], cwd: Optional[Path] = None) -> None:
         raise SellerServiceError(
             f"`{' '.join(cmd[:2])}` failed with exit code {exc.returncode}."
         ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Activation endpoint pointer (indirection)
+# ---------------------------------------------------------------------------
+#
+# The activation endpoint URL contains the API Gateway REST API id, which AWS
+# assigns. If the API is ever replaced — a stack rebuild, a region move, an
+# account migration — the id changes, and every already-installed copy of the
+# extension is running in a CUSTOMER's account where the seller cannot reach it to
+# update a baked-in URL. That makes the URL permanent in the worst way.
+#
+# So the endpoint is published as a small pointer object next to `latest.json`,
+# and the extension reads it at activation time rather than trusting only what was
+# compiled in. Same pattern, and the same regional layout, as `latest.json`.
+#
+# SECURITY: the pointer carries NO key material, deliberately.
+# --------------------------------------------------------
+# The public verification key stays embedded in the published extension. If the
+# pointer file also carried the key, then whoever can write to the artifact bucket
+# could substitute both a hostile endpoint AND the key that validates its tokens —
+# making the bucket a forgery trust root and the entitlement gate worthless.
+#
+# With key material excluded, a tampered pointer can only redirect the request to
+# somewhere that cannot produce a signature verifying against the embedded key. The
+# activation then fails closed, and the buyer-side grace period on the
+# last-known-good token absorbs it. Worst case is denial of service, not free access.
+#
+# `signingKeyId` is therefore a HINT ONLY — for choosing among keys the extension
+# already embeds during a rotation. It must never be treated as a key, or fetched
+# from.
+
+ACTIVATION_POINTER_FILENAME = "activation.json"
+ACTIVATION_POINTER_SCHEMA_VERSION = "1.0"
+
+
+def utc_now_iso() -> str:
+    """Same format publisher._now_iso() writes into latest.json, so the two
+    pointer objects are comparable by eye."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def activation_pointer_key(feature_id: str, s3_prefix: str = "") -> str:
+    """S3 key for a feature's activation pointer, mirroring `latest.json`'s layout.
+
+    Version-free and at the extension base, because it is a pointer: readers must
+    resolve the *current* endpoint, not one pinned to a release.
+    """
+    base = f"extensions/{feature_id}/{ACTIVATION_POINTER_FILENAME}"
+    prefix = s3_prefix.strip("/")
+    return f"{prefix}/{base}" if prefix else base
+
+
+def build_activation_pointer(
+    *,
+    activation_endpoint: str,
+    signing_key_id: str = "",
+    service_version: str = "",
+    published_at: str = "",
+) -> dict:
+    """The pointer document. Pure, so its shape is a tested contract."""
+    if not activation_endpoint.startswith("https://"):
+        raise SellerServiceError(
+            "activation endpoint must be an https URL, got: "
+            f"{activation_endpoint!r}. Extensions send SigV4-signed credentials "
+            "to it; plaintext http would expose them."
+        )
+    document = {
+        "schemaVersion": ACTIVATION_POINTER_SCHEMA_VERSION,
+        "activationEndpoint": activation_endpoint,
+    }
+    # Hint only — never key material. See the note above.
+    if signing_key_id:
+        document["signingKeyId"] = signing_key_id
+    if service_version:
+        document["serviceVersion"] = service_version
+    if published_at:
+        document["publishedAt"] = published_at
+    return document
+
+
+def publish_activation_pointer(
+    *,
+    s3_client: Any,
+    bucket: str,
+    feature_ids: list[str],
+    document: dict,
+    s3_prefix: str = "",
+    make_public: bool = True,
+) -> list[str]:
+    """Write the pointer for each feature into one regional bucket.
+
+    Returns the keys written. Public-read by default: the reader is an extension
+    running in an arbitrary buyer account, exactly like the template and
+    `latest.json` it sits beside.
+    """
+    if "publicKey" in document or "publicKeyPem" in document or "key" in document:
+        raise SellerServiceError(
+            "refusing to publish key material in the activation pointer — that "
+            "would make the artifact bucket a forgery trust root. The public "
+            "verification key belongs embedded in the extension."
+        )
+    body = json.dumps(document, indent=2, sort_keys=True).encode("utf-8")
+    extra: dict[str, Any] = {"ContentType": "application/json"}
+    if make_public:
+        extra["ACL"] = "public-read"
+
+    written = []
+    for feature_id in feature_ids:
+        key = activation_pointer_key(feature_id, s3_prefix)
+        try:
+            s3_client.put_object(Bucket=bucket, Key=key, Body=body, **extra)
+        except Exception as exc:  # noqa: BLE001
+            raise SellerServiceError(
+                f"could not write s3://{bucket}/{key}: {exc}"
+            ) from exc
+        written.append(key)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Build-time trust material
+# ---------------------------------------------------------------------------
+#
+# What an extension author needs, once per release, to bake into the bundle:
+#
+#   * the public verification key — EMBEDDED, so tokens are verified against
+#     something an attacker cannot swap;
+#   * `kid` — the value the service actually puts in the token's `kid` claim, so
+#     the verifier can map a claim to one of the keys it embeds during a rotation;
+#   * the activation endpoint — as the compiled-in fallback for when the runtime
+#     pointer (`activation.json`) is unreachable.
+#
+# Note the deliberate asymmetry with the pointer file: the public key belongs
+# HERE, in build-time material that ends up inside the published bundle, and NOT
+# in the runtime pointer. Runtime-fetched key material would make the artifact
+# bucket a forgery trust root; build-time embedded key material is exactly what
+# stops it being one.
+
+TRUST_BUNDLE_SCHEMA_VERSION = "1.0"
+# nosec B105 - "RSASSA_PSS_SHA_256" is a KMS signing-algorithm NAME, not a
+# credential. Bandit's hardcoded-password heuristic fires only because the
+# identifier contains the substring "TOKEN". Nothing secret is expressible here:
+# the value is echoed to buyers in every activation response, and the signing key
+# never leaves KMS.
+TOKEN_SIGNING_ALGORITHM = "RSASSA_PSS_SHA_256"  # nosec B105
+
+
+def der_to_pem(der: bytes, label: str = "PUBLIC KEY") -> str:
+    """Wrap DER bytes as PEM. KMS returns SubjectPublicKeyInfo DER; most verifier
+    libraries want PEM, and doing the conversion here keeps a base64/openssl
+    incantation out of every extension's release process."""
+    import base64 as _b64
+    import textwrap
+
+    body = _b64.b64encode(der).decode("ascii")
+    lines = textwrap.wrap(body, 64)
+    return (
+        f"-----BEGIN {label}-----\n" + "\n".join(lines) + f"\n-----END {label}-----\n"
+    )
+
+
+def fetch_signing_public_key(kms_client: Any, key_arn: str) -> bytes:
+    """The SubjectPublicKeyInfo DER for the token signing key.
+
+    Verifies the key is actually a signing key: exporting an ENCRYPT_DECRYPT key's
+    public half here would produce a bundle that silently fails every
+    verification.
+    """
+    try:
+        resp = kms_client.get_public_key(KeyId=key_arn)
+    except Exception as exc:  # noqa: BLE001
+        raise SellerServiceError(
+            f"Could not fetch the public key for {key_arn}: {exc}\n"
+            "The caller needs kms:GetPublicKey on the signing key. Note the "
+            "activation Lambda deliberately does NOT hold that permission — run "
+            "this with your own seller credentials."
+        ) from exc
+
+    usage = str(resp.get("KeyUsage", ""))
+    if usage != "SIGN_VERIFY":
+        raise SellerServiceError(
+            f"{key_arn} has KeyUsage {usage!r}, not SIGN_VERIFY. That is not the "
+            "token signing key — a bundle built from it would fail every "
+            "verification."
+        )
+    der = resp.get("PublicKey")
+    if not der:
+        raise SellerServiceError(f"KMS returned no public key for {key_arn}")
+    return bytes(der)
+
+
+def build_trust_bundle(
+    *,
+    activation_endpoint: str,
+    kid: str,
+    public_key_der: bytes,
+    service_version: str = "",
+    exported_at: str = "",
+) -> dict:
+    """Build-time trust material for one seller service. Pure, so its shape is a
+    tested contract that the extension build can rely on."""
+    if not kid:
+        raise SellerServiceError(
+            "kid is empty. It must be the signing key ARN, byte-identical to the "
+            "`kid` claim the service puts in its tokens, or a verifier cannot map "
+            "a token to the key that signed it."
+        )
+    return {
+        "schemaVersion": TRUST_BUNDLE_SCHEMA_VERSION,
+        "activationEndpoint": activation_endpoint,
+        # Byte-identical to the token's `kid` claim (the Lambda uses the key ARN).
+        "kid": kid,
+        "signingAlgorithm": TOKEN_SIGNING_ALGORITHM,
+        "publicKeyPem": der_to_pem(public_key_der),
+        "serviceVersion": service_version,
+        "exportedAt": exported_at,
+    }
+
+
+def verify_deployed_registry(
+    *,
+    cfn_client: Any,
+    lambda_client: Any,
+    stack_name: str,
+    expected_product_ids: list[str],
+) -> dict:
+    """Read the registry back off the DEPLOYED function and confirm it survived.
+
+    This exists because a mangled registry is invisible from the outside. The
+    endpoint deploys clean, answers every request, and refuses every activation
+    with the same body it uses for a genuine non-subscriber — so neither a smoke
+    test nor the live security test can tell a correctly-configured service from
+    one serving no products at all. The only reliable check is to look at what the
+    function actually received. Raises rather than warns: shipping an endpoint that
+    refuses all paying customers is worse than a failed deploy.
+    """
+    try:
+        detail = cfn_client.describe_stack_resource(
+            StackName=stack_name, LogicalResourceId="ActivateFunction"
+        )
+        function_name = detail["StackResourceDetail"]["PhysicalResourceId"]
+        config = lambda_client.get_function_configuration(FunctionName=function_name)
+    except Exception as exc:  # noqa: BLE001
+        raise SellerServiceError(
+            "Deployed, but could not read the activation function back to verify "
+            f"the product registry: {exc}\n"
+            "Check it by hand before announcing the endpoint: the registry must "
+            "list every product you expect to serve."
+        ) from exc
+
+    raw = (
+        (config.get("Environment") or {})
+        .get("Variables", {})
+        .get("PRODUCT_REGISTRY_JSON", "")
+    )
+    try:
+        deployed = json.loads(raw)
+        if not isinstance(deployed, dict):
+            raise ValueError(f"expected a JSON object, got {type(deployed).__name__}")
+    except ValueError as exc:
+        raise SellerServiceError(
+            f"The product registry did not survive deployment: {exc}\n"
+            f"  the function received: {raw!r}\n"
+            "Every activation will be refused as an unknown product — which is "
+            "indistinguishable from 'not subscribed' from the caller's side, so "
+            "this would not show up in testing. Do not announce this endpoint."
+        ) from exc
+
+    missing = [p for p in expected_product_ids if p not in deployed]
+    if missing:
+        raise SellerServiceError(
+            f"These products are not in the DEPLOYED registry: {', '.join(missing)}\n"
+            f"  the function received: {raw}\n"
+            "Activation for them will be refused as an unknown product."
+        )
+    return deployed
 
 
 def read_service_version(service_dir: Path) -> Optional[str]:

--- a/lib/idp_feature_sdk/tests/test_seller_service.py
+++ b/lib/idp_feature_sdk/tests/test_seller_service.py
@@ -18,13 +18,20 @@ import pytest
 
 from idp_feature_sdk.seller_service import (
     SellerServiceError,
+    activation_pointer_key,
+    build_activation_pointer,
     build_sam_deploy_command,
+    build_trust_bundle,
+    der_to_pem,
     fetch_activations,
+    fetch_signing_public_key,
     find_seller_service_dir,
     parse_product_registry,
     preflight,
+    publish_activation_pointer,
     read_service_version,
     resolve_stack_output,
+    verify_deployed_registry,
 )
 
 _PRODUCT = "prod-a5ee62vs2xa72"
@@ -246,11 +253,84 @@ def test_deploy_command_passes_registry_and_region(tmp_path):
     # Don't fail a no-op redeploy — re-running deploy must be safe.
     assert "--no-fail-on-empty-changeset" in cmd
     overrides = cmd[cmd.index("--parameter-overrides") + 1 :]
-    assert f"ProductRegistryJson={_REGISTRY}" in overrides
-    assert "MarketplaceAgreementRegion=us-east-1" in overrides
+    # Single-quoted, NOT bare. SAM re-tokenizes overrides with its own quote-aware
+    # parser and truncates an unquoted value at the first double quote, so a bare
+    # registry arrives as `{`. See _sam_override().
+    registry_override = next(
+        o for o in overrides if o.startswith("ProductRegistryJson=")
+    )
+    value = registry_override[len("ProductRegistryJson=") :]
+    assert value.startswith("'") and value.endswith("'"), (
+        f"registry override is not quoted: {registry_override!r} — SAM would "
+        "truncate it at the first double quote"
+    )
+    assert json.loads(value[1:-1]) == json.loads(_REGISTRY)
+    assert "MarketplaceAgreementRegion='us-east-1'" in overrides
     # Omitted options must not appear as empty overrides.
     assert not any(o.startswith("AllowedAccounts=") for o in overrides)
     assert not any(o.startswith("TokenTtlSeconds=") for o in overrides)
+
+
+def test_deploy_command_survives_sams_override_parser(tmp_path):
+    """Round-trip the override through SAM's actual parsing rules.
+
+    This is the regression guard for a live defect: the registry was passed bare,
+    SAM delivered `{` as the whole value, and the deployed service refused every
+    activation as an unknown product — indistinguishable from "not subscribed",
+    so nothing caught it. Reimplements the one rule that matters (an unquoted
+    value stops at the first `"`; a single-quoted one is taken verbatim).
+    """
+    import re
+
+    cmd = build_sam_deploy_command(
+        service_dir=tmp_path,
+        stack_name="s",
+        region="us-east-1",
+        product_registry_json=_REGISTRY,
+    )
+    overrides = cmd[cmd.index("--parameter-overrides") + 1 :]
+    parsed = {}
+    for override in overrides:
+        key, _, raw = override.partition("=")
+        match = re.match(r"^'([^']*)'$", raw)
+        # Unquoted values are truncated by SAM at the first double quote.
+        parsed[key] = match.group(1) if match else raw.split('"')[0]
+
+    assert json.loads(parsed["ProductRegistryJson"]) == json.loads(_REGISTRY), (
+        f"registry did not survive SAM's parser: {parsed['ProductRegistryJson']!r}"
+    )
+
+
+def test_deploy_command_compacts_pretty_printed_registry(tmp_path):
+    """A multi-line registry is the natural thing to paste when adding a second
+    product; SAM splits overrides on whitespace, so it must be compacted first."""
+    pretty = """{
+      "prod-aaaaaaaaaaaaaa": {"productCode": "c1", "allowFreeTier": false},
+      "prod-bbbbbbbbbbbbbb": {"productCode": "c2", "allowFreeTier": true}
+    }"""
+    cmd = build_sam_deploy_command(
+        service_dir=tmp_path,
+        stack_name="s",
+        region="us-east-1",
+        product_registry_json=pretty,
+    )
+    override = next(o for o in cmd if o.startswith("ProductRegistryJson="))
+    value = override[len("ProductRegistryJson=") :]
+    assert "\n" not in value and " " not in value, (
+        f"registry still contains whitespace, SAM will split it: {value!r}"
+    )
+    assert json.loads(value[1:-1]) == json.loads(pretty)
+
+
+def test_deploy_command_rejects_a_single_quote_rather_than_mangling_it(tmp_path):
+    with pytest.raises(SellerServiceError, match="single quote"):
+        build_sam_deploy_command(
+            service_dir=tmp_path,
+            stack_name="s",
+            region="us-east-1",
+            product_registry_json=_REGISTRY,
+            allowed_accounts="111122223333'",
+        )
 
 
 def test_deploy_command_includes_optional_overrides(tmp_path):
@@ -264,9 +344,284 @@ def test_deploy_command_includes_optional_overrides(tmp_path):
         guided=True,
     )
     overrides = cmd[cmd.index("--parameter-overrides") + 1 :]
-    assert "AllowedAccounts=111122223333" in overrides
-    assert "TokenTtlSeconds=900" in overrides
+    # Quoted, for the same reason as the registry: SAM re-tokenizes these.
+    assert "AllowedAccounts='111122223333'" in overrides
+    assert "TokenTtlSeconds='900'" in overrides
     assert "--guided" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Activation endpoint pointer (indirection)
+# ---------------------------------------------------------------------------
+
+_ENDPOINT = "https://abc123.execute-api.us-east-1.amazonaws.com/prod/activate"
+
+
+class _FakeS3:
+    def __init__(self, error=None):
+        self.puts = []
+        self._error = error
+
+    def put_object(self, **kwargs):
+        if self._error:
+            raise self._error
+        self.puts.append(kwargs)
+        return {}
+
+
+def test_pointer_key_sits_beside_latest_json():
+    """Same layout as latest.json, and version-free — it is a pointer, so a
+    reader must get the CURRENT endpoint, not one pinned to a release."""
+    assert (
+        activation_pointer_key("idp-auto-optimizer")
+        == "extensions/idp-auto-optimizer/activation.json"
+    )
+    assert (
+        activation_pointer_key("idp-auto-optimizer", "artifacts/genai-idp-mp")
+        == "artifacts/genai-idp-mp/extensions/idp-auto-optimizer/activation.json"
+    )
+    # Stray slashes in the prefix must not produce a doubled separator.
+    assert activation_pointer_key("f", "/a/b/") == "a/b/extensions/f/activation.json"
+
+
+def test_pointer_document_shape():
+    doc = build_activation_pointer(
+        activation_endpoint=_ENDPOINT,
+        signing_key_id="arn:aws:kms:us-east-1:1:key/abc",
+        service_version="0.6.5.dev1",
+        published_at="2026-08-20T00:00:00Z",
+    )
+    assert doc["schemaVersion"] == "1.0"
+    assert doc["activationEndpoint"] == _ENDPOINT
+    assert doc["serviceVersion"] == "0.6.5.dev1"
+
+
+def test_pointer_document_carries_no_key_material():
+    """The whole security argument for the pointer rests on this.
+
+    If the pointer carried the public verification key, whoever can write to the
+    artifact bucket could swap in a hostile endpoint AND the key that validates
+    its tokens — making the bucket a forgery trust root. With no key material, a
+    tampered pointer can only redirect to something that cannot produce a
+    signature verifying against the key embedded in the extension, so activation
+    fails closed. Worst case is denial of service, not free access.
+    """
+    doc = build_activation_pointer(
+        activation_endpoint=_ENDPOINT, signing_key_id="arn:aws:kms:us-east-1:1:key/abc"
+    )
+    serialized = json.dumps(doc)
+    for forbidden in ("BEGIN PUBLIC KEY", "publicKey", "MII"):
+        assert forbidden not in serialized, (
+            f"pointer leaks key material ({forbidden!r}) — the artifact bucket "
+            "must not become a trust root for token verification"
+        )
+
+
+def test_pointer_refuses_to_publish_key_material():
+    """Belt-and-braces: even if a caller hand-builds a document with a key in it."""
+    s3 = _FakeS3()
+    with pytest.raises(SellerServiceError, match="forgery trust root"):
+        publish_activation_pointer(
+            s3_client=s3,
+            bucket="b",
+            feature_ids=["f"],
+            document={"activationEndpoint": _ENDPOINT, "publicKey": "MIIBI..."},
+        )
+    assert s3.puts == [], "nothing may be written when key material is present"
+
+
+def test_pointer_requires_https():
+    """Extensions send SigV4-signed credentials to this URL."""
+    with pytest.raises(SellerServiceError, match="https"):
+        build_activation_pointer(
+            activation_endpoint="http://abc.execute-api.us-east-1.amazonaws.com/prod/activate"
+        )
+
+
+def test_pointer_is_published_public_read_for_every_feature():
+    """Read by an extension running in an arbitrary buyer account, exactly like
+    the template and latest.json beside it."""
+    s3 = _FakeS3()
+    doc = build_activation_pointer(activation_endpoint=_ENDPOINT)
+    written = publish_activation_pointer(
+        s3_client=s3,
+        bucket="aws-ml-blog-us-east-1",
+        feature_ids=["idp-auto-optimizer", "idp-monitor"],
+        document=doc,
+        s3_prefix="artifacts/genai-idp-mp",
+    )
+    assert len(written) == 2 and len(s3.puts) == 2
+    for put in s3.puts:
+        assert put["ACL"] == "public-read"
+        assert put["ContentType"] == "application/json"
+        assert json.loads(put["Body"])["activationEndpoint"] == _ENDPOINT
+    assert "idp-monitor" in written[1]
+
+
+def test_pointer_can_be_published_private():
+    s3 = _FakeS3()
+    publish_activation_pointer(
+        s3_client=s3,
+        bucket="b",
+        feature_ids=["f"],
+        document=build_activation_pointer(activation_endpoint=_ENDPOINT),
+        make_public=False,
+    )
+    assert "ACL" not in s3.puts[0]
+
+
+def test_pointer_publish_failure_is_actionable():
+    s3 = _FakeS3(error=RuntimeError("AccessDenied"))
+    with pytest.raises(SellerServiceError, match="could not write s3://"):
+        publish_activation_pointer(
+            s3_client=s3,
+            bucket="b",
+            feature_ids=["f"],
+            document=build_activation_pointer(activation_endpoint=_ENDPOINT),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Build-time trust material
+# ---------------------------------------------------------------------------
+
+# Deliberately a stub, in the same short form the sibling suites use
+# (test_activate.py, test_payload_robustness.py). In production `kid` is the real
+# KMS key ARN, but nothing here validates ARN shape — the assertions only prove
+# the value round-trips unchanged — and a realistic key ARN is both a needless
+# identifier to publish and rejected outright by the commit scanner.
+_KEY_ARN = "arn:aws:kms:us-east-1:1:key/abc"
+# Not a real key; only the DER->PEM framing is under test here.
+_DER = bytes(range(256)) * 2
+
+
+class _FakeKms:
+    def __init__(self, key_usage="SIGN_VERIFY", public_key=_DER, error=None):
+        self._usage = key_usage
+        self._public_key = public_key
+        self._error = error
+
+    def get_public_key(self, KeyId):  # noqa: N803
+        if self._error:
+            raise self._error
+        return {"KeyUsage": self._usage, "PublicKey": self._public_key}
+
+
+def test_der_to_pem_round_trips():
+    import base64
+
+    pem = der_to_pem(_DER)
+    assert pem.startswith("-----BEGIN PUBLIC KEY-----\n")
+    assert pem.rstrip().endswith("-----END PUBLIC KEY-----")
+    body = "".join(line for line in pem.splitlines() if not line.startswith("-----"))
+    assert base64.b64decode(body) == _DER
+    # PEM requires the base64 wrapped; a single long line breaks strict parsers.
+    assert all(len(line) <= 64 for line in pem.splitlines())
+
+
+def test_trust_bundle_kid_is_the_key_arn():
+    """The kid MUST be byte-identical to the `kid` claim the Lambda emits, which
+    is the signing key ARN (see _mint_token). If these diverge, a verifier cannot
+    map a token to the key that signed it and rotation is impossible."""
+    bundle = build_trust_bundle(
+        activation_endpoint=_ENDPOINT, kid=_KEY_ARN, public_key_der=_DER
+    )
+    assert bundle["kid"] == _KEY_ARN
+    assert bundle["signingAlgorithm"] == "RSASSA_PSS_SHA_256"
+    assert bundle["activationEndpoint"] == _ENDPOINT
+    assert "BEGIN PUBLIC KEY" in bundle["publicKeyPem"]
+
+
+def test_trust_bundle_requires_a_kid():
+    with pytest.raises(SellerServiceError, match="kid is empty"):
+        build_trust_bundle(activation_endpoint=_ENDPOINT, kid="", public_key_der=_DER)
+
+
+def test_fetch_public_key_rejects_a_non_signing_key():
+    """Exporting an ENCRYPT_DECRYPT key's public half would produce a bundle that
+    fails every verification, with nothing to indicate why."""
+    with pytest.raises(SellerServiceError, match="not SIGN_VERIFY"):
+        fetch_signing_public_key(_FakeKms(key_usage="ENCRYPT_DECRYPT"), _KEY_ARN)
+
+
+def test_fetch_public_key_error_names_the_missing_permission():
+    with pytest.raises(SellerServiceError, match="kms:GetPublicKey"):
+        fetch_signing_public_key(
+            _FakeKms(error=RuntimeError("AccessDeniedException")), _KEY_ARN
+        )
+
+
+def test_fetch_public_key_rejects_an_empty_response():
+    with pytest.raises(SellerServiceError, match="no public key"):
+        fetch_signing_public_key(_FakeKms(public_key=b""), _KEY_ARN)
+
+
+def test_trust_bundle_carries_the_key_but_the_pointer_does_not():
+    """The deliberate asymmetry, asserted in one place so it cannot drift.
+
+    Build-time material embeds the key (that is what makes verification
+    trustworthy); the runtime pointer must not (that is what stops the artifact
+    bucket becoming a forgery trust root).
+    """
+    bundle = build_trust_bundle(
+        activation_endpoint=_ENDPOINT, kid=_KEY_ARN, public_key_der=_DER
+    )
+    pointer = build_activation_pointer(
+        activation_endpoint=_ENDPOINT, signing_key_id=_KEY_ARN
+    )
+    assert "publicKeyPem" in bundle
+    assert not any("publicKey" in k or "Pem" in k for k in pointer), (
+        f"the runtime pointer must carry no key material, got {sorted(pointer)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Post-deploy registry read-back
+# ---------------------------------------------------------------------------
+
+
+class _FakeCfnResource:
+    def describe_stack_resource(self, StackName, LogicalResourceId):  # noqa: N803
+        return {"StackResourceDetail": {"PhysicalResourceId": "the-function"}}
+
+
+class _FakeLambda:
+    def __init__(self, registry_value):
+        self._value = registry_value
+
+    def get_function_configuration(self, FunctionName):  # noqa: N803
+        return {"Environment": {"Variables": {"PRODUCT_REGISTRY_JSON": self._value}}}
+
+
+def _verify(registry_value, expected=("prod-a5ee62vs2xa72",)):
+    return verify_deployed_registry(
+        cfn_client=_FakeCfnResource(),
+        lambda_client=_FakeLambda(registry_value),
+        stack_name="s",
+        expected_product_ids=list(expected),
+    )
+
+
+def test_verify_deployed_registry_accepts_a_good_deployment():
+    deployed = _verify('{"prod-a5ee62vs2xa72":{"productCode":"c"}}')
+    assert "prod-a5ee62vs2xa72" in deployed
+
+
+def test_verify_deployed_registry_catches_the_truncated_registry():
+    """`{` is exactly what SAM delivered when the value was passed unquoted."""
+    with pytest.raises(SellerServiceError, match="did not survive deployment"):
+        _verify("{")
+
+
+def test_verify_deployed_registry_catches_an_empty_registry():
+    """`{}` is the template default — it means no product is served at all."""
+    with pytest.raises(SellerServiceError, match="not in the DEPLOYED registry"):
+        _verify("{}")
+
+
+def test_verify_deployed_registry_catches_a_missing_product():
+    with pytest.raises(SellerServiceError, match="prod-wanted"):
+        _verify('{"prod-other":{"productCode":"c"}}', expected=("prod-wanted",))
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/sdlc/docs/CI_TEST_COVERAGE.md
+++ b/scripts/sdlc/docs/CI_TEST_COVERAGE.md
@@ -27,6 +27,7 @@ its `make` target and the skill that documents how to run it.
 | Full offline test battery (no AWS) | `make test` | `.claude/skills/full-test-battery.md` |
 | Package/Lambda offline suites (idp_cli, idp_sdk, idp_feature_sdk, feature-platform, seller-entitlement-service) | `make test-packages-cicd` | — *(runs per commit in the GitHub `developer-tests` workflow)* |
 | Seller-service ownership preflight (read-only) | `make seller-entitlement-service-preflight PRODUCT_REGISTRY='{…}'` | `feature-platform/seller-entitlement-service/README.md` |
+| Seller-service **e2e** (deploy → live probe → teardown) | `make stacktest-seller` | `.claude/skills/run-stack-tests.md` |
 | Seller-service live activation + payload probe | `python feature-platform/seller-entitlement-service/tests/dynamic_activation_test.py --endpoint … --product-id …` | `feature-platform/seller-entitlement-service/README.md` |
 | Seller-service test-stack teardown (incl. retained KMS key + table) | `feature-platform/seller-entitlement-service/tests/teardown_test_stack.sh --stack-name …-citest` | `feature-platform/seller-entitlement-service/README.md` |
 | Run security tests + curate a public-safe snapshot | `make security-results [STACK_NAME=… REGION=…]` (offline-only if no stack) | `.claude/skills/curate-security-results.md` |

--- a/scripts/srt/issues.json
+++ b/scripts/srt/issues.json
@@ -1752,5 +1752,50 @@
     "assessmentCount": 1,
     "suppressionReason": "Accepted: CloudTrail DynamoDB data-plane logging is an account-level control (trail + log bucket) owned by the deploying customer; the solution template cannot assume or create account-wide trails. Same rationale as every other table in the solution (TrackingTable, InstalledFeaturesTable, ClaimsStatusTable, ...). The mapping table is SSE-encrypted, PITR-enabled, and reachable only via the RBAC-gated feature API.",
     "suppressedAt": "2026-07-24T16:30:00.000Z"
+  },
+  {
+    "source": "security-matrix",
+    "path": "feature-platform/seller-entitlement-service/template.yaml",
+    "resourceType": "AWS::KMS::Key",
+    "resourceName": "TokenSigningKey",
+    "issue": "KMS key deployed without monitoring infrastructure for events and compliance",
+    "fix": "Add EventBridge rule with EventPattern source \"aws.kms\" and Lambda function target for KMS event monitoring. The Lambda function should have X-Ray tracing enabled. The Lambda function should have CloudWatch Alarms for the following Lambda metrics: Errors, Throttles, Duration, Invocations, ConcurrentExecutions, and DeadLetterErrors.",
+    "priority": "HIGH",
+    "check_id": "KMS-007",
+    "status": "suppressed",
+    "isCustomResource": false,
+    "firstDetectedAt": "2026-08-20T00:00:00.000Z",
+    "assessmentCount": 1,
+    "suppressionReason": "Accepted: KMS key event monitoring (EventBridge rule + monitoring Lambda + alarms) is account-level infrastructure owned by the account operator, out of scope for this template. Same rationale as the other KMS-007 records in this baseline. This service is deployed by an extension SELLER into their own Marketplace seller account, so KMS-event monitoring is theirs to configure against their existing CloudTrail. The service's own security-relevant events are already recorded independently: the API access log records every caller account, the activation roster records every attempt, and a CloudWatch metric filter alarms on refusals."
+  },
+  {
+    "source": "security-matrix",
+    "path": "feature-platform/seller-entitlement-service/template.yaml",
+    "resourceType": "AWS::KMS::Key",
+    "resourceName": "LogEncryptionKey",
+    "issue": "KMS key deployed without monitoring infrastructure for events and compliance",
+    "fix": "Add EventBridge rule with EventPattern source \"aws.kms\" and Lambda function target for KMS event monitoring. The Lambda function should have X-Ray tracing enabled. The Lambda function should have CloudWatch Alarms for the following Lambda metrics: Errors, Throttles, Duration, Invocations, ConcurrentExecutions, and DeadLetterErrors.",
+    "priority": "HIGH",
+    "check_id": "KMS-007",
+    "status": "suppressed",
+    "isCustomResource": false,
+    "firstDetectedAt": "2026-08-20T00:00:00.000Z",
+    "assessmentCount": 1,
+    "suppressionReason": "Accepted: KMS key event monitoring (EventBridge rule + monitoring Lambda + alarms) is account-level infrastructure owned by the account operator, out of scope for this template. Same rationale as the other KMS-007 records in this baseline. This service is deployed by an extension SELLER into their own Marketplace seller account, so KMS-event monitoring is theirs to configure against their existing CloudTrail. The service's own security-relevant events are already recorded independently: the API access log records every caller account, the activation roster records every attempt, and a CloudWatch metric filter alarms on refusals."
+  },
+  {
+    "source": "security-matrix",
+    "path": "feature-platform/seller-entitlement-service/template.yaml",
+    "resourceType": "AWS::DynamoDB::Table",
+    "resourceName": "ActivationsTable",
+    "issue": "DynamoDB data plane events are not captured by CloudTrail logging",
+    "fix": "Enable CloudTrail logging for DynamoDB data plane events for this table. Create a CloudTrail Trail if none exists. Add this table's ARN to an EventSelector with DataResources type 'AWS::DynamoDB::Table' \u2014 append to existing values array if one exists, otherwise create a new EventSelector. For CDK: use the L1 escape hatch (trail.node.defaultChild as CfnTrail).eventSelectors as DataResourceType.DYNAMODB_TABLE does not exist.\n\nIMPORTANT - S3 Bucket Logging Requirements:\nIf creating a new S3 bucket for CloudTrail logs:\n1. First check if the template already has an S3 bucket configured as a logging destination (look for buckets referenced in other buckets' LoggingConfiguration.DestinationBucketName)\n2. If a logging bucket exists, configure the new CloudTrail bucket's LoggingConfiguration to use it with LoggingPrefix 'cloudtrail-logs/'\n3. If no logging bucket exists, create a dedicated server access logging bucket first, then configure the CloudTrail bucket to log to it with LoggingPrefix 'cloudtrail-logs/'",
+    "priority": "HIGH",
+    "check_id": "DDB-002",
+    "status": "suppressed",
+    "isCustomResource": false,
+    "firstDetectedAt": "2026-08-20T00:00:00.000Z",
+    "assessmentCount": 1,
+    "suppressionReason": "Accepted: capturing DynamoDB data-plane events requires a CloudTrail trail with data-event selectors (and a log bucket), which is account-global infrastructure owned by the account operator, not something a single feature stack should create. Same rationale as the other DDB-002 records in this baseline. Compensating controls on this specific table are unusually strong: the activation Lambda's IAM grants dynamodb:UpdateItem ONLY (no GetItem, Query, Scan or Delete - asserted by tests/test_template_security.py), so the function can neither read nor destroy the roster; reads require the operator's own credentials; the table has SSE + point-in-time recovery and is Retain-on-delete; and every write is independently mirrored by the API Gateway access log and an EMF activation metric."
   }
 ]


### PR DESCRIPTION
Follow-up to #629. Deploying the Seller Entitlement Service for the first time surfaced three defects that no offline test could see, plus a set of SRT HIGH findings. Verified against a live stack in the Marketplace seller account.

## Deployment fixes

Each of these caused a rollback or a silently broken service:

- **`InvokeRole: NONE`** on the activation API. SAM defaults `InvokeRole` to `CALLER_CREDENTIALS` under an `AWS_IAM` authorizer, which API Gateway refuses to deploy alongside a resource policy (`Caller provided credentials not allowed when resource policy is set`, [aws/serverless-application-model#1708](https://github.com/aws/serverless-application-model/issues/1708)). It also could never have worked: invoking as the caller would require every **buyer** account to hold `lambda:InvokeFunction` on the seller's function. Authentication is unchanged — `DefaultAuthorizer` is still `AWS_IAM`.
- **Account-level API Gateway CloudWatch role.** A REST stage with access logging is rejected unless it is set, and it never is in a fresh seller account — exactly the account this template targets. Same fix and rationale as `nested/api-resolvers`, including `Retain` so a teardown does not clear the account setting out from under other APIs. Also pre-declares the execution log group so it is CMK-encrypted and expiring rather than auto-created in plaintext.
- **Product registry quoting.** SAM re-tokenizes `--parameter-overrides` and truncates an unquoted value at the first `"`, so the deployed registry was literally `{`. The service served **zero products** and refused every activation as "unknown product" — byte-identical to "not entitled" by design — so it passed the live security probe while being completely non-functional. Now compacted and single-quoted, and `deploy` reads the registry back off the deployed Lambda and fails if it did not survive. Registry faults are invisible from outside, so they have to be caught at deploy time.

## Endpoint durability and per-release trust material

- **`seller-service publish-endpoint`** publishes `activation.json` beside `latest.json`, per region. The endpoint URL embeds an API-Gateway-assigned API id, so without indirection replacing the API would permanently break every installed extension — those run in customer accounts the seller cannot reach. The pointer carries the endpoint and deliberately **no key material**: a runtime-fetched key would make the artifact bucket a forgery trust root.
- **`seller-service export-trust-bundle`** emits the endpoint, `kid` (the signing key ARN, byte-identical to the token claim), the algorithm, and the public key as PEM, so a release embeds generated material instead of hand-copied values. Output verified to parse as RSA-2048 by both `cryptography` and `openssl pkey`.

## SRT HIGH findings — 2 fixed, 2 accepted, 1 false positive

| Finding | Verdict | Action |
|---|---|---|
| Bandit **B613** `trojansource` | Real | **Fixed** — the fuzz corpus held literal invisible U+202E/U+200B characters, so the file could display differently from how it executes. Now escapes; runtime strings asserted byte-identical. |
| **KMS-002** overly-permissive key policy | Real | **Fixed** — `LogEncryptionKey` granted `kms:Encrypt*`/`Decrypt*`/`Describe*`, strictly broader than intended. Narrowed to the exact actions CloudWatch Logs needs, matching the main stack's `CustomerManagedEncryptionKey`. |
| **KMS-007** ×2 (no KMS event monitoring) | Accepted | Suppressed in `scripts/srt/issues.json` — account-level infrastructure owned by the account operator, consistent with the 5 existing KMS-007 records. |
| **DDB-002** (no CloudTrail data events) | Accepted | Suppressed — requires an account-global trail; consistent with the 23 existing DDB-002 records. Reason cites compensating controls: the Lambda holds `dynamodb:UpdateItem` **only**, so it can neither read nor destroy the roster. |
| Bandit **B105** | False positive | `# nosec B105` — `"RSASSA_PSS_SHA_256"` is an algorithm name; the heuristic fires only because the identifier contains `TOKEN`. |

`scripts/srt/issues.json` is purely additive: 118 → 121 records, 0 existing records modified or removed. Suppression records verified to match SRT's real merge key, `(path, resourceType, resourceName, check_id)`.

## Tests

New static guards, all mutation-tested (each fails when the property is reverted): `InvokeRole: NONE`, the account CloudWatch role's presence and retention, log-group encryption, KMS wildcard breadth, SAM override round-tripping, the post-deploy registry read-back, and the build-time/runtime key-material asymmetry.

**`make stacktest-seller`** is a new e2e that deploys a throwaway stack, probes the live API and tears it down including retained resources. It was referenced in a docstring but never existed — and it is what would have caught the two deploy-time defects, since both were invisible to every offline suite. It needs no real Marketplace listing: every assertion is a refusal, so it registers a synthetic product id.

## Verification

- `make test-packages-cicd` — green, run hermetically with AWS config unset.
- `make srt-scan` — **zero HIGH findings in tracked files**; the 3 suppressions confirmed matched. (Remaining local HIGHs are all in gitignored `.aws-sam/*.yaml`, which CI never checks out.)
- `make check-arn-partitions`, `ruff check`, `ruff format --check` — clean.
- Live: deploy → registry read-back → `dynamic_activation_test.py` (unsigned 403, unentitled 403, no existence oracle, 400, 413, 15 hostile payloads no 5xx) → teardown.

## Not covered

The positive path — a token issued and verified — needs a genuinely subscribed buyer account, which cannot be created on demand. Run `dynamic_activation_test.py --entitled-profile` once a console subscribe exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)