### PR TITLE
fix(ui): stop the Configuration Profiles table wrapping and shrink its footprint

### DIFF
--- a/docs/configuration-profiles.md
+++ b/docs/configuration-profiles.md
@@ -262,9 +262,13 @@ The **View/Edit Configuration** page includes a Configuration Profiles table tha
 | **Profile Name** | Unique identifier (e.g., `default`, `Production`, `lending`) — click to open in editor |
 | **Type** | Badges showing **Managed** (blue) or **Custom** (grey), plus **Active** (green) if applicable. Sortable. |
 | **Description** | Optional description (max 200 characters) |
-| **Created** | Timestamp when the profile was first created |
 | **Updated** | Timestamp of the last modification |
 | **History** | Number of retained revisions — click to open the revision history |
+
+**Created** is available in the preferences gear but hidden by default: two
+timestamps cost a column for something **Updated** already answers, and the table
+sits above the configuration editor, so every column it does not need is vertical
+space taken from the thing you came to edit.
 
 The table includes a **type filter** (All / Managed / Custom) and a **preferences gear** to configure page size and visible columns.
 

--- a/src/ui/src/components/configuration-layout/ConfigurationVersionsTable.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationVersionsTable.tsx
@@ -76,7 +76,10 @@ const VISIBLE_CONTENT_OPTIONS = [
 
 const DEFAULT_PREFERENCES = {
   pageSize: 10,
-  visibleContent: ['versionName', 'type', 'description', 'createdAt', 'updatedAt', 'history'],
+  // Created is available in the preferences gear but off by default: two
+  // timestamps cost a whole column for information the Updated column already
+  // answers, and the extra column is what squeezed the others into wrapping.
+  visibleContent: ['versionName', 'type', 'description', 'updatedAt', 'history'],
   wrapLines: false,
 };
 
@@ -135,7 +138,6 @@ const ConfigurationVersionsTable = ({
         </Box>
       ),
       sortingField: 'versionName',
-      width: '25%',
     },
     {
       id: 'type',
@@ -163,27 +165,26 @@ const ConfigurationVersionsTable = ({
         const bType = isVersionManaged(b) ? 'managed' : 'custom';
         return aType.localeCompare(bType);
       },
-      width: 160,
+      width: 150,
     },
     {
       id: 'description',
       header: 'Description',
       cell: (item: ConfigVersion) => item.description || '-',
-      width: '25%',
     },
     {
       id: 'createdAt',
       header: 'Created',
       cell: (item: ConfigVersion) => (item.createdAt ? new Date(item.createdAt).toLocaleString() : '-'),
       sortingField: 'createdAt',
-      width: '20%',
+      width: 180,
     },
     {
       id: 'updatedAt',
       header: 'Updated',
       cell: (item: ConfigVersion) => (item.updatedAt ? new Date(item.updatedAt).toLocaleString() : '-'),
       sortingField: 'updatedAt',
-      width: '20%',
+      width: 180,
     },
     {
       id: 'history',
@@ -198,7 +199,7 @@ const ConfigurationVersionsTable = ({
           {item.latestRevision ? `${item.latestRevision} revision${item.latestRevision === 1 ? '' : 's'}` : 'History'}
         </Button>
       ),
-      width: 140,
+      width: 130,
     },
   ];
 
@@ -260,6 +261,9 @@ const ConfigurationVersionsTable = ({
         loadingText="Loading profiles..."
         resizableColumns
         stripedRows
+        // The profile table sits ABOVE the configuration editor, so its vertical
+        // footprint is what pushes the thing you came to edit off-screen.
+        contentDensity="compact"
         selectionType="multi"
         selectedItems={selectedItems}
         onSelectionChange={({ detail }) => {


### PR DESCRIPTION
The Configuration Profiles table wrapped its rows by default, eating vertical space above the configuration editor.

## Cause

A width budget I over-committed when adding the History column in #690:

| Column | Requested |
|---|---|
| Profile Name | 25% |
| Type | 160px |
| Description | 25% |
| Created | 20% |
| Updated | 20% |
| History | 140px |

Percentages sum to **90%** while two more columns ask for a further **300px**, so every column is squeezed below its content on any viewport and the text wraps. Not a preference problem — `wrapLines` was already false.

## Fix

- **Widths are fixed only where content size is predictable** (Type, Updated, History = 640px). Profile Name and Description carry free text, so they get no explicit width and flex into what remains. The budget can no longer over-commit however many columns are visible.
- **Created is off by default**, still available in the preferences gear. Two timestamps cost a whole column to answer what Updated already answers.
- **Compact content density**, matching `TestComparison` — roughly a third less vertical space per row. That is the substance of the complaint: this table sits *above* the editor, so its height pushes the thing you came to edit off-screen.

## Why not tabs

Considered splitting profile browsing and configuration editing into separate tabs. Against: the profile list is both how you navigate *to* a configuration and how you activate or compare one *afterwards*, so a tab adds a click to every switch and costs the "which profile am I editing" context that the current layout gives for free. The section is already collapsible for anyone who wants it out of the way. If it still feels busy after this, the next lever I would pull is collapsing that section automatically once a profile is open — smaller change, keeps one page.

UI lint, `tsc --noEmit`, and 352 UI tests green. No backend change, so no redeploy needed beyond a UI rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)