### PR TITLE
docs(benchmarks): correct the assessment_incomplete claim — escalation was OFF

### DIFF
--- a/benchmarks/results/v0.6.5-advverify/FINDINGS.md
+++ b/benchmarks/results/v0.6.5-advverify/FINDINGS.md
@@ -48,15 +48,48 @@ Layer 3 is confirmed working too: `completeness_check` now carries the new
 `unexplained_empty_lists` / `complete` fields, and `population_check` reports 4/4
 fields populated (it was 3/4 with `Transactions` empty).
 
-## Residual, NOT caused by these fixes
+## Residual, NOT caused by these fixes — and NOT yet a defect
 
 3 of 4 `core-tt-adv-int` runs raise `assessment_incomplete` (severity **error**):
 *"1 list row(s) could not be confidence-scored"* — 1 row of 100, confined to the
 **integrated** cell, absent from all four `separate` runs. This is confidence
-*coverage*, not extraction data loss, and it is consistent with the standing
-guidance to prefer `separate` on list-bearing schemas. It is not comparable to the
-pre-fix run, which had zero rows to score, so no before/after claim is made here —
-it needs its own investigation.
+*coverage*, not extraction data loss.
+
+⚠️ **Read with the config in hand: these cells ran with the escalation rung of the
+self-healing ladder switched OFF.**
+
+```
+escalation_enabled = False          # the model-escalation rung, disabled
+escalation_model   = us.anthropic.claude-sonnet-5:1m
+geometry.mode      = ocr_only       # the documented per-row-output remedy, already applied
+```
+
+`assessment_incomplete` fires only when rows remain unscored **after the full
+ladder** (shrink batch → retry → escalate model). With `escalation_enabled: false`,
+`batching.py` sets `ladder_escalation_model = None`, so the third rung never ran —
+the ladder had shrink+retry only. And that is not an accident of this run: the
+benchmark's `default_cell` sets `escalation: "off"` deliberately, so escalation cost
+does not confound cross-cell cost comparisons.
+
+So this is a reproducible **observation on a configuration that declines the
+recovery mechanism built for exactly this case** — not a demonstrated product
+defect, and not a demonstrated inherent limit either. The run that would settle it
+is `advverify` with `--set escalation=on`: if the row recovers it is a config
+artifact; if it does not, it is a real ceiling worth chasing.
+
+What the data *does* support: **integrated is more exposed than separate.** That is
+the expected direction — integrated carries confidence in one larger response, so a
+batch is likelier to hit the output ceiling, while `separate` gives the confidence
+model its own budget. It corroborates the standing guidance to prefer `separate` on
+list-bearing schemas rather than revealing anything new.
+
+No before/after claim is made against the pre-fix run either: it had zero rows to
+score.
+
+It **is** surfaced properly — `assessment_incomplete` is severity `error`, so the
+processing report's status line reads `COMPLETED WITH ERRORS`, the issue is listed
+with its root cause, and the section shows an `error` status indicator in the UI's
+Processing Issues column. Nothing here is silent.
 
 ## Cost note
 

--- a/benchmarks/results/v0.6.6-advverify-post668/FINDINGS.md
+++ b/benchmarks/results/v0.6.6-advverify-post668/FINDINGS.md
@@ -35,21 +35,53 @@ The agent **declined the recommended table tool in 5 of these 8 runs** and extra
 the table directly anyway — the same behaviour the prompt rule was written to make
 safe, and consistent with 6 of 8 in the previous run.
 
