### PR TITLE
test(benchmarks): post-#668 no-harm evidence, and a reproduced residual

### DIFF
--- a/benchmarks/results/v0.6.6-advverify-post668/FINDINGS.md
+++ b/benchmarks/results/v0.6.6-advverify-post668/FINDINGS.md
@@ -1,0 +1,59 @@
+# Post-#668 no-harm check, and a reproduced residual
+
+Second `advverify` run, after [#668](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/pull/668)
+un-gated the empty-declared-list check so it no longer sits behind
+`extraction.agentic.validation.enabled` (default `false`).
+
+- Stack: IDPBench065, `stack_version` 0.6.6.dev1, commit `612f3225b`
+- Suite: `advverify` (`--set extraction_model=sonnet5`), `longdesc_100.pdf`, 2 cells x 4 repeats
+- Companion run before #668: [`../v0.6.5-advverify/`](../v0.6.5-advverify/FINDINGS.md)
+
+## What this run is for
+
+**A no-harm check, not a new proof of the fix.** #668 made the validator callback
+get built on every Advanced-mode section with table evidence, where previously it
+was `None` on default configs. The risk that introduces is to the *happy path* —
+an extra check running where nothing ran before. This run exercises exactly that.
+
+It does **not** exercise the newly-reachable retry: the retry only fires when every
+declared list comes back empty, and on this document the list is never empty. So
+"the ungated retry works end-to-end" remains **unverified live** and is carried by
+unit tests only.
+
+## Result: no harm
+
+| cell | runs | failures | recall | scalar accuracy |
+|---|---|---|---|---|
+| `core-tt-adv-int` | 4 | 0 | **1.000** | 1.000 |
+| `core-tt-adv-sep` | 4 | 0 | **1.000** | 1.000 |
+
+All 8 returned 100/100 rows and `completeness_check.complete = true`. Combined with
+the 8 runs in `v0.6.5-advverify`, that is **16/16 at 100/100** against a pre-fix
+baseline of `Transactions: null` (0 of 100).
+
+The agent **declined the recommended table tool in 5 of these 8 runs** and extracted
+the table directly anyway — the same behaviour the prompt rule was written to make
+safe, and consistent with 6 of 8 in the previous run.
+
+## Reproduced residual: `assessment_incomplete` (NOT caused by these fixes)
+
+`assessment_incomplete` (severity **error**, *"1 list row(s) could not be
+confidence-scored"*) fired in 3 of 4 `core-tt-adv-int` runs (repeats 0, 1, 3) and
+**0 of 4** `core-tt-adv-sep` runs — matching the previous run exactly.
+
+Across both sessions: **6 of 8 integrated runs, 0 of 8 separate runs.** That makes it
+a reproducible defect rather than a one-off, confined to `integrated` confidence
+mode. It is confidence *coverage*, not extraction data loss — recall is 1.000 — and
+it is consistent with the standing guidance to prefer `separate` on list-bearing
+schemas.
+
+It is **not diagnosed and not fixed**, and no before/after claim is made: the
+pre-fix run had zero rows to score, so there is nothing to compare against. Needs
+its own investigation.
+
+## No cost claim from this run
+
+`core-tt-adv-int` cost CV = **0.47** at n=4 (the harness emitted its own
+`high cost variance (CV>0.25) — increase repeats` warning). The `int` mean ($0.794)
+reads above `sep` ($0.634), the same direction as earlier findings, but at that
+spread these 8 runs do not support the comparison. Use the `cost` suite.

--- a/benchmarks/results/v0.6.6-advverify-post668/cell_stats.csv
+++ b/benchmarks/results/v0.6.6-advverify-post668/cell_stats.csv
@@ -1,0 +1,3 @@
+cell,n_success,n_fail,cost_mean,cost_stdev,cost_cv,cost_min,cost_max,recall_mean,acc_mean,wall_mean
+core-tt-adv-int,4,0,0.79415,0.37317,0.4699,0.5353,1.3458,1.0,1.0,279.57109
+core-tt-adv-sep,4,0,0.63428,0.09795,0.1544,0.5174,0.7455,1.0,1.0,191.08474

--- a/benchmarks/results/v0.6.6-advverify-post668/summary.csv
+++ b/benchmarks/results/v0.6.6-advverify-post668/summary.csv
@@ -1,0 +1,9 @@
+cell,doc,repeat,status,success,page_count,completeness_recall,truncation_prefix,scalar_accuracy,weighted_accuracy,parse_failures,mean_confidence,pct_conf_below_0.9,calibration_separation,wall_s,cost
+core-tt-adv-int,longdesc_100.pdf,0,COMPLETED,True,3.0,1.0,100,1.0,,,0.6375,39.5,,284.384094,0.6054
+core-tt-adv-int,longdesc_100.pdf,1,COMPLETED,True,3.0,1.0,100,1.0,,,0.6609,32.9,,292.788187,0.5353
+core-tt-adv-int,longdesc_100.pdf,2,COMPLETED,True,3.0,1.0,100,1.0,,,0.6576,32.9,,283.670458,0.6901
+core-tt-adv-int,longdesc_100.pdf,3,COMPLETED,True,3.0,1.0,100,1.0,,,0.6374,39.5,,257.441618,1.3458
+core-tt-adv-sep,longdesc_100.pdf,0,COMPLETED,True,3.0,1.0,100,1.0,,,0.6623,32.6,,191.121695,0.6001
+core-tt-adv-sep,longdesc_100.pdf,1,COMPLETED,True,3.0,1.0,100,1.0,,,0.9721,0.0,,197.983013,0.7455
+core-tt-adv-sep,longdesc_100.pdf,2,COMPLETED,True,3.0,1.0,100,1.0,,,0.655,32.6,,176.604689,0.5174
+core-tt-adv-sep,longdesc_100.pdf,3,COMPLETED,True,3.0,1.0,100,1.0,,,0.9779,0.3,,198.629583,0.6741

--- a/benchmarks/results/v0.6.6-advverify-post668/summary.json
+++ b/benchmarks/results/v0.6.6-advverify-post668/summary.json
@@ -1,0 +1,480 @@
+{
+  "meta": {
+    "stack": "IDPBench065",
+    "stack_version": "0.6.6.dev1",
+    "suite": "advverify",
+    "class": "bank_statement",
+    "commit": "612f3225b",
+    "pricing_sha256": "bc68d49e506ef4609c1ba96a5a811988b6d6b5de51bf5b4d4962f1d26f05f2e2",
+    "scored_at": "2026-08-27T18:36:39.037814Z",
+    "region": "us-west-2"
+  },
+  "rows": [
+    {
+      "cell": "core-tt-adv-int",
+      "doc": "longdesc_100.pdf",
+      "repeat": 0,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "integrated",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-130520",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 284.384094,
+      "cost": 0.6054,
+      "cost_by_phase": {
+        "OCR": 0.04602,
+        "Classification": 5e-05,
+        "Extraction": 0.55927,
+        "Assessment": 2e-05,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 53772,
+        "outputTokens": 14553,
+        "cacheReadInputTokens": 95792,
+        "cacheWriteInputTokens": 23948
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.6375,
+      "pct_conf_below_0.9": 39.5,
+      "n_conf_leaves": 304
+    },
+    {
+      "cell": "core-tt-adv-int",
+      "doc": "longdesc_100.pdf",
+      "repeat": 1,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "integrated",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-130527",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 292.788187,
+      "cost": 0.5353,
+      "cost_by_phase": {
+        "OCR": 0.04601,
+        "Classification": 2e-05,
+        "Extraction": 0.48924,
+        "Assessment": 4e-05,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 38342,
+        "outputTokens": 12444,
+        "cacheReadInputTokens": 143688,
+        "cacheWriteInputTokens": 23948
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.6609,
+      "pct_conf_below_0.9": 32.9,
+      "n_conf_leaves": 304
+    },
+    {
+      "cell": "core-tt-adv-int",
+      "doc": "longdesc_100.pdf",
+      "repeat": 2,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "integrated",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-130541",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 283.670458,
+      "cost": 0.6901,
+      "cost_by_phase": {
+        "OCR": 0.04601,
+        "Classification": 2e-05,
+        "Extraction": 0.64405,
+        "Assessment": 1e-05,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 70072,
+        "outputTokens": 15910,
+        "cacheReadInputTokens": 119740,
+        "cacheWriteInputTokens": 23948
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.6576,
+      "pct_conf_below_0.9": 32.9,
+      "n_conf_leaves": 307
+    },
+    {
+      "cell": "core-tt-adv-int",
+      "doc": "longdesc_100.pdf",
+      "repeat": 3,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "integrated",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-130559",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 257.441618,
+      "cost": 1.3458,
+      "cost_by_phase": {
+        "OCR": 0.04538,
+        "Classification": 2e-05,
+        "Extraction": 1.30038,
+        "Assessment": 2e-05,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 264375,
+        "outputTokens": 18739,
+        "cacheReadInputTokens": 311324,
+        "cacheWriteInputTokens": 0
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.6374,
+      "pct_conf_below_0.9": 39.5,
+      "n_conf_leaves": 304
+    },
+    {
+      "cell": "core-tt-adv-sep",
+      "doc": "longdesc_100.pdf",
+      "repeat": 0,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "separate",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-131053",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 191.121695,
+      "cost": 0.6001,
+      "cost_by_phase": {
+        "OCR": 0.04541,
+        "Classification": 2e-05,
+        "Extraction": 0.55098,
+        "Assessment": 0.00375,
+        "Summarization": 1e-05
+      },
+      "tokens": {
+        "inputTokens": 70346,
+        "outputTokens": 23678,
+        "cacheReadInputTokens": 131461,
+        "cacheWriteInputTokens": 23421
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.6623,
+      "pct_conf_below_0.9": 32.6,
+      "n_conf_leaves": 307
+    },
+    {
+      "cell": "core-tt-adv-sep",
+      "doc": "longdesc_100.pdf",
+      "repeat": 1,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "separate",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-131125",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 197.983013,
+      "cost": 0.7455,
+      "cost_by_phase": {
+        "OCR": 0.04536,
+        "Classification": 2e-05,
+        "Extraction": 0.69686,
+        "Assessment": 0.00323,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 86257,
+        "outputTokens": 28469,
+        "cacheReadInputTokens": 81364,
+        "cacheWriteInputTokens": 23421
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.9721,
+      "pct_conf_below_0.9": 0.0,
+      "n_conf_leaves": 307
+    },
+    {
+      "cell": "core-tt-adv-sep",
+      "doc": "longdesc_100.pdf",
+      "repeat": 2,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "separate",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-131203",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 176.604689,
+      "cost": 0.5174,
+      "cost_by_phase": {
+        "OCR": 0.04529,
+        "Classification": 2e-05,
+        "Extraction": 0.46829,
+        "Assessment": 0.00375,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 72426,
+        "outputTokens": 24611,
+        "cacheReadInputTokens": 107836,
+        "cacheWriteInputTokens": 0
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.655,
+      "pct_conf_below_0.9": 32.6,
+      "n_conf_leaves": 307
+    },
+    {
+      "cell": "core-tt-adv-sep",
+      "doc": "longdesc_100.pdf",
+      "repeat": 3,
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "separate",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "run_id": "bench-longdesc_100-20260827-131246",
+      "status": "COMPLETED",
+      "success": true,
+      "page_count": 3.0,
+      "wall_s": 198.629583,
+      "cost": 0.6741,
+      "cost_by_phase": {
+        "OCR": 0.04536,
+        "Classification": 2e-05,
+        "Extraction": 0.6253,
+        "Assessment": 0.00341,
+        "Summarization": 2e-05
+      },
+      "tokens": {
+        "inputTokens": 107953,
+        "outputTokens": 24061,
+        "cacheReadInputTokens": 198469,
+        "cacheWriteInputTokens": 0
+      },
+      "rows_truth": 100,
+      "rows_extracted": 100,
+      "completeness_recall": 1.0,
+      "truncation_prefix": 100,
+      "dups": 0,
+      "n_gaps": 0,
+      "scalar_accuracy": 1.0,
+      "mean_confidence": 0.9779,
+      "pct_conf_below_0.9": 0.3,
+      "n_conf_leaves": 307
+    }
+  ],
+  "cell_stats": {
+    "core-tt-adv-int": {
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "integrated",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "n_runs": 4,
+      "n_success": 4,
+      "n_fail": 0,
+      "max_repeat": 4,
+      "cost": {
+        "n": 4,
+        "mean": 0.79415,
+        "stdev": 0.37317,
+        "cv": 0.4699,
+        "min": 0.5353,
+        "max": 1.3458
+      },
+      "completeness_recall": {
+        "n": 4,
+        "mean": 1.0,
+        "stdev": 0.0,
+        "cv": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "scalar_accuracy": {
+        "n": 4,
+        "mean": 1.0,
+        "stdev": 0.0,
+        "cv": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "weighted_accuracy": {
+        "n": 0,
+        "mean": null,
+        "stdev": null,
+        "cv": null,
+        "min": null,
+        "max": null
+      },
+      "wall_s": {
+        "n": 4,
+        "mean": 279.57109,
+        "stdev": 15.32291,
+        "cv": 0.0548,
+        "min": 257.44162,
+        "max": 292.78819
+      }
+    },
+    "core-tt-adv-sep": {
+      "resolved": {
+        "ocr": "textract_tables",
+        "extraction_mode": "advanced",
+        "assessment": "separate",
+        "geometry": "ocr_only",
+        "escalation": "off",
+        "extraction_model": "sonnet5",
+        "confidence_model": "nova_lite",
+        "reasoning_effort": "low"
+      },
+      "n_runs": 4,
+      "n_success": 4,
+      "n_fail": 0,
+      "max_repeat": 4,
+      "cost": {
+        "n": 4,
+        "mean": 0.63428,
+        "stdev": 0.09795,
+        "cv": 0.1544,
+        "min": 0.5174,
+        "max": 0.7455
+      },
+      "completeness_recall": {
+        "n": 4,
+        "mean": 1.0,
+        "stdev": 0.0,
+        "cv": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "scalar_accuracy": {
+        "n": 4,
+        "mean": 1.0,
+        "stdev": 0.0,
+        "cv": 0.0,
+        "min": 1.0,
+        "max": 1.0
+      },
+      "weighted_accuracy": {
+        "n": 0,
+        "mean": null,
+        "stdev": null,
+        "cv": null,
+        "min": null,
+        "max": null
+      },
+      "wall_s": {
+        "n": 4,
+        "mean": 191.08474,
+        "stdev": 10.23367,
+        "cv": 0.0536,
+        "min": 176.60469,
+        "max": 198.62958
+      }
+    }
+  }
+}


### PR DESCRIPTION
Second `advverify` run, after [#668](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/pull/668) un-gated the empty-declared-list check so it no longer sits behind `extraction.agentic.validation.enabled` (default `false`).

Stack IDPBench065, `stack_version 0.6.6.dev1`, commit `612f3225b`, Sonnet 5.

## No harm

| cell | runs | failures | recall | scalar accuracy |
|---|---|---|---|---|
| `core-tt-adv-int` | 4 | 0 | **1.000** | 1.000 |
| `core-tt-adv-sep` | 4 | 0 | **1.000** | 1.000 |

All 8 at 100/100 rows and `completeness_check.complete = true`. With the 8 in `v0.6.5-advverify` that is **16/16** against a pre-fix baseline of `Transactions: null`. The agent **declined the recommended table tool in 5 of these 8 runs** and extracted the table directly anyway.

## What this run deliberately does NOT show

`FINDINGS.md` says so up front. This is a **no-harm check on the happy path** — the actual risk #668 introduces, since the validator callback now gets built where it previously returned `None`. It does **not** exercise the newly-reachable retry: that fires only when *every* declared list comes back empty, which never happens on this document. **"The ungated retry works end-to-end" remains unverified live**, carried by unit tests only.

## Reproduced residual (not caused by these fixes)

`assessment_incomplete` (severity **error**, *"1 list row(s) could not be confidence-scored"*) fired in 3 of 4 `core-tt-adv-int` runs and **0 of 4** `core-tt-adv-sep` — matching the previous run exactly. Across both sessions: **6 of 8 integrated, 0 of 8 separate.**

That promotes it from a one-off observation to a **reproducible defect confined to `integrated` confidence mode**. It is coverage, not data loss (recall is 1.000), and it is consistent with the standing advice to prefer `separate` on list-bearing schemas. It is **not diagnosed and not fixed**, and no before/after claim is made — the pre-fix run had zero rows to score. It needs its own investigation.

## No cost claim

`core-tt-adv-int` cost CV = **0.47** at n=4; the harness emitted its own `high cost variance (CV>0.25) — increase repeats` warning. The `int` mean ($0.794) reads above `sep` ($0.634), the same direction as earlier findings, but these 8 runs do not support the comparison.

## Housekeeping

File set matches the `v0.6.5-advverify` precedent (`FINDINGS.md`, `summary.json`, `summary.csv`, `cell_stats.csv`); the raw `results/run-*/` runmap stays ignored per `benchmarks/.gitignore`. Data only — no code changes. **IDPBench065 has been torn down.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)