### PR TITLE
test(benchmarks): commit the advverify suite the published results were run with

### DIFF
--- a/benchmarks/matrices/config_matrix.yaml
+++ b/benchmarks/matrices/config_matrix.yaml
@@ -138,6 +138,14 @@ suites:
   # non-deterministic and the failure is a partial list, not an error), so it gets
   # repeats and the `separate` cell alongside as a same-doc control.
   intconf: {cells: [core-tt-simple-int, core-tt-simple-sep], docs: [longdesc_100], repeats: 4}
+  # advverify: re-verifies the OTHER standing list-loss hazard — an ADVANCED-mode
+  # agent that declines the recommended table tool and returns the whole list as
+  # `null` (#666/#668). Same rationale as `intconf` above: the failure is
+  # non-deterministic and silent (schema-valid, scalar accuracy 1.000, status
+  # COMPLETED), so a single run cannot settle it. `core-tt-adv-sep` runs alongside
+  # as a same-doc control. Run it with `--set extraction_model=sonnet5`, the model
+  # the failure was observed on. Evidence: benchmarks/results/v0.6.5-advverify/.
+  advverify: {cells: [core-tt-adv-int, core-tt-adv-sep], docs: [longdesc_100], repeats: 4}
   full:    {cells: "core_cells+sweeps", docs: "all", repeats: 1}
   scaling: {cells: [core-tt-simple-sep, core-tt-adv-sep], docs: "scaling_series", repeats: 1}
   # cost: purpose-built to DETECT COST DIFFERENCES between configs with confidence.

--- a/docs/benchmarking/index.md
+++ b/docs/benchmarking/index.md
@@ -104,6 +104,7 @@ reference test sets to reference, with each doc's ground-truth pointer and confi
 | `scaling` | simple vs advanced across the size series | The completeness-cliff study |
 | `cost` | cost-decision cells × 1 mid doc, repeats≥5 | Cost-difference detection (variance-aware) |
 | `intconf` | integrated + separate confidence × 1 list doc, repeats=4 | Re-verifies the integrated-confidence row-loss hazard; the one finding a single-sample grid cannot settle |
+| `advverify` | advanced × integrated + separate × 1 list doc, repeats=4 | Re-verifies the **tool-decline** list-loss hazard (an agent that declines the table tool returning the whole list as `null`). Run with `--set extraction_model=sonnet5` |
 | `full` | core + all one-axis sweeps | The deep study for the paper (expensive) |
 
 > **Picking the extraction model.** The committed `default_cell` holds `extraction_model` at


### PR DESCRIPTION
`benchmarks/results/v0.6.5-advverify/` landed on develop citing `--suite advverify`, but that suite existed only in my working tree. So the committed evidence was **not reproducible** — which is precisely what the *Reproducibility & honesty rules* in `docs/benchmarking/index.md` exist to prevent.

Promoted to a permanent suite, with the same justification `intconf` already carries: the failure is non-deterministic and **silent** (schema-valid, scalar accuracy 1.000, status `COMPLETED`), so a single run cannot settle it, and `core-tt-adv-sep` runs alongside as a same-document control.

The comment records the `--set extraction_model=sonnet5` the failure was observed on — without it the suite would run the cross-version control model and not reproduce the finding — and points at the results directory. Also added to the suite table in `docs/benchmarking/index.md`, next to `intconf`.

```yaml
advverify: {cells: [core-tt-adv-int, core-tt-adv-sep], docs: [longdesc_100], repeats: 4}
```

No code change. `make lint-cicd` → exit 0; `pytest benchmarks/tests` → 33 passed; matrix parses and the suite resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)