### PR TITLE
fix(ui): finish the Configuration Profile rename across the UI

### DIFF
--- a/docs/configuration-profiles.md
+++ b/docs/configuration-profiles.md
@@ -97,10 +97,10 @@ Configuration versions fall into two categories, indicated by a **Type** badge i
 - **Overwritten on stack updates** — always reflect the latest defaults shipped with the solution
 - **Save disabled** — the "Save changes" button is disabled and an info banner explains the config is stack-managed
 - **Delete disabled** — managed versions cannot be deleted in the UI or via the API
-- **Editable copies** — use "Save as Version" to create a custom, editable copy from any managed version
+- **Editable copies** — use "Save as Profile" to create a custom, editable copy from any managed profile
 - **Test Studio integration** — when a test set is selected in Test Studio, the matching managed config version is auto-selected
 
-> **Tip:** To customize a managed configuration, open it, then click **Save as Version** to create an editable copy. The original managed version remains untouched and will continue to be updated with solution upgrades.
+> **Tip:** To customize a managed configuration, open it, then click **Save as Profile** to create an editable copy. The original managed profile remains untouched and will continue to be updated with solution upgrades.
 
 For full details on managed configuration deployment and the config library, see [Configuration — Managed Configuration Versions](configuration.md#managed-configuration-versions).
 
@@ -294,9 +294,9 @@ When you open a version in the configuration editor:
 #### Unsaved Changes Indicator
 
 - Individual fields with unsaved edits display an **orange dot** (●) next to the field label
-- An **info banner** appears at the top: *"You have unsaved changes. Click Save changes to persist, or Discard changes to revert."* — this appears for **all** versions, including the stack-managed `default` (where the banner instead points you to **Save as Version**, since Save changes is disabled)
+- An **info banner** appears at the top: *"You have unsaved changes. Click Save changes to persist, or Discard changes to revert."* — this appears for **all** profiles, including the stack-managed `default` (where the banner instead points you to **Save as Profile**, since Save changes is disabled)
 - The **Discard changes** button reloads the last-saved configuration from the server
-- A successful save (or Save as Version / Reset to Default) also shows a brief **success toast** in the top-right notification area, visible even when scrolled deep in a long form
+- A successful save (or Save as Profile / Reset to Default) also shows a brief **success toast** in the top-right notification area, visible even when scrolled deep in a long form
 
 #### Browser Navigation Guard
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ The stack automatically deploys **managed configuration versions** for each pre-
 - **Overwritten on stack updates** — always reflect the latest defaults shipped with the solution
 - **Save disabled** — the Save button is disabled and an info banner explains the config is stack-managed
 - **Delete disabled** — managed versions cannot be deleted in the UI or via the API
-- **Editable copies** — use "Save as Version" to create a custom, editable copy
+- **Editable copies** — use "Save as Profile" to create a custom, editable copy
 - **Not importable** — managed configs are stored separately (`config_library/managed_config/`) and do not appear in the configuration import browser
 - **Test Studio integration** — when a test set is selected, the matching managed config version is auto-selected
 
@@ -52,7 +52,7 @@ For comprehensive documentation, see [configuration-profiles.md](configuration-p
 
 ### Configuration Management Features
 
-- **Save Changes**: Save your current configuration changes. The button is **enabled only when you have unsaved changes** (comparing your edits against the last saved configuration); when it's disabled on a stack-managed version, hovering it explains why. After a successful save, a confirmation banner **and** a brief success toast (top-right notification area) are shown. Less-frequent actions (Export, Save as default, Restore default (All), Save as Version, and BDA sync) are grouped under an **Actions** menu next to Save changes.
+- **Save Changes**: Save your current configuration changes. The button is **enabled only when you have unsaved changes** (comparing your edits against the last saved configuration); when it's disabled on a stack-managed version, hovering it explains why. After a successful save, a confirmation banner **and** a brief success toast (top-right notification area) are shown. Less-frequent actions (Export, Save as default, Restore default (All), Save as Profile, and BDA sync) are grouped under an **Actions** menu next to Save changes.
 - **Unsaved Changes Indicator**: Individual fields with unsaved edits display an orange dot next to the field label, and an info banner with a "Discard changes" button appears when the configuration form has unsaved edits (shown on all versions, including the stack-managed `default`).
 - **Browser Navigation Guard**: The browser warns before leaving the page when unsaved configuration changes exist (both on browser close/refresh and SPA navigation).
 - **Save as Default**: Save your current version's configuration as the new default baseline. This replaces the existing default configuration. **Warning**: Default configurations may be overwritten during solution upgrades - export your configuration first for backup.

--- a/docs/proposals/config-profiles-and-revisions.md
+++ b/docs/proposals/config-profiles-and-revisions.md
@@ -313,7 +313,7 @@ Phases 0, 1 and 2 are implemented. Three deliberate departures in Phases 0–1:
 2. **No `compareConfigProfileRevisions` API.** The UI fetches both revisions and
    reuses the existing client-side `ConfigurationComparison` diff, so the server
    gained no comparison endpoint. Fewer moving parts, identical output.
-3. **The feature-preset change is deferred.** `apply_feature_config_preset` still
+3. **The feature-preset change is deferred** ([#697](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/697)). `apply_feature_config_preset` still
    mints `<feature>-v<semver>` profile names. It writes raw sparse rows directly with
    `put_item` (bypassing `ConfigurationManager`), has no `idp_common` layer and no
    configuration-bucket access, and its version names are load-bearing for feature
@@ -438,19 +438,34 @@ badly (§5.1), so their spread is itself worth watching.
    nobody will turn.
 3. ~~**Should `Viewer` see revision history?**~~ **Resolved:** yes, read-only, for
    in-scope profiles — consistent with `getConfigVersion`.
-3b. ~~**Confidence-curve keying**~~ **Resolved for now:** curves stay keyed per
+4. ~~**Confidence-curve keying**~~ **Resolved for now:** curves stay keyed per
    profile. Fingerprint keying was deliberately not wired, because doing it at only
    the call site that knows the pinned revision (a scoring run) while review
    observations kept landing on the profile key would split the two data sources the
    estimate reads — worse than today. Each revision records a
    `confidenceFingerprint` so the switch is cheap once all three call sites can
-   supply it.
-4. **Author-created profiles**, ever? Staying Admin-only keeps the privilege boundary
+   supply it. Tracked as
+   [#698](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/698).
+5. **Author-created profiles**, ever? Staying Admin-only keeps the privilege boundary
    clean, but a scoped Author still needs an Admin to start a genuinely new use case.
    An alternative is "Author may create a profile *within a family they are scoped
    to*", which requires the families work closed above. **Open on purpose**: this is
    the question a customer request would answer, and answering it speculatively is
    how the grouping layer would get built for nobody.
+6. ~~**A revision picker in Capacity Planning?**~~ **Decided against.** Capacity
+   Planning estimates throughput and cost *from* a configuration, so pinning a
+   revision would let you ask "what would this have cost under r5?" — coherent, and
+   the selector component already exists, so it is cheap. It is not being added
+   because nobody asked for it, and a control that exists only because it was easy is
+   a control someone has to understand. Revisit if a real capacity question turns out
+   to need a historical configuration.
+7. ~~**Auto-collapse the profiles section once a profile is open?**~~ **Decided
+   against for now.** `versionsTableExpanded` always defaults to true; the change
+   would expand it when nothing is selected and collapse it while editing (~10 lines).
+   The vertical-footprint complaint it was meant to answer was instead fixed at the
+   source — the table's width budget was over-committed, so rows wrapped; with that
+   fixed plus compact density and one fewer column, the section no longer dominates
+   the page. Revisit only if the page still reads as busy in daily use.
 
 ## 14. Related
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -96,7 +96,7 @@ HITL REVIEW
 CONFIGURATION
   View config profiles            ✅      ✅†      ❌        ✅†
   View/Edit configuration         ✅      ✅†      ❌        ❌
-  Save as Version (new profile)   ✅      ❌       ❌        ❌
+  Save as Profile (new profile)   ✅      ❌       ❌        ❌
   Save as Default                 ✅      ❌       ❌        ❌
   Delete config profile           ✅      ❌       ❌        ❌
   Set active profile              ✅      ✅†      ❌        ❌
@@ -351,7 +351,7 @@ The UI adapts based on the user's role and scope:
 - Action buttons (delete, reprocess, upload, save, import) are hidden for roles that can't perform those actions
 - Version dropdowns are automatically filtered to show only scoped versions
 - The top navigation badge shows the user's role with color coding (blue=Admin, green=Author, grey=Reviewer/Viewer)
-- **Admin-only buttons**: "Save as Version", "Save as Default" in Configuration; Import/Restore/Save in Pricing and Model Limits
+- **Admin-only buttons**: "Save as Profile", "Save as Default" in Configuration; Import/Restore/Save in Pricing and Model Limits
 - **Pricing page**: Shows "View Pricing" (read-only) for non-admin; "Pricing Configuration" (editable) for admin
 - **Model Limits page**: Shows "View Model Limits" (read-only) for non-admin; "Model Limits Configuration" (editable) for admin
 

--- a/src/ui/src/components/agent-chat/AgentChatLayout.tsx
+++ b/src/ui/src/components/agent-chat/AgentChatLayout.tsx
@@ -155,7 +155,7 @@ const AgentChatLayout = ({
         `documents (introduce the term gently, do not assume I already know it). Then ask whether I'd ` +
         `like to adjust any fields or start processing my documents. Keep it concise; save deeper ` +
         `configuration-version details for if I ask.\n\n` +
-        `[Discovery saved the schema to configuration version "${result.configVersion}". Its fields ` +
+        `[Discovery saved the schema to configuration profile "${result.configVersion}". Its fields ` +
         `are not shown here — call get_class_schema for version "${result.configVersion}" before ` +
         `answering questions about the fields or refining them.]`;
       setAttachedFiles([]);

--- a/src/ui/src/components/capacity-planning/CapacityPlanningLayout.tsx
+++ b/src/ui/src/components/capacity-planning/CapacityPlanningLayout.tsx
@@ -215,7 +215,7 @@ const CapacityPlanningLayout = () => {
       if (activeVersion) {
         const activeVersionOption = versionOptions.find((option) => option.value === activeVersion.versionName);
         if (activeVersionOption) {
-          console.log('Setting selected config version to active:', activeVersionOption.value);
+          console.log('Setting selected configuration profile to active:', activeVersionOption.value);
           setSelectedConfigVersion(activeVersionOption);
           return;
         }
@@ -1271,7 +1271,7 @@ const CapacityPlanningLayout = () => {
     setHasCalculated(false);
     try {
       // Fetch the latest configuration before calculating
-      // IMPORTANT: Use the selected config version, not 'default'
+      // IMPORTANT: Use the selected configuration profile, not 'default'
       if (selectedConfigVersion) {
         await fetchConfiguration(selectedConfigVersion.value, true);
       }
@@ -1920,9 +1920,9 @@ const CapacityPlanningLayout = () => {
     csvContent += `Export Date:,${new Date().toISOString()}\n`;
     csvContent += `Pattern:,${getDeployedPattern().toUpperCase()}\n`;
 
-    // Configuration version information
+    // Configuration profile information
     const currentVersion = versions.find((v) => v.versionName === selectedConfigVersion?.value);
-    csvContent += `Configuration Version:,${selectedConfigVersion?.value || 'Not selected'}\n`;
+    csvContent += `Configuration Profile:,${selectedConfigVersion?.value || 'Not selected'}\n`;
     if (currentVersion?.description) {
       csvContent += `Version Description:,"${currentVersion.description}"\n`;
     }
@@ -2046,14 +2046,14 @@ const CapacityPlanningLayout = () => {
           variant="h1"
           actions={
             <SpaceBetween direction="horizontal" size="s">
-              <FormField label="Configuration Version">
+              <FormField label="Configuration Profile">
                 <Select
                   selectedOption={selectedConfigVersion}
                   onChange={({ detail }) => setSelectedConfigVersion(detail.selectedOption as SelectOption)}
                   options={getVersionOptions()}
-                  placeholder={versions.length === 0 ? 'Loading versions...' : 'Select config version'}
+                  placeholder={versions.length === 0 ? 'Loading profiles...' : 'Select configuration profile'}
                   disabled={versions.length === 0}
-                  loadingText="Loading versions..."
+                  loadingText="Loading profiles..."
                 />
               </FormField>
               <Button variant="primary" iconName="download" onClick={exportCapacityPlan}>
@@ -2068,11 +2068,11 @@ const CapacityPlanningLayout = () => {
         {/* Configuration Status Alert */}
         {configuration && (
           <Alert type="success">
-            <strong>✓</strong> Using configuration version: <Badge color="green">{selectedConfigVersion?.value || 'default'}</Badge>
+            <strong>✓</strong> Using configuration profile: <Badge color="green">{selectedConfigVersion?.value || 'default'}</Badge>
             {selectedConfigVersion?.label?.includes('Active') && <Badge color="blue">Active</Badge>}
             <Box margin={{ top: 'xs' }}>
               Token calculations and processing times are loaded from your pattern configuration. Update models in{' '}
-              <strong>View/Edit Configuration</strong> to see changes reflected immediately, or select a different configuration version
+              <strong>View/Edit Configuration</strong> to see changes reflected immediately, or select a different configuration profile
               above.
             </Box>
           </Alert>
@@ -2735,7 +2735,7 @@ const CapacityPlanningLayout = () => {
           loading={loading}
           disabled={!selectedConfigVersion || !configuration}
         >
-          {!selectedConfigVersion ? 'Loading configuration version...' : 'Calculate Capacity Requirements'}
+          {!selectedConfigVersion ? 'Loading configuration profile...' : 'Calculate Capacity Requirements'}
         </Button>
 
         {results?.success === false && results?.metrics && (

--- a/src/ui/src/components/chat-panel/ChatPanel.tsx
+++ b/src/ui/src/components/chat-panel/ChatPanel.tsx
@@ -553,8 +553,8 @@ const ChatPanel = ({ objectKey, configVersion = 'default' }: ChatPanelProps): Re
               label="Model"
               description={
                 modelOptions.length
-                  ? `Default from configuration version "${configVersion}". Choose a larger-context model if the document is very long.`
-                  : `Default model from configuration version "${configVersion}". (Model list not available — using configured default.)`
+                  ? `Default from configuration profile "${configVersion}". Choose a larger-context model if the document is very long.`
+                  : `Default model from configuration profile "${configVersion}". (Model list not available — using configured default.)`
               }
             >
               {modelOptions.length > 0 ? (

--- a/src/ui/src/components/common/ReprocessDocumentModal.tsx
+++ b/src/ui/src/components/common/ReprocessDocumentModal.tsx
@@ -116,19 +116,19 @@ const ReprocessDocumentModal = ({
 
         {isPattern1 && (
           <Alert type="info">
-            <strong>NOTE:</strong> To ensure that BDA project blueprints are aligned with your selected config version, be sure to execute
-            &quot;Sync To BDA&quot; for your config version from the View/Edit Configuration page.
+            <strong>NOTE:</strong> To ensure that BDA project blueprints are aligned with your selected configuration profile, be sure to
+            execute &quot;Sync To BDA&quot; for your configuration profile from the View/Edit Configuration page.
           </Alert>
         )}
 
-        <FormField label="Configuration Version" description="Select which configuration version to use for reprocessing these documents">
+        <FormField label="Configuration Profile" description="Select which configuration profile to use for reprocessing these documents">
           <Select
             selectedOption={selectedVersion}
             onChange={({ detail }) => setSelectedVersion(detail.selectedOption)}
             options={getVersionOptions()}
-            placeholder={versions.length === 0 ? 'Loading versions...' : 'Select configuration version'}
+            placeholder={versions.length === 0 ? 'Loading profiles...' : 'Select configuration profile'}
             disabled={isLoading || versions.length === 0}
-            loadingText="Loading versions..."
+            loadingText="Loading profiles..."
           />
         </FormField>
 

--- a/src/ui/src/components/common/config-class-options.ts
+++ b/src/ui/src/components/common/config-class-options.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 /**
- * The document classes a config version defines, as dropdown options.
+ * The document classes a configuration profile defines, as dropdown options.
  *
  * Shared by human review and Test Studio annotation: both correct a misclassified
  * section, and both must offer exactly the classes the bound config knows about,

--- a/src/ui/src/components/configuration-layout/ConfigBuilder.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigBuilder.tsx
@@ -1882,14 +1882,14 @@ const ConfigBuilder = ({
                 <SpaceBetween size="l">
                   {/* Version Description Field */}
                   <FormField
-                    label="Version Description"
-                    description="Optional description for this configuration version (max 200 characters)"
+                    label="Profile Description"
+                    description="Optional description for this configuration profile (max 200 characters)"
                     errorText={versionDescription && versionDescription.length > 200 ? 'Description cannot exceed 200 characters' : ''}
                   >
                     <Input
                       value={versionDescription}
                       onChange={({ detail }) => onDescriptionChange?.(detail.value)}
-                      placeholder="Enter a description for this configuration version..."
+                      placeholder="Enter a description for this configuration profile..."
                       invalid={!!versionDescription && versionDescription.length > 200}
                     />
                   </FormField>

--- a/src/ui/src/components/configuration-layout/ConfigurationComparison.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationComparison.tsx
@@ -359,7 +359,7 @@ const ConfigurationComparison = ({ versions, configs }: ConfigurationComparisonP
         <Box textAlign="center" color="inherit">
           <SpaceBetween size="m">
             <b>No differences found</b>
-            <Box variant="p">The selected configuration versions are identical.</Box>
+            <Box variant="p">The selected configuration profiles are identical.</Box>
           </SpaceBetween>
         </Box>
       ) : (

--- a/src/ui/src/components/configuration-layout/ConfigurationLayout.tsx
+++ b/src/ui/src/components/configuration-layout/ConfigurationLayout.tsx
@@ -47,7 +47,7 @@ const logger = new ConsoleLogger('ConfigurationLayout');
 
 // Shown as the disabled-reason tooltip on actions that cannot run against the
 // stack-managed `default` version (the user must first create an editable copy).
-const STACK_MANAGED_DISABLED_REASON = 'This is the stack-managed default version — use Save as Version to create an editable copy.';
+const STACK_MANAGED_DISABLED_REASON = 'This is the stack-managed default profile — use Save as Profile to create an editable copy.';
 
 // One-line explanations shown on hover for the version Type/state badges.
 const BADGE_TOOLTIPS = {
@@ -1991,7 +1991,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
 
   return (
     <SpaceBetween size="s">
-      {/* Configuration Versions Table */}
+      {/* Configuration Profiles Table */}
       <ExpandableSection
         headerText="Configuration Profiles"
         headingTagOverride="h1"
@@ -2082,7 +2082,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
       <Modal
         visible={showSaveAsVersionModal}
         onDismiss={() => setShowSaveAsVersionModal(false)}
-        header="Save as New Version"
+        header="Save as New Profile"
         footer={
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
@@ -2090,7 +2090,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
                 Cancel
               </Button>
               <Button variant="primary" onClick={handleSaveAsVersion} loading={isSaving} disabled={!saveAsVersionName.trim()}>
-                Save as Version
+                Save as Profile
               </Button>
             </SpaceBetween>
           </Box>
@@ -2103,8 +2103,8 @@ const ConfigurationLayout = (): React.JSX.Element => {
             </Alert>
           )}
           <FormField
-            label="Version Name"
-            description="Enter a unique name for this configuration version"
+            label="Profile Name"
+            description="Enter a unique name for this configuration profile"
             errorText={
               saveAsVersionName && !/^[a-zA-Z0-9._-]+$/.test(saveAsVersionName)
                 ? 'Version name can only contain letters, numbers, periods, hyphens, and underscores'
@@ -2118,14 +2118,14 @@ const ConfigurationLayout = (): React.JSX.Element => {
             />
           </FormField>
           <FormField
-            label="Version Description (Optional)"
-            description="Optional description for this version (max 200 characters)"
+            label="Profile Description (Optional)"
+            description="Optional description for this profile (max 200 characters)"
             errorText={saveAsVersionDescription && saveAsVersionDescription.length > 200 ? 'Description cannot exceed 200 characters' : ''}
           >
             <Input
               value={saveAsVersionDescription}
               onChange={({ detail }) => setSaveAsVersionDescription(detail.value)}
-              placeholder="Enter a description for this version..."
+              placeholder="Enter a description for this profile..."
             />
           </FormField>
         </SpaceBetween>
@@ -2211,7 +2211,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
           setImportError(null);
           setShowImportSourceModal(false);
         }}
-        header="Import as New Version"
+        header="Import as New Profile"
         footer={
           <Box float="right">
             <Button variant="link" onClick={() => setShowImportSourceModal(false)}>
@@ -2371,7 +2371,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
                       ? [
                           {
                             id: 'save-as-version',
-                            text: 'Save as Version…',
+                            text: 'Save as Profile…',
                             disabled: validationErrors.length > 0,
                             disabledReason: 'Resolve validation errors first',
                           },
@@ -2502,13 +2502,13 @@ const ConfigurationLayout = (): React.JSX.Element => {
                       setShowSaveAsVersionModal(true);
                     }}
                   >
-                    Save as Version
+                    Save as Profile
                   </Button>
                 ) : undefined
               }
             >
               This configuration is managed by the stack and cannot be saved directly. It will be overwritten on stack updates. Use{' '}
-              <strong>Save as Version</strong> to create an editable copy.
+              <strong>Save as Profile</strong> to create an editable copy.
             </Alert>
           )}
 
@@ -2641,7 +2641,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
               {currentVersionName === 'default' || currentVersion?.managed === true ? (
                 <>
                   You have unsaved changes to this stack-managed version, which can&rsquo;t be saved directly. Use{' '}
-                  <strong>Save as Version</strong> to keep them as an editable copy, or <strong>Discard changes</strong> to revert.
+                  <strong>Save as Profile</strong> to keep them as an editable copy, or <strong>Discard changes</strong> to revert.
                 </>
               ) : (
                 <>
@@ -2800,7 +2800,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
           setNewVersionName('');
           setNewVersionDescription('');
         }}
-        header="Create New Version"
+        header="Create New Profile"
         footer={
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
@@ -2842,7 +2842,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
           </Alert>
 
           <FormField
-            label="Version Name"
+            label="Profile Name"
             errorText={
               newVersionName &&
               (newVersionName.length > 50
@@ -2855,7 +2855,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
             <Input
               value={newVersionName}
               onChange={({ detail }) => setNewVersionName(detail.value)}
-              placeholder="Version name"
+              placeholder="Profile name"
               invalid={!!newVersionName && (newVersionName.length > 50 || !/^[a-zA-Z0-9._-]+$/.test(newVersionName))}
             />
           </FormField>
@@ -2961,7 +2961,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
                 {
                   value: 'create',
                   label: 'Create a new BDA project',
-                  description: 'A new BDA project will be automatically created for this config version.',
+                  description: 'A new BDA project will be automatically created for this configuration profile.',
                 },
                 {
                   value: 'existing',
@@ -3030,10 +3030,10 @@ const ConfigurationLayout = (): React.JSX.Element => {
         <SpaceBetween size="m">
           {syncFromBdaMode === 'replace' && (
             <Alert type="warning">
-              <strong>Replace</strong> mode will remove all document classes in this config version that are not in the BDA project.
+              <strong>Replace</strong> mode will remove all document classes in this configuration profile that are not in the BDA project.
             </Alert>
           )}
-          <FormField label="Sync Mode" description="Choose how BDA blueprints are applied to your config version.">
+          <FormField label="Sync Mode" description="Choose how BDA blueprints are applied to your configuration profile.">
             <RadioGroup
               value={syncFromBdaMode}
               onChange={({ detail }) => setSyncFromBdaMode(detail.value)}
@@ -3041,20 +3041,20 @@ const ConfigurationLayout = (): React.JSX.Element => {
                 {
                   value: 'replace',
                   label: 'Replace',
-                  description: 'Align config version with BDA project. Classes not in BDA will be removed.',
+                  description: 'Align configuration profile with BDA project. Classes not in BDA will be removed.',
                 },
                 {
                   value: 'merge',
                   label: 'Merge',
-                  description: 'Import BDA blueprints into config version. Existing classes will be kept.',
+                  description: 'Import BDA blueprints into configuration profile. Existing classes will be kept.',
                 },
               ]}
             />
           </FormField>
           {!currentVersion?.bdaProjectArn && (
             <Box>
-              No BDA project is currently linked to this config version. Enter the ARN of the BDA project to import blueprints from. The
-              project will be linked to this version for future syncs.
+              No BDA project is currently linked to this configuration profile. Enter the ARN of the BDA project to import blueprints from.
+              The project will be linked to this version for future syncs.
             </Box>
           )}
           {Boolean(currentVersion?.bdaProjectArn) && (
@@ -3091,7 +3091,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
           setShowActivateVersionConfirmModal(false);
           setActivateVersionTarget(null);
         }}
-        header="Confirm Activate Version"
+        header="Confirm Activate Profile"
         footer={
           <Box float="right">
             <SpaceBetween direction="horizontal" size="xs">
@@ -3127,7 +3127,7 @@ const ConfigurationLayout = (): React.JSX.Element => {
             {activateVersionTarget ? (
               <>
                 Activating version <strong>{activateVersionTarget}</strong> will first sync your IDP document classes to BDA blueprints,
-                then set it as the active configuration version.
+                then set it as the active configuration profile.
               </>
             ) : (
               <>No version selected. Please select a version to activate.</>

--- a/src/ui/src/components/configuration-layout/tools-panel.tsx
+++ b/src/ui/src/components/configuration-layout/tools-panel.tsx
@@ -22,7 +22,7 @@ const ToolsPanel = (): React.JSX.Element => (
           </li>
           <li>
             <a href={`${DOCS_BASE_URL}/configuration-versions/`} target="_blank" rel="noopener noreferrer">
-              Configuration Versions
+              Configuration Profiles
             </a>
           </li>
           <li>
@@ -49,7 +49,7 @@ const ToolsPanel = (): React.JSX.Element => (
       <p>
         Each configuration is a self-contained <strong>version</strong>. The <strong>default</strong> version is managed by the stack and is
         read-only — it is overwritten on stack upgrades. To customize it, open it and click <strong>Save as Version</strong> to create an
-        editable copy. Use the <strong>Configuration Versions</strong> table at the top of the page to open, activate, compare, import, or
+        editable copy. Use the <strong>Configuration Profiles</strong> table at the top of the page to open, activate, compare, import, or
         delete versions.
       </p>
 

--- a/src/ui/src/components/custom-models/CreateConfigVersionModal.tsx
+++ b/src/ui/src/components/custom-models/CreateConfigVersionModal.tsx
@@ -41,7 +41,7 @@ const CreateConfigVersionModal = ({
   const [error, setError] = useState<string | null>(null);
   const [description, setDescription] = useState('');
 
-  // Fetch config versions when modal opens
+  // Fetch configuration profiles when modal opens
   const fetchConfigVersions = useCallback(async () => {
     setVersionsLoading(true);
     try {
@@ -69,11 +69,11 @@ const CreateConfigVersionModal = ({
       if (data?.success && data.versions) {
         setConfigVersions(data.versions);
       } else {
-        setError(data?.error?.message || 'Failed to fetch configuration versions.');
+        setError(data?.error?.message || 'Failed to fetch configuration profiles.');
       }
     } catch (err) {
-      console.error('Error fetching config versions:', err);
-      setError('Failed to fetch configuration versions.');
+      console.error('Error fetching configuration profiles:', err);
+      setError('Failed to fetch configuration profiles.');
     } finally {
       setVersionsLoading(false);
     }
@@ -108,10 +108,10 @@ const CreateConfigVersionModal = ({
 
   const validateForm = (): string | null => {
     if (!selectedSourceVersion) {
-      return 'Please select a source configuration version.';
+      return 'Please select a source configuration profile.';
     }
     if (!newVersionName.trim()) {
-      return 'Please enter a name for the new configuration version.';
+      return 'Please enter a name for the new configuration profile.';
     }
     if (!/^[a-zA-Z0-9._-]+$/.test(newVersionName)) {
       return 'Version name can only contain letters, numbers, periods, hyphens, and underscores.';
@@ -124,7 +124,7 @@ const CreateConfigVersionModal = ({
     }
     // Check if version name already exists
     if (configVersions.some((v) => v.versionName === newVersionName)) {
-      return `A configuration version named "${newVersionName}" already exists. Please choose a different name.`;
+      return `A configuration profile named "${newVersionName}" already exists. Please choose a different name.`;
     }
     if (!useForExtraction && !useForClassification) {
       return 'Please select at least one option: Extraction or Classification.';
@@ -145,7 +145,7 @@ const CreateConfigVersionModal = ({
     try {
       const client = generateClient();
 
-      // Step 1: Fetch the source config version's full configuration
+      // Step 1: Fetch the source configuration profile's full configuration
       const configResponse = (await client.graphql({
         query: `
           query GetConfigVersion($versionName: String!) {
@@ -247,12 +247,12 @@ const CreateConfigVersionModal = ({
           const errorDetails = validationErrors.map((e) => `${e.field}: ${e.message}`).join('; ');
           throw new Error(`Configuration validation failed: ${errorDetails}`);
         }
-        throw new Error(updateData?.error?.message || 'Failed to create configuration version.');
+        throw new Error(updateData?.error?.message || 'Failed to create configuration profile.');
       }
 
       onSuccess(newVersionName);
     } catch (err) {
-      console.error('Error creating config version:', err);
+      console.error('Error creating configuration profile:', err);
       const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred.';
       setError(errorMessage);
     } finally {
@@ -274,7 +274,7 @@ const CreateConfigVersionModal = ({
     <Modal
       visible={visible}
       onDismiss={onDismiss}
-      header="Create Configuration Version with Custom Model"
+      header="Create Configuration Profile with Custom Model"
       footer={
         <Box float="right">
           <SpaceBetween direction="horizontal" size="xs">
@@ -301,29 +301,29 @@ const CreateConfigVersionModal = ({
         )}
 
         <Alert type="info">
-          This will create a new configuration version based on an existing one, with the custom model deployment ARN automatically set for
+          This will create a new configuration profile based on an existing one, with the custom model deployment ARN automatically set for
           the selected pipeline stages.
         </Alert>
 
         <FormField
-          label="Source Configuration Version"
-          description="Select the existing configuration version to copy as the base for the new version"
+          label="Source Configuration Profile"
+          description="Select the existing configuration profile to copy as the base for the new version"
         >
           <Select
             selectedOption={selectedSourceVersion}
             onChange={({ detail }) => setSelectedSourceVersion(detail.selectedOption as SelectOption)}
             options={versionOptions}
-            placeholder="Select a configuration version"
-            loadingText="Loading configuration versions..."
+            placeholder="Select a configuration profile"
+            loadingText="Loading configuration profiles..."
             statusType={versionsLoading ? 'loading' : 'finished'}
-            empty="No configuration versions available"
+            empty="No configuration profiles available"
             filteringType="auto"
           />
         </FormField>
 
         <FormField
-          label="New Version Name"
-          description="A unique name for the new configuration version (letters, numbers, hyphens, underscores)"
+          label="New Profile Name"
+          description="A unique name for the new configuration profile (letters, numbers, hyphens, underscores)"
           constraintText="Max 50 characters. Cannot be 'default'."
         >
           <Input
@@ -333,7 +333,7 @@ const CreateConfigVersionModal = ({
           />
         </FormField>
 
-        <FormField label="Description" description="Optional description for the new configuration version">
+        <FormField label="Description" description="Optional description for the new configuration profile">
           <Input
             value={description}
             onChange={({ detail }) => setDescription(detail.value)}

--- a/src/ui/src/components/custom-models/FinetuningJobDetail.tsx
+++ b/src/ui/src/components/custom-models/FinetuningJobDetail.tsx
@@ -452,7 +452,7 @@ const FinetuningJobDetail = (): React.JSX.Element => {
                               Bedrock InvokeModel API. The model is billed on-demand (pay-per-token) with no hourly charges.
                             </Alert>
                             <Button variant="primary" iconName="add-plus" onClick={() => setShowCreateConfigModal(true)}>
-                              Create Config Version
+                              Create Config Profile
                             </Button>
                           </SpaceBetween>
                         </Box>
@@ -538,7 +538,7 @@ const FinetuningJobDetail = (): React.JSX.Element => {
           </SpaceBetween>
         </Modal>
 
-        {/* Create Config Version Modal */}
+        {/* Create Config Profile Modal */}
         {job.customModelDeploymentArn && (
           <CreateConfigVersionModal
             visible={showCreateConfigModal}
@@ -550,14 +550,14 @@ const FinetuningJobDetail = (): React.JSX.Element => {
               addNotification(
                 'success',
                 <>
-                  Configuration version <strong>{versionName}</strong> created successfully with the custom model deployment ARN. You can
+                  Configuration profile <strong>{versionName}</strong> created successfully with the custom model deployment ARN. You can
                   view and edit it in the{' '}
                   <a href="#/configuration" style={{ color: 'inherit' }}>
                     Configuration
                   </a>{' '}
                   page.
                 </>,
-                'Config Version Created',
+                'Config Profile Created',
               );
             }}
           />

--- a/src/ui/src/components/discovery/CreateDiscoveryVersionModal.tsx
+++ b/src/ui/src/components/discovery/CreateDiscoveryVersionModal.tsx
@@ -4,7 +4,7 @@
 /**
  * CreateDiscoveryVersionModal
  *
- * Lets a user create a brand-new configuration version from within the
+ * Lets a user create a brand-new configuration profile from within the
  * Discovery panels, so discovered schema can be saved to a fresh version
  * without leaving the Discovery workflow.
  *
@@ -82,16 +82,16 @@ const CreateDiscoveryVersionModal = ({
   }, [visible, defaultSourceVersion]);
 
   const validate = useCallback((): string | null => {
-    if (!selectedSource) return 'Please select a source configuration version to copy from.';
+    if (!selectedSource) return 'Please select a source configuration profile to copy from.';
     const name = newVersionName.trim();
-    if (!name) return 'Please enter a name for the new configuration version.';
+    if (!name) return 'Please enter a name for the new configuration profile.';
     if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
       return 'Version name can only contain letters, numbers, periods, hyphens, and underscores.';
     }
     if (name.length > 50) return 'Version name cannot exceed 50 characters.';
     if (name === 'default') return 'Cannot use "default" as a version name — it is reserved.';
     if (versions.some((v) => v.versionName === name)) {
-      return `A configuration version named "${name}" already exists. Please choose a different name.`;
+      return `A configuration profile named "${name}" already exists. Please choose a different name.`;
     }
     return null;
   }, [selectedSource, newVersionName, versions]);
@@ -115,11 +115,11 @@ const CreateDiscoveryVersionModal = ({
       const name = newVersionName.trim();
       const result = await saveAsNewVersion(fullConfig, name, description.trim() || `Created from ${selectedSource!.value} for discovery`);
       if (!result.success) {
-        throw new Error(result.error || 'Failed to create configuration version.');
+        throw new Error(result.error || 'Failed to create configuration profile.');
       }
       onCreated(name);
     } catch (err) {
-      console.error('Error creating discovery config version:', err);
+      console.error('Error creating discovery configuration profile:', err);
       setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
     } finally {
       setCreating(false);
@@ -130,7 +130,7 @@ const CreateDiscoveryVersionModal = ({
     <Modal
       visible={visible}
       onDismiss={onDismiss}
-      header="Create New Configuration Version"
+      header="Create New Configuration Profile"
       footer={
         <Box float="right">
           <SpaceBetween direction="horizontal" size="xs">
@@ -152,24 +152,24 @@ const CreateDiscoveryVersionModal = ({
         )}
 
         <Alert type="info">
-          Creates a new configuration version that inherits its settings and document classes from the selected source version. Discovered
+          Creates a new configuration profile that inherits its settings and document classes from the selected source version. Discovered
           schema will then be saved to this new version.
         </Alert>
 
-        <FormField label="Copy from version" description="The existing configuration version to use as the base for the new version">
+        <FormField label="Copy from profile" description="The existing configuration profile to use as the base for the new version">
           <Select
             selectedOption={selectedSource}
             onChange={({ detail }) => setSelectedSource(detail.selectedOption)}
             options={getVersionOptions()}
-            placeholder="Select a source version"
+            placeholder="Select a source profile"
             filteringType="auto"
-            empty="No configuration versions available"
+            empty="No configuration profiles available"
           />
         </FormField>
 
         <FormField
-          label="New version name"
-          description="A unique name for the new configuration version"
+          label="New profile name"
+          description="A unique name for the new configuration profile"
           constraintText="Letters, numbers, periods, hyphens, underscores. Max 50 characters. Cannot be 'default'."
         >
           <Input
@@ -179,7 +179,7 @@ const CreateDiscoveryVersionModal = ({
           />
         </FormField>
 
-        <FormField label="Description" description="Optional description for the new configuration version">
+        <FormField label="Description" description="Optional description for the new configuration profile">
           <Input value={description} onChange={({ detail }) => setDescription(detail.value)} placeholder="Optional description" />
         </FormField>
       </SpaceBetween>

--- a/src/ui/src/components/discovery/DiscoveryJobDetails.tsx
+++ b/src/ui/src/components/discovery/DiscoveryJobDetails.tsx
@@ -291,7 +291,7 @@ const DiscoveryJobDetails = (): React.JSX.Element => {
             </Box>
           </div>
           <div>
-            <Box variant="awsui-key-label">Config Version</Box>
+            <Box variant="awsui-key-label">Config Profile</Box>
             <Box>{formatConfigVersionLink(job.version, versions as unknown as ConfigVersion[])}</Box>
           </div>
           {isMultiDoc && (

--- a/src/ui/src/components/discovery/DiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/DiscoveryPanel.tsx
@@ -122,7 +122,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
   const [isLoadingJobs, setIsLoadingJobs] = useState(false);
   const [isValidatingJson, setIsValidatingJson] = useState(false);
   const [selectedVersion, setSelectedVersion] = useState<SelectProps.Option | null>(null);
-  // Save mode: 'augment' (default) adds to the version's existing schema;
+  // Save mode: 'augment' (default) adds to the profile's existing schema;
   // 'replace' clears it first so discovery rebuilds the schema from scratch.
   const [saveMode, setSaveMode] = useState<'augment' | 'replace'>('augment');
   const [showCreateVersionModal, setShowCreateVersionModal] = useState(false);
@@ -390,7 +390,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
       return;
     }
     if (selectedVersion?.value === 'default') {
-      setError('The "default" configuration version is read-only. Create a new version to save the discovered schema.');
+      setError('The "default" configuration profile is read-only. Create a new version to save the discovered schema.');
       return;
     }
 
@@ -690,7 +690,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
     },
     {
       id: 'version',
-      header: 'Config Version',
+      header: 'Config Profile',
       cell: (item: DiscoveryJob) => formatConfigVersionLink(item.version, versions as unknown as ConfigVersion[]),
       width: 140,
     },
@@ -780,17 +780,17 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
           </TextContent>
 
           <FormField
-            label="Configuration Version"
-            description="Select which configuration version to save the discovered document schema to, or create a new one"
+            label="Configuration Profile"
+            description="Select which configuration profile to save the discovered document schema to, or create a new one"
           >
             <SpaceBetween size="xs" direction="horizontal" alignItems="end">
               <Select
                 selectedOption={selectedVersion}
                 onChange={({ detail }) => setSelectedVersion(detail.selectedOption)}
                 options={getVersionOptions()}
-                placeholder={versions.length === 0 ? 'Loading versions...' : 'Select configuration version'}
+                placeholder={versions.length === 0 ? 'Loading profiles...' : 'Select configuration profile'}
                 disabled={isUploading || versionsLoading || versions.length === 0}
-                loadingText="Loading versions..."
+                loadingText="Loading profiles..."
               />
               <Button iconName="add-plus" onClick={() => setShowCreateVersionModal(true)} disabled={isUploading}>
                 Create new version
@@ -800,7 +800,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
 
           {selectedVersion?.value === 'default' && (
             <Alert type="warning">
-              The <strong>default</strong> configuration version is read-only and cannot be overwritten by discovery. Click{' '}
+              The <strong>default</strong> configuration profile is read-only and cannot be overwritten by discovery. Click{' '}
               <strong>Create new version</strong> to save the discovered schema to a new version (it will be seeded from{' '}
               <strong>default</strong>).
             </Alert>
@@ -808,7 +808,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
 
           <FormField
             label="Save mode"
-            description="Choose whether discovered classes are added to the version's existing schema or replace it"
+            description="Choose whether discovered classes are added to the profile's existing schema or replace it"
           >
             <RadioGroup
               value={saveMode}
@@ -1123,7 +1123,7 @@ const DiscoveryPanel = ({ discoveryType = 'classes' }: DiscoveryPanelProps = {})
                   label: 'Job properties',
                   options: [
                     { id: 'documentKey', label: 'Document' },
-                    { id: 'version', label: 'Config Version' },
+                    { id: 'version', label: 'Config Profile' },
                     { id: 'status', label: 'Status' },
                     { id: 'createdAt', label: 'Created' },
                     { id: 'elapsed', label: 'Duration' },

--- a/src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx
+++ b/src/ui/src/components/discovery/MultiDocDiscoveryPanel.tsx
@@ -153,11 +153,11 @@ const DEFAULT_PAGE_SIZE = 10;
 
 const MultiDocDiscoveryPanel = () => {
   const navigate = useNavigate();
-  // Settings & config versions
+  // Settings & configuration profiles
   const { settings } = useSettingsContext();
   const { versions, loading: versionsLoading, getVersionOptions, fetchVersions } = useConfigurationVersions();
   const [selectedVersion, setSelectedVersion] = useState<SelectProps.Option | null>(null);
-  // Save mode: 'augment' (default) adds to the version's existing schema;
+  // Save mode: 'augment' (default) adds to the profile's existing schema;
   // 'replace' clears it first so discovery rebuilds the schema from scratch.
   const [saveMode, setSaveMode] = useState<'augment' | 'replace'>('augment');
   const [showCreateVersionModal, setShowCreateVersionModal] = useState(false);
@@ -231,11 +231,11 @@ const MultiDocDiscoveryPanel = () => {
 
   const handleStartDiscovery = async () => {
     if (!selectedVersion) {
-      setError('Please select a configuration version');
+      setError('Please select a configuration profile');
       return;
     }
     if (selectedVersion.value === 'default') {
-      setError('The "default" configuration version is read-only. Create a new version to save the discovered schema.');
+      setError('The "default" configuration profile is read-only. Create a new version to save the discovered schema.');
       return;
     }
 
@@ -542,7 +542,7 @@ const MultiDocDiscoveryPanel = () => {
             <Box>{job.clustersFound ?? '—'}</Box>
           </div>
           <div>
-            <Box variant="awsui-key-label">Config Version</Box>
+            <Box variant="awsui-key-label">Config Profile</Box>
             <Box>{job.version || '—'}</Box>
           </div>
           <div>
@@ -675,7 +675,7 @@ const MultiDocDiscoveryPanel = () => {
     },
     {
       id: 'version',
-      header: 'Config Version',
+      header: 'Config Profile',
       cell: (item: MultiDocJob) => formatConfigVersionLink(item.version, versions as unknown as ConfigVersion[]),
       width: 140,
     },
@@ -755,18 +755,18 @@ const MultiDocDiscoveryPanel = () => {
         }
       >
         <SpaceBetween size="m">
-          {/* Config Version */}
+          {/* Config Profile */}
           <FormField
-            label="Configuration Version"
-            description="Discovered classes will be saved to this config version, or create a new one"
+            label="Configuration Profile"
+            description="Discovered classes will be saved to this configuration profile, or create a new one"
           >
             <SpaceBetween size="xs" direction="horizontal" alignItems="end">
               <Select
                 selectedOption={selectedVersion}
                 onChange={({ detail }) => setSelectedVersion(detail.selectedOption)}
                 options={getVersionOptions()}
-                placeholder="Select a configuration version"
-                loadingText="Loading versions..."
+                placeholder="Select a configuration profile"
+                loadingText="Loading profiles..."
                 statusType={versionsLoading ? 'loading' : 'finished'}
               />
               <Button iconName="add-plus" onClick={() => setShowCreateVersionModal(true)} disabled={starting}>
@@ -777,7 +777,7 @@ const MultiDocDiscoveryPanel = () => {
 
           {selectedVersion?.value === 'default' && (
             <Alert type="warning">
-              The <strong>default</strong> configuration version is read-only and cannot be overwritten by discovery. Click{' '}
+              The <strong>default</strong> configuration profile is read-only and cannot be overwritten by discovery. Click{' '}
               <strong>Create new version</strong> to save the discovered schema to a new version (it will be seeded from{' '}
               <strong>default</strong>).
             </Alert>
@@ -786,7 +786,7 @@ const MultiDocDiscoveryPanel = () => {
           {/* Save Mode */}
           <FormField
             label="Save mode"
-            description="Choose whether discovered classes are added to the version's existing schema or replace it"
+            description="Choose whether discovered classes are added to the profile's existing schema or replace it"
           >
             <RadioGroup
               value={saveMode}
@@ -990,7 +990,7 @@ const MultiDocDiscoveryPanel = () => {
                     { id: 'currentStep', label: 'Current Step' },
                     { id: 'totalDocuments', label: 'Documents' },
                     { id: 'clustersFound', label: 'Clusters' },
-                    { id: 'version', label: 'Config Version' },
+                    { id: 'version', label: 'Config Profile' },
                     { id: 'createdAt', label: 'Created' },
                     { id: 'duration', label: 'Duration' },
                     { id: 'result', label: 'Result' },

--- a/src/ui/src/components/document-list/documents-table-config.tsx
+++ b/src/ui/src/components/document-list/documents-table-config.tsx
@@ -155,7 +155,7 @@ export const COLUMN_DEFINITIONS_MAIN = (versions: ConfigVersion[] = []): TablePr
   },
   {
     id: 'configVersion',
-    header: 'Config Version',
+    header: 'Config Profile',
     cell: (item) =>
       formatConfigVersionLink(
         item.configVersion,
@@ -257,7 +257,7 @@ const VISIBLE_CONTENT_OPTIONS = [
       { id: 'initialEventTime', label: 'Submitted' },
       { id: 'completionTime', label: 'Completed' },
       { id: 'duration', label: 'Duration' },
-      { id: 'configVersion', label: 'Config Version' },
+      { id: 'configVersion', label: 'Config Profile' },
       { id: 'evaluationStatus', label: 'Evaluation' },
       { id: 'confidenceAlertCount', label: 'Confidence Alerts' },
       { id: 'processingIssueCount', label: 'Processing Issues' },

--- a/src/ui/src/components/document-panel/DocumentPanel.tsx
+++ b/src/ui/src/components/document-panel/DocumentPanel.tsx
@@ -559,7 +559,7 @@ const DocumentAttributes = ({ item, versions }: DocumentAttributesProps): React.
         <SpaceBetween size="xs">
           <div>
             <Box margin={{ bottom: 'xxxs' }} color="text-label">
-              <strong>Config Version</strong>
+              <strong>Config Profile</strong>
             </Box>
             <div>{formatConfigVersionLink(item.configVersion, versions)}</div>
           </div>
@@ -741,7 +741,7 @@ export const DocumentPanel = ({
 
   // Fetch active configuration for dynamic confidence threshold (used by sections panel, etc.)
   const { mergedConfig } = useConfiguration();
-  // Fetch the specific config version that was used to process this document (for flow viewer).
+  // Fetch the specific configuration profile that was used to process this document (for flow viewer).
   // Optimization: skip the extra API call when the document version is 'default' or unset,
   // since useConfiguration() above already fetches the default config.
   const docConfigVersion = localItem?.configVersion || 'default';
@@ -1012,7 +1012,7 @@ export const DocumentPanel = ({
             sections: displayedItem.sections,
             pages: displayedItem.pages,
             documentItem: displayedItem,
-            // Use the config version the document was processed with, not the
+            // Use the configuration profile the document was processed with, not the
             // stack's current live config. This drives the Edit Mode class
             // dropdown (so users see the classes the doc was actually
             // classified against) and section confidence-alert thresholds.
@@ -1029,7 +1029,7 @@ export const DocumentPanel = ({
         <DocumentVersionsPanel objectKey={localItem.objectKey} viewingRunId={viewingRunId} onViewVersion={handleViewVersion} />
         <ChatPanel objectKey={localItem.objectKey} configVersion={docConfigVersion} />
 
-        {/* Step Function Flow Viewer - uses the document's config version, not the active stack config */}
+        {/* Step Function Flow Viewer - uses the document's configuration profile, not the active stack config */}
         {localItem?.executionArn && (
           <StepFunctionFlowViewer
             executionArn={localItem.executionArn}

--- a/src/ui/src/components/document-panel/DocumentVersionsPanel.tsx
+++ b/src/ui/src/components/document-panel/DocumentVersionsPanel.tsx
@@ -278,7 +278,7 @@ const DocumentVersionsPanel = ({ objectKey, viewingRunId = null, onViewVersion }
             },
             {
               id: 'configVersion',
-              header: 'Config Version',
+              header: 'Config Profile',
               cell: (item: DocumentVersion) => item.ConfigVersion || 'N/A',
             },
             {

--- a/src/ui/src/components/sections-panel/SectionsPanel.tsx
+++ b/src/ui/src/components/sections-panel/SectionsPanel.tsx
@@ -874,7 +874,7 @@ const SectionsPanel = ({
   // (see DocumentPanel: it fetches `documentVersionConfig` from the doc's
   // `configVersion` and passes it in here). Using the current live config
   // instead would show the wrong class vocabulary in Edit Mode for docs
-  // processed under a previous or different config version.
+  // processed under a previous or different configuration profile.
   const configuration = mergedConfig;
   const { settings: settings2 } = useSettingsContext();
   const { isReviewerOnly, canWrite, canReview } = useUserRole();
@@ -1011,7 +1011,7 @@ const SectionsPanel = ({
     }
   }, [isEditMode, sections]);
 
-  // Get available classes from the document's config version (passed in as
+  // Get available classes from the document's configuration profile (passed in as
   // `mergedConfig`). Shared with Test Studio's annotation editor, which offers
   // the same correction against the same config.
   const getAvailableClasses = () => getConfigClassOptions(configuration);

--- a/src/ui/src/components/test-studio/GenerateDraftLabelsModal.tsx
+++ b/src/ui/src/components/test-studio/GenerateDraftLabelsModal.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 /**
- * GenerateDraftLabelsModal — choose what to label, and with which config version.
+ * GenerateDraftLabelsModal — choose what to label, and with which configuration profile.
  *
  * Documents carrying authored ground truth (uploaded or generated) are listed but
  * not selectable, because the server refuses to overwrite them. Prior machine
@@ -83,7 +83,7 @@ const GenerateDraftLabelsModal = ({ visible, testSetId, documents, onDismiss, on
           })),
       ]);
     } catch (err) {
-      logger.error('Could not load config versions:', err);
+      logger.error('Could not load configuration profiles:', err);
       setVersionOptions([{ label: 'Active configuration', value: ACTIVE_CONFIG }]);
     } finally {
       setLoadingVersions(false);
@@ -100,7 +100,7 @@ const GenerateDraftLabelsModal = ({ visible, testSetId, documents, onDismiss, on
   const effectiveKeys = selectAll ? undefined : selected.map((d) => d.objectKey);
   const targetCount = selectAll ? labelable.length : selected.length;
   // Option.value is `string | undefined`, so the type guard is required: a
-  // non-string reaching the API pins the run to a bogus config version.
+  // non-string reaching the API pins the run to a bogus configuration profile.
   const rawConfigVersion = configVersion.value;
   const selectedConfigVersion = typeof rawConfigVersion === 'string' && rawConfigVersion !== ACTIVE_CONFIG ? rawConfigVersion : undefined;
 
@@ -147,14 +147,14 @@ const GenerateDraftLabelsModal = ({ visible, testSetId, documents, onDismiss, on
         )}
 
         <FormField
-          label="Configuration version"
-          description="Which configuration to label with. Pick a different version to compare, or to redo a run that used the wrong settings."
+          label="Configuration profile"
+          description="Which configuration to label with. Pick a different profile to compare, or to redo a run that used the wrong settings."
         >
           <Select
             selectedOption={configVersion}
             onChange={({ detail }) => setConfigVersion(detail.selectedOption)}
             options={versionOptions}
-            loadingText="Loading configuration versions"
+            loadingText="Loading configuration profiles"
             statusType={loadingVersions ? 'loading' : 'finished'}
             filteringType="auto"
           />
@@ -226,7 +226,7 @@ const GenerateDraftLabelsModal = ({ visible, testSetId, documents, onDismiss, on
 
         {loadingVersions && (
           <Box textAlign="center">
-            <Spinner /> Loading configuration versions…
+            <Spinner /> Loading configuration profiles…
           </Box>
         )}
       </SpaceBetween>

--- a/src/ui/src/components/test-studio/GenerateSyntheticDataModal.tsx
+++ b/src/ui/src/components/test-studio/GenerateSyntheticDataModal.tsx
@@ -4,7 +4,7 @@
 /**
  * Modal shell for synthetic generation, serving the Schema Builder deep-link
  * (`?generate=1&version=…&className=…`) that lands directly on the form with a
- * preselected config version and class. The create-test-set wizard is the normal
+ * preselected configuration profile and class. The create-test-set wizard is the normal
  * entry point; both render the same fields via useGenerateSyntheticForm.
  */
 

--- a/src/ui/src/components/test-studio/GroundTruthVisualEditor.tsx
+++ b/src/ui/src/components/test-studio/GroundTruthVisualEditor.tsx
@@ -214,7 +214,7 @@ const GroundTruthVisualEditor = ({
 
   const documentClassType = (localData?.document_class as Record<string, unknown> | undefined)?.type as string | undefined;
 
-  // Classes come from the config version stamped on the baseline, not the
+  // Classes come from the configuration profile stamped on the baseline, not the
   // deployment's active config, which may have moved on since the labels were
   // written.
   const baselineConfigVersion =
@@ -225,7 +225,10 @@ const GroundTruthVisualEditor = ({
   // class was since renamed would silently blank the field.
   const classOptionsWithCurrent = useMemo(() => {
     if (!documentClassType || classOptions.some((o) => o.value === documentClassType)) return classOptions;
-    return [{ label: documentClassType, value: documentClassType, description: 'Not defined in this config version' }, ...classOptions];
+    return [
+      { label: documentClassType, value: documentClassType, description: 'Not defined in this configuration profile' },
+      ...classOptions,
+    ];
   }, [classOptions, documentClassType]);
   const classChanged = Boolean(savedClassType) && documentClassType !== savedClassType;
   const editHistoryCount = Array.isArray(localData?._editHistory) ? (localData._editHistory as unknown[]).length : 0;
@@ -489,7 +492,7 @@ const GroundTruthVisualEditor = ({
                           label="Class label"
                           description={
                             classOptions.length > 0
-                              ? 'What this section is classified as, from this config version. Distinct from the extraction labels below.'
+                              ? 'What this section is classified as, from this configuration profile. Distinct from the extraction labels below.'
                               : 'What this section is classified as. Distinct from the extraction labels below.'
                           }
                         >

--- a/src/ui/src/components/test-studio/ReviewEffortModal.tsx
+++ b/src/ui/src/components/test-studio/ReviewEffortModal.tsx
@@ -133,7 +133,7 @@ const CONFIDENCE_COPY: Record<string, { type: 'info' | 'warning' | 'success'; he
   measured: {
     type: 'success',
     header: 'Measured on this set',
-    body: 'Derived from observed confidence-vs-accuracy on these documents under this config version.',
+    body: 'Derived from observed confidence-vs-accuracy on these documents under this configuration profile.',
   },
   unreliable: {
     type: 'warning',
@@ -256,7 +256,7 @@ const ReviewEffortModal = ({ visible, testSetId, configVersion, onDismiss, onCon
                 ? ` (AUROC ${estimate.calibration.auroc.toFixed(2)}, where 0.5 is a coin flip)`
                 : ''}
               , so reviewing the documents with the most confidence alerts would find no more errors than reviewing at random. Review
-              everything, or change the confidence model for this config version and re-score.
+              everything, or change the confidence model for this configuration profile and re-score.
             </Alert>
           )}
 

--- a/src/ui/src/components/test-studio/TestComparison.tsx
+++ b/src/ui/src/components/test-studio/TestComparison.tsx
@@ -296,7 +296,7 @@ const TestComparison = ({ preSelectedTestRunIds = [] }: TestComparisonProps): Re
       ['Test Set', ...Object.values(completeTestRuns).map((run) => run.testSetName || 'N/A')],
       ['Context', ...Object.values(completeTestRuns).map((run) => run.context || 'N/A')],
       [
-        'Config Version',
+        'Config Profile',
         ...Object.values(completeTestRuns).map((run) =>
           formatConfigVersionText(
             run.configVersion as string | undefined,
@@ -1056,8 +1056,8 @@ const TestComparison = ({ preSelectedTestRunIds = [] }: TestComparisonProps): Re
                   ),
                 },
                 {
-                  metric: 'Config Version',
-                  metricKey: 'Config Version',
+                  metric: 'Config Profile',
+                  metricKey: 'Config Profile',
                   ...Object.fromEntries(
                     Object.entries(completeTestRuns).map(([testRunId, testRun]) => [
                       testRunId,
@@ -1195,7 +1195,7 @@ const TestComparison = ({ preSelectedTestRunIds = [] }: TestComparisonProps): Re
 
                     return (
                       <span style={{ ...style, WebkitPrintColorAdjust: 'exact', colorAdjust: 'exact' }}>
-                        {item.metricKey === 'Config Version' ? (value as React.ReactNode) : String(value)}
+                        {item.metricKey === 'Config Profile' ? (value as React.ReactNode) : String(value)}
                       </span>
                     );
                   },

--- a/src/ui/src/components/test-studio/TestResults.tsx
+++ b/src/ui/src/components/test-studio/TestResults.tsx
@@ -1452,7 +1452,7 @@ const TestResults = ({ testRunId, setSelectedTestRunId }: TestResultsProps): Rea
           </Box>
           {Boolean(results.configVersion) && (
             <Box>
-              <Box variant="awsui-key-label">Config Version</Box>
+              <Box variant="awsui-key-label">Config Profile</Box>
               <Box fontSize="heading-l">{formatConfigVersionLink(results.configVersion as string, versions)}</Box>
             </Box>
           )}

--- a/src/ui/src/components/test-studio/TestResultsList.tsx
+++ b/src/ui/src/components/test-studio/TestResultsList.tsx
@@ -251,7 +251,7 @@ const TestResultsList = ({
 
   const downloadToExcel = () => {
     // Convert test runs data to CSV format
-    const headers = ['Test Run ID', 'Test Set', 'Context', 'Config Version', 'Status', 'Files Count', 'Created At', 'Completed At'];
+    const headers = ['Test Run ID', 'Test Set', 'Context', 'Config Profile', 'Status', 'Files Count', 'Created At', 'Completed At'];
     const csvData = testRuns.map((run) => [
       run.testRunId,
       run.testSetName || '',
@@ -451,7 +451,7 @@ const TestResultsList = ({
           },
           {
             id: 'configVersion',
-            header: 'Config Version',
+            header: 'Config Profile',
             cell: (item) => formatConfigVersionLink(item.configVersion, versions, undefined, item.configRevision),
             sortingField: 'configVersion',
             width: 150,

--- a/src/ui/src/components/test-studio/TestRunner.tsx
+++ b/src/ui/src/components/test-studio/TestRunner.tsx
@@ -29,7 +29,7 @@ interface TestSetData {
   filePattern?: string;
   fileCount: number;
   status: string;
-  /** Config version this test set declares for itself (optional). */
+  /** Config profile this test set declares for itself (optional). */
   configVersion?: string | null;
 }
 
@@ -225,7 +225,7 @@ const TestRunner = ({
             onChange={({ detail }) => {
               setSelectedTestSet(detail.selectedOption);
               setNumberOfFiles(''); // Reset numberOfFiles when test set changes
-              // Auto-select the configuration version for the chosen test set, in
+              // Auto-select the configuration profile for the chosen test set, in
               // priority order:
               //
               //   1. `configVersion` declared ON the test set record. Lets a test
@@ -233,7 +233,7 @@ const TestRunner = ({
               //      deployed by an extension, whose config presets are named
               //      `<featureId>-v<version>` by the Feature Platform and so can
               //      never equal the test set id.
-              //   2. A config version whose name EQUALS the test set id. The
+              //   2. A configuration profile whose name EQUALS the test set id. The
               //      convention the stack-managed benchmark sets rely on
               //      (e.g. "fake-w2", "docsplit").
               //   3. The active version — nothing specific applies.
@@ -264,16 +264,16 @@ const TestRunner = ({
         </FormField>
 
         <FormField
-          label="Configuration Version"
-          description="Select which configuration version to use for processing these test documents"
+          label="Configuration Profile"
+          description="Select which configuration profile to use for processing these test documents"
         >
           <Select
             selectedOption={selectedVersion}
             onChange={({ detail }) => setSelectedVersion(detail.selectedOption)}
             options={getVersionOptions()}
-            placeholder={versions.length === 0 ? 'Loading versions...' : 'Select configuration version'}
+            placeholder={versions.length === 0 ? 'Loading profiles...' : 'Select configuration profile'}
             disabled={loading || versions.length === 0}
-            loadingText="Loading versions..."
+            loadingText="Loading profiles..."
           />
         </FormField>
 

--- a/src/ui/src/components/test-studio/useGenerateSyntheticForm.tsx
+++ b/src/ui/src/components/test-studio/useGenerateSyntheticForm.tsx
@@ -44,7 +44,7 @@ export const MAX_COUNT = 50;
 export const FAST_THRESHOLD = 7;
 export const QUALITY_THRESHOLD = 9;
 
-// Document-class names from a fetched config version. Configs arrive as AWSJSON
+// Document-class names from a fetched configuration profile. Configs arrive as AWSJSON
 // strings; classes live under `.classes[]`, identified by `$id` /
 // `x-aws-idp-document-type` as on the backend. A version's own classes win, and
 // the default config is consulted only when the version defines none: otherwise
@@ -328,7 +328,7 @@ export const useGenerateSyntheticForm = ({
     ...(mode === 'prompt'
       ? [{ label: 'Description', value: prompt.trim() || '—' }]
       : [
-          { label: 'Configuration version', value: (selectedVersion?.label as string) || '—' },
+          { label: 'Configuration profile', value: (selectedVersion?.label as string) || '—' },
           { label: 'Document class', value: (selectedClass?.label as string) || '—' },
         ]),
     {
@@ -358,7 +358,7 @@ export const useGenerateSyntheticForm = ({
             {
               value: 'config',
               label: 'From a configuration',
-              description: "Use an existing config version's document class, so labels match your extraction schema.",
+              description: "Use an existing configuration profile's document class, so labels match your extraction schema.",
             },
           ]}
         />
@@ -380,23 +380,23 @@ export const useGenerateSyntheticForm = ({
         </>
       ) : (
         <>
-          <FormField label="Configuration version" description="The version whose document class defines the fields to generate.">
+          <FormField label="Configuration profile" description="The profile whose document class defines the fields to generate.">
             <Select
               selectedOption={selectedVersion}
               onChange={({ detail }) => setSelectedVersion(detail.selectedOption)}
               options={versionOptions}
-              placeholder="Select a configuration version"
+              placeholder="Select a configuration profile"
               filteringType="auto"
             />
           </FormField>
-          <FormField label="Document class" description="Which class from that version to generate documents for.">
+          <FormField label="Document class" description="Which class from that profile to generate documents for.">
             <Select
               selectedOption={selectedClass}
               onChange={({ detail }) => setSelectedClass(detail.selectedOption)}
               options={classOptions}
-              placeholder={selectedVersion ? 'Select a document class' : 'Select a configuration version first'}
+              placeholder={selectedVersion ? 'Select a document class' : 'Select a configuration profile first'}
               disabled={!selectedVersion}
-              empty="No document classes in this version"
+              empty="No document classes in this profile"
               statusType={classesLoading ? 'loading' : 'finished'}
               loadingText="Loading document classes"
               filteringType="auto"

--- a/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
+++ b/src/ui/src/components/upload-document/UploadDocumentPanel.tsx
@@ -151,7 +151,7 @@ const UploadDocumentPanel = (): React.JSX.Element => {
   };
 
   // Fetch + parse a library preset (config.yaml, falling back to config.json)
-  // and save it as a new, non-active configuration version named after the
+  // and save it as a new, non-active configuration profile named after the
   // config folder. Returns the version name to use for processing.
   const importConfigVersion = async (configId: string): Promise<string> => {
     let file = await getFile(SAMPLE_CONFIG_PATTERN_DIR, configId, 'config.yaml');
@@ -352,14 +352,14 @@ const UploadDocumentPanel = (): React.JSX.Element => {
           <Input value={prefix} onChange={handlePrefixChange} placeholder="Leave empty for root folder" disabled={isUploading} />
         </FormField>
 
-        <FormField label="Configuration Version" description="Select which configuration version to use for processing these documents">
+        <FormField label="Configuration Profile" description="Select which configuration profile to use for processing these documents">
           <Select
             selectedOption={selectedVersion}
             onChange={({ detail }) => setSelectedVersion(detail.selectedOption)}
             options={getVersionOptions()}
-            placeholder={versions.length === 0 ? 'Loading versions...' : 'Select configuration version'}
+            placeholder={versions.length === 0 ? 'Loading profiles...' : 'Select configuration profile'}
             disabled={isUploading || versions.length === 0 || (isSampleMode && showAutoImport && autoImportConfig)}
-            loadingText="Loading versions..."
+            loadingText="Loading profiles..."
           />
         </FormField>
 
@@ -415,14 +415,14 @@ const UploadDocumentPanel = (): React.JSX.Element => {
             Also import and use its configuration ({activeSample?.configId})
             <Box variant="small" color="text-body-secondary">
               This sample is tuned for the &ldquo;{activeSample?.configId}&rdquo; library configuration, which is not yet imported. It will
-              be saved as a new configuration version and selected for processing.
+              be saved as a new configuration profile and selected for processing.
             </Box>
           </Checkbox>
         )}
 
         {isSampleMode && activeSample?.configId && configAlreadyImported && (
           <Alert type="info">
-            This sample is tuned for the already-imported &ldquo;{activeSample.configId}&rdquo; configuration version, which has been
+            This sample is tuned for the already-imported &ldquo;{activeSample.configId}&rdquo; configuration profile, which has been
             pre-selected above. You can choose a different version if you prefer.
           </Alert>
         )}

--- a/src/ui/src/components/user-management/UserManagementLayout.tsx
+++ b/src/ui/src/components/user-management/UserManagementLayout.tsx
@@ -419,7 +419,7 @@ const UserManagementLayout = (): React.JSX.Element => {
     },
     {
       id: 'allowedConfigVersions',
-      header: 'Config Version Scope',
+      header: 'Config Profile Scope',
       cell: (item: User) => formatConfigVersions(item.allowedConfigVersions),
     },
     {
@@ -581,16 +581,16 @@ const UserManagementLayout = (): React.JSX.Element => {
               <FormField
                 label={
                   <span>
-                    Configuration Version Scope <em>- optional</em>
+                    Configuration Profile Scope <em>- optional</em>
                   </span>
                 }
-                description="Restrict this user to specific configuration versions. Leave empty for unrestricted access to all versions."
+                description="Restrict this user to specific configuration profiles. Leave empty for unrestricted access to all versions."
               >
                 <Multiselect
                   selectedOptions={selectedConfigVersions}
                   onChange={({ detail }) => setSelectedConfigVersions(detail.selectedOptions as { label: string; value: string }[])}
                   options={configVersionOptions}
-                  placeholder="All versions (unrestricted)"
+                  placeholder="All profiles (unrestricted)"
                   filteringType="auto"
                   tokenLimit={3}
                 />
@@ -639,14 +639,14 @@ const UserManagementLayout = (): React.JSX.Element => {
           <Form>
             <SpaceBetween size="l">
               <FormField
-                label="Configuration Version Scope"
-                description="Select which configuration versions this user can access. Clear all to give unrestricted access."
+                label="Configuration Profile Scope"
+                description="Select which configuration profiles this user can access. Clear all to give unrestricted access."
               >
                 <Multiselect
                   selectedOptions={editScopeVersions}
                   onChange={({ detail }) => setEditScopeVersions(detail.selectedOptions as { label: string; value: string }[])}
                   options={configVersionOptions}
-                  placeholder="All versions (unrestricted)"
+                  placeholder="All profiles (unrestricted)"
                   filteringType="auto"
                   tokenLimit={3}
                 />

--- a/src/ui/src/contexts/guidedTour.tsx
+++ b/src/ui/src/contexts/guidedTour.tsx
@@ -53,7 +53,7 @@ const buildTutorial = (flags: TourFlags): AnnotationContextProps.Tutorial => ({
         },
         {
           title: 'View / edit configuration',
-          content: 'Review, edit, and activate configuration versions — the document classes and fields IDP extracts.',
+          content: 'Review, edit, and activate configuration profiles — the document classes and fields IDP extracts.',
           hotspotId: 'nav-configuration',
         },
         {

--- a/src/ui/src/hooks/use-configuration-versions.ts
+++ b/src/ui/src/hooks/use-configuration-versions.ts
@@ -46,7 +46,7 @@ const useConfigurationVersions = (): UseConfigurationVersionsReturn => {
   // Get updateConfiguration from useConfiguration hook
   const { updateConfiguration } = useConfiguration();
 
-  // Get user's config version scope for filtering
+  // Get user's configuration profile scope for filtering
   const { allowedConfigVersions } = useUserRole();
 
   // Filter versions by user's allowed scope (null = unrestricted)
@@ -76,7 +76,7 @@ const useConfigurationVersions = (): UseConfigurationVersionsReturn => {
       );
       setAllVersions(fetchedVersions);
     } catch (err: unknown) {
-      logger.error('Error fetching configuration versions:', err);
+      logger.error('Error fetching configuration profiles:', err);
       console.error('Full error object:', err);
       const graphqlErr = err as { errors?: { message: string }[]; message?: string };
       if (graphqlErr.errors) {
@@ -109,7 +109,7 @@ const useConfigurationVersions = (): UseConfigurationVersionsReturn => {
         custom: response.Custom,
       };
     } catch (err) {
-      logger.error('Error fetching configuration version:', err);
+      logger.error('Error fetching configuration profile:', err);
       throw err;
     }
   };

--- a/src/ui/src/hooks/use-user-role.ts
+++ b/src/ui/src/hooks/use-user-role.ts
@@ -16,7 +16,7 @@ import { getMyProfile } from '../graphql/generated';
  * Users can be in multiple groups (union of permissions applies).
  * Users can optionally have allowedConfigVersions for config-version scoping and
  * allowedTestSets for test-set annotation scoping. These are independent axes:
- * the former limits which config versions' documents a user sees, the latter
+ * the former limits which configuration profiles' documents a user sees, the latter
  * which test sets they may annotate.
  *
  * Every group name the app understands must appear in APP_GROUPS below: the
@@ -46,13 +46,13 @@ interface UserRoleReturn {
   canWrite: boolean;
   /** True if user can manage users (Admin only) */
   canManageUsers: boolean;
-  /** True if user can delete config versions (Admin only) */
+  /** True if user can delete configuration profiles (Admin only) */
   canDeleteConfig: boolean;
   /** True if user can perform HITL reviews (Admin or Reviewer) */
   canReview: boolean;
   /** True if user can annotate test-set ground truth (Admin, Author or Annotator) */
   canAnnotate: boolean;
-  /** Config versions the user is allowed to access. null/undefined = unrestricted (all versions). */
+  /** Config profiles the user is allowed to access. null/undefined = unrestricted (all versions). */
   allowedConfigVersions: string[] | null;
   /**
    * Test sets an Annotator is scoped to. null = unrestricted for Admin/Author;

--- a/src/ui/src/utils/__tests__/github-feedback.test.ts
+++ b/src/ui/src/utils/__tests__/github-feedback.test.ts
@@ -64,7 +64,7 @@ describe('buildBugReportUrl', () => {
     expect(url.searchParams.get('title')).toContain('lending_package-long.pdf');
     const body = url.searchParams.get('body') ?? '';
     expect(body).toContain('FAILED');
-    expect(body).toContain('Config version:');
+    expect(body).toContain('Config profile:');
     expect(body).toContain('The extraction step timed out.');
   });
 

--- a/src/ui/src/utils/github-feedback.ts
+++ b/src/ui/src/utils/github-feedback.ts
@@ -82,7 +82,7 @@ const buildTroubleshootSection = (doc: DocumentContext): string => {
   const meta: string[] = [];
   if (doc.objectKey) meta.push(`- **Document:** ${doc.objectKey}`);
   if (doc.objectStatus) meta.push(`- **Status:** ${doc.objectStatus}`);
-  if (doc.configVersion) meta.push(`- **Config version:** ${doc.configVersion}`);
+  if (doc.configVersion) meta.push(`- **Config profile:** ${doc.configVersion}`);
   if (doc.executionArn) meta.push(`- **Execution ARN:** ${doc.executionArn}`);
   if (meta.length) parts.push(`## Document context\n${meta.join('\n')}`);
   if (doc.jobError) parts.push(`## Error\n\`\`\`\n${doc.jobError}\n\`\`\``);


### PR DESCRIPTION
#690 relabelled the profiles table and the revision panel, but left "Configuration Version" in **33 other UI files** — pickers, modals, column headers, help text, error messages. Most of the app was still using the old vocabulary while the docs used the new one.

## What changed

**158 user-facing phrase occurrences**, plus a case variant the original sweep missed entirely: `Configuration version` with a lowercase *v*, which is what Test Studio's draft-labeling modal and the synthetic-data form actually rendered.

Affordances that said only "Version" but meant a profile were renamed too:

| Before | After |
|---|---|
| Save as Version | Save as Profile |
| Version Name | Profile Name |
| Import as New Version | Import as New Profile |
| Create New Version | Create New Profile |
| Confirm Activate Version | Confirm Activate Profile |
| Copy from version / New version name | Copy from profile / New profile name |
| All versions (unrestricted) | All profiles (unrestricted) |
| "Loading versions…" ×6 (profile pickers) | "Loading profiles…" |

## Deliberately NOT renamed

- **API and wire names.** Every replaced phrase contains a space, so it cannot match `configVersion`, `getConfigVersions`, `allowedConfigVersions`, `versionName`, `ConfigVersion` or `CreateConfigVersionModal`. Verified by counting each identifier on both sides of the diff — **equal on every one**.
- **Document versions.** `DocumentVersionsPanel` keeps "Compare versions", "Delete version", "Loading version history…": those are snapshots of processing runs, and per the terminology table documents have *versions*.
- **"Important: Version upgrade considerations"** — that warning is about upgrading the *solution* to a new release, not a configuration profile. Renaming it would have made it wrong.
- **`saveAsVersion`** stays named that way where docs describe the mutation flag.

Docs updated where they told users to click a button by its old name (`configuration-profiles.md`, `configuration.md`, `rbac.md`).

## One test changed

`github-feedback.test.ts` asserted `'Config version:'` in the bug-report template and now asserts `'Config profile:'`. That is the label genuinely changing — the test was pinning user-facing wording, so it follows the wording.

UI lint, `tsc --noEmit`, 363 UI tests, `make fastlint`, and 376 sdlc/scripts tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)