-## Reproduced residual: `assessment_incomplete` (NOT caused by these fixes)
+## Reproduced residual: `assessment_incomplete` — reproducible, but NOT a defect
 
 `assessment_incomplete` (severity **error**, *"1 list row(s) could not be
 confidence-scored"*) fired in 3 of 4 `core-tt-adv-int` runs (repeats 0, 1, 3) and
-**0 of 4** `core-tt-adv-sep` runs — matching the previous run exactly.
+**0 of 4** `core-tt-adv-sep` runs — matching the previous run exactly. Across both
+sessions: **6 of 8 integrated runs, 0 of 8 separate runs.**
 
-Across both sessions: **6 of 8 integrated runs, 0 of 8 separate runs.** That makes it
-a reproducible defect rather than a one-off, confined to `integrated` confidence
-mode. It is confidence *coverage*, not extraction data loss — recall is 1.000 — and
-it is consistent with the standing guidance to prefer `separate` on list-bearing
-schemas.
+⚠️ **Correction to the first version of this file, which called it "a reproducible
+defect". It is a reproducible *observation on a configuration that switched off the
+recovery mechanism built for exactly this case.*** Both cells ran with:
 
-It is **not diagnosed and not fixed**, and no before/after claim is made: the
-pre-fix run had zero rows to score, so there is nothing to compare against. Needs
-its own investigation.
+```
+escalation_enabled = False          # the model-escalation rung, disabled
+escalation_model   = us.anthropic.claude-sonnet-5:1m
+geometry.mode      = ocr_only       # the documented per-row-output remedy, already applied
+```
+
+`assessment_incomplete` fires only when rows remain unscored **after the full
+self-healing ladder** (shrink batch → retry → escalate model). With
+`escalation_enabled: false`, `batching.py` sets `ladder_escalation_model = None`, so
+the third rung never ran. That is deliberate in the benchmark, not a mistake here:
+`default_cell` holds `escalation: "off"` so escalation cost does not confound
+cross-cell cost comparisons — which makes these cells the wrong instrument for
+judging whether the ladder can recover the row.
+
+**The run that settles it:** `advverify` with `--set escalation=on`. If the row
+recovers, this is a config artifact. If it does not, it is a real ceiling worth
+chasing. Until then it is neither a product defect nor an inherent limitation.
+
+What the data *does* support: **integrated is more exposed than separate**, the
+expected direction — integrated carries confidence in one larger response, so a
+batch is likelier to hit the output ceiling, while `separate` gives the confidence
+model its own budget. That corroborates the standing guidance to prefer `separate`
+on list-bearing schemas rather than revealing anything new.
+
+Not diagnosed further because the raw `split_stats` (carried on the issue's
+`details`, and the one thing that would say *why* that row failed) became
+unreadable: the stack was torn down and its KMS key entered `PendingDeletion`
+before the section artifacts were pulled. **Pull section artifacts before tearing a
+stack down.**
+
+It **is** surfaced properly. Severity `error` makes the processing report's status
+line read `COMPLETED WITH ERRORS`; the issue is listed with its root cause (
+confidence model, geometry mode, derived-vs-configured batch size, truncated-call
+count, escalation chain); and the section renders an `error` status indicator in the
+UI's Processing Issues column with a popover, plus the full text in the Processing
+Report tab. Nothing about it is silent.
 
 ## No cost claim from this run
 


### PR DESCRIPTION
## Correcting a published claim of mine

I published the `assessment_incomplete` residual as **"a reproducible defect"** in both `advverify` FINDINGS files. It is not one, and the reason is in the resolved config I failed to read before attributing it to the product.

Both cells ran with:

```
escalation_enabled = False          # the model-escalation rung, DISABLED
escalation_model   = us.anthropic.claude-sonnet-5:1m
geometry.mode      = ocr_only       # the documented per-row-output remedy, already applied
```

`assessment_incomplete` fires **only when rows remain unscored after the full self-healing ladder** — shrink batch → retry → escalate model. With `escalation_enabled: false`, `batching.py:1155` does:

```python
ladder_escalation_model = escalation_model if escalation_enabled else None
```

…so the third rung never ran. The ladder had shrink+retry only.

And that setting is **deliberate in the benchmark**, not a slip in my run: `default_cell` holds `escalation: "off"` so escalation cost doesn't confound cross-cell cost comparisons. Which makes these cells precisely the wrong instrument for judging whether that row is recoverable.

So: a reproducible **observation on a configuration that declines the recovery mechanism built for exactly this case** — neither a demonstrated product defect nor a demonstrated inherent limit.

## What both files now say

- The escalation-off precondition, with the config block and the `batching.py` mechanism.
- **The run that settles it:** `advverify --set escalation=on`. Row recovers → config artifact. Row doesn't → a real ceiling worth chasing. *(Running now on a fresh stack.)*
- A clean separation of what the data **does** support — **integrated is more exposed than separate** (6/8 vs 0/8), the expected direction since integrated carries confidence in one larger response while `separate` gets its own output budget, corroborating existing guidance rather than revealing anything new — from what it does **not** support (any recoverability claim).
- That the raw `split_stats` (on the issue's `details`, the one thing that would say *why* that row failed) are **gone**: the teardown put the stack's KMS key into `PendingDeletion` before the section artifacts were pulled → `KMS.KMSInvalidStateException` on every `GetObject`. Recorded as a rule: **pull `sections/N/result.json` before tearing a stack down.**
- That the issue **is** surfaced properly, verified in code, not assumed: severity `error` drives `COMPLETED WITH ERRORS` on the report status line (`service.py:2293`), the issue and its root cause are listed (`service.py:2512-2523`), and the section renders an `error` status indicator with a popover in the UI's **Processing Issues** column (`SectionsPanel.tsx:161`, `processing-issues-utils.ts`) plus full text in the **Processing Report** tab. Nothing about it is silent.

Docs only — no code changes. `make lint-cicd` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)