### PR TITLE
test(agentic): stop stubbing a package that is actually installed

### DIFF
--- a/lib/idp_common_pkg/pytest.ini
+++ b/lib/idp_common_pkg/pytest.ini
@@ -5,6 +5,10 @@
 markers =
     unit: mark a test as a unit test
     integration: mark a test as an integration test
+    # A live agentic run against real Bedrock. ALWAYS combine with `integration`:
+    # `agentic` alone is not filtered by anything, so a test carrying only this
+    # marker runs in the default gate and bills a real model call.
+    agentic: mark a test as a live agentic (real Bedrock) test
 
 # By default, run all tests except those marked as integration
 addopts = -m "not integration"

--- a/lib/idp_common_pkg/tests/conftest.py
+++ b/lib/idp_common_pkg/tests/conftest.py
@@ -5,6 +5,7 @@
 Pytest configuration file for the IDP Common package tests.
 """
 
+import importlib
 import os
 import sys
 from unittest.mock import MagicMock
@@ -24,16 +25,59 @@ os.environ.setdefault("AWS_REGION", "us-east-1")
 # Mock external dependencies that may not be available in test environments
 # These mocks need to be set up before any imports that might use these packages
 
-# Mock strands modules for agent functionality
-sys.modules["strands"] = MagicMock()
-sys.modules["strands.models"] = MagicMock()
-sys.modules["strands.hooks"] = MagicMock()
-sys.modules["strands.hooks.events"] = MagicMock()
 
-# Mock bedrock_agentcore modules for secure code execution
-sys.modules["bedrock_agentcore"] = MagicMock()
-sys.modules["bedrock_agentcore.tools"] = MagicMock()
-sys.modules["bedrock_agentcore.tools.code_interpreter_client"] = MagicMock()
+def _stub_if_absent(*module_names: str) -> None:
+    """Install a MagicMock for each module ONLY when it is genuinely absent.
+
+    This used to stub unconditionally, and for ``strands`` that was actively
+    harmful: ``strands-agents`` is a real dependency of the ``[all]`` extra, which
+    both ``make dev`` and CI install, so the stub replaced a package that WAS
+    importable. Every agentic test guards itself with
+    ``pytest.importorskip``-style detection (``from strands.types.agent import
+    AgentInput``), that import saw a MagicMock without the attribute, and 42 tests
+    reported "strands-agents package not installed" and skipped — permanently, in
+    every environment, including CI.
+
+    Skipped tests read as green. So the agentic extraction path had 42 tests that
+    could never fail, which is the same failure mode as having no tests at all
+    except that it looks covered. Stubbing only what is missing keeps the suite
+    runnable in a bare environment while letting a properly installed one actually
+    exercise the code.
+    """
+    for name in module_names:
+        if name in sys.modules:
+            continue
+        try:
+            importlib.import_module(name)
+        except ImportError:
+            sys.modules[name] = MagicMock()
+
+
+_stub_if_absent(
+    "strands",
+    "strands.models",
+    "strands.hooks",
+    "strands.hooks.events",
+)
+
+# Agent submodules some test modules used to stub for themselves; centralized
+# here so no single module can replace a real installed package for every module
+# imported after it.
+_stub_if_absent(
+    "strands.agent",
+    "strands.agent.conversation_manager",
+    "strands.tools",
+    "strands.tools.mcp",
+)
+
+# bedrock_agentcore (secure code execution) is not a test dependency, so in
+# practice these are always stubbed — routed through the same helper so the rule
+# is uniform rather than a second, differently-behaved mechanism.
+_stub_if_absent(
+    "bedrock_agentcore",
+    "bedrock_agentcore.tools",
+    "bedrock_agentcore.tools.code_interpreter_client",
+)
 
 # PIL module is now used directly for document conversion functionality
 # No mocking needed as PIL is a required dependency for the OCR module

--- a/lib/idp_common_pkg/tests/unit/agents/analytics/test_agent.py
+++ b/lib/idp_common_pkg/tests/unit/agents/analytics/test_agent.py
@@ -8,19 +8,16 @@ Unit tests for the analytics agent module.
 # ruff: noqa: E402, I001
 # The above line disables E402 (module level import not at top of file) and I001 (import block sorting) for this file
 
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Mock strands modules before importing analytics modules
-sys.modules["strands"] = MagicMock()
-sys.modules["strands.models"] = MagicMock()
-
-# Mock bedrock_agentcore modules before importing analytics modules
-sys.modules["bedrock_agentcore"] = MagicMock()
-sys.modules["bedrock_agentcore.tools"] = MagicMock()
-sys.modules["bedrock_agentcore.tools.code_interpreter_client"] = MagicMock()
+# `strands` and `bedrock_agentcore` are stubbed by tests/conftest.py, and ONLY
+# when genuinely absent. This module used to force MagicMocks into `sys.modules`
+# here instead, unconditionally and without ever restoring them — which replaced
+# a real installed `strands` for every test module imported after this one, so
+# whether the agentic tests ran against the real library depended on collection
+# order. See the note in tests/conftest.py.
 
 
 @pytest.mark.unit

--- a/lib/idp_common_pkg/tests/unit/agents/analytics/test_config.py
+++ b/lib/idp_common_pkg/tests/unit/agents/analytics/test_config.py
@@ -9,19 +9,15 @@ Unit tests for the analytics configuration module.
 # The above line disables E402 (module level import not at top of file) and I001 (import block sorting) for this file
 
 import os
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-# Mock strands modules before importing analytics modules
-sys.modules["strands"] = MagicMock()
-sys.modules["strands.models"] = MagicMock()
-
-# Mock bedrock_agentcore modules before importing analytics modules
-sys.modules["bedrock_agentcore"] = MagicMock()
-sys.modules["bedrock_agentcore.tools"] = MagicMock()
-sys.modules["bedrock_agentcore.tools.code_interpreter_client"] = MagicMock()
+# `strands` and `bedrock_agentcore` are stubbed by tests/conftest.py, and ONLY
+# when genuinely absent. This module used to force a MagicMock into
+# `sys.modules` here instead, unconditionally and without ever restoring it —
+# which replaced a real installed `strands` for every test module imported after
+# this one. See the note in tests/conftest.py.
 
 from idp_common.agents.analytics.config import (
     get_analytics_config,

--- a/lib/idp_common_pkg/tests/unit/agents/analytics/test_integration.py
+++ b/lib/idp_common_pkg/tests/unit/agents/analytics/test_integration.py
@@ -8,19 +8,16 @@ Integration tests for the analytics agent functionality.
 # ruff: noqa: E402, I001
 # The above line disables E402 (module level import not at top of file) and I001 (import block sorting) for this file
 
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Mock strands modules before importing analytics modules
-sys.modules["strands"] = MagicMock()
-sys.modules["strands.models"] = MagicMock()
-
-# Mock bedrock_agentcore modules before importing analytics modules
-sys.modules["bedrock_agentcore"] = MagicMock()
-sys.modules["bedrock_agentcore.tools"] = MagicMock()
-sys.modules["bedrock_agentcore.tools.code_interpreter_client"] = MagicMock()
+# `strands` and `bedrock_agentcore` are stubbed by tests/conftest.py, and ONLY
+# when genuinely absent. This module used to force MagicMocks into `sys.modules`
+# here instead, unconditionally and without ever restoring them — which replaced
+# a real installed `strands` for every test module imported after this one, so
+# whether the agentic tests ran against the real library depended on collection
+# order. See the note in tests/conftest.py.
 
 from idp_common.agents.analytics import (
     get_analytics_config,

--- a/lib/idp_common_pkg/tests/unit/agents/common/test_monitoring.py
+++ b/lib/idp_common_pkg/tests/unit/agents/common/test_monitoring.py
@@ -8,40 +8,20 @@ Unit tests for agent monitoring functionality.
 # ruff: noqa: E402, I001
 # The above line disables E402 (module level import not at top of file) and I001 (import block sorting) for this file
 
-import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
-# Mock strands modules before importing monitoring modules
-mock_strands = MagicMock()
-mock_hooks = MagicMock()
-mock_events = MagicMock()
-
-
-# Create a mock HookProvider class that behaves like the real one
-class MockHookProvider:
-    def __init__(self):
-        self.execution_stats = {
-            "messages_added": 0,
-            "tool_invocations": 0,
-            "model_invocations": 0,
-            "requests_processed": 0,
-            "start_time": None,
-            "end_time": None,
-        }
-        self.messages = []
-        self.message_history = []
-        self.tool_history = []
-        self.model_history = []
-
-
-mock_hooks.HookProvider = MockHookProvider
-mock_hooks.HookRegistry = MagicMock()
-
-sys.modules["strands"] = mock_strands
-sys.modules["strands.hooks"] = mock_hooks
-sys.modules["strands.hooks.events"] = mock_events
+# `strands` is stubbed by tests/conftest.py, and ONLY when genuinely absent.
+#
+# This module used to build its own `strands.hooks` MagicMock — including a
+# hand-written stand-in for `HookProvider`, the class `AgentMonitor` subclasses —
+# and force it into `sys.modules` unconditionally, without ever restoring it. Two
+# problems: `AgentMonitor` was never once tested against the real base class it
+# derives from, and every test module imported after this one inherited the mock,
+# so whether the agentic tests exercised real `strands` depended on collection
+# order. `AgentMonitor` imports and behaves correctly against the real
+# `HookProvider`, so the stand-in is gone. See the note in tests/conftest.py.
 
 from idp_common.agents.common.dynamodb_logger import DynamoDBMessageTracker
 from idp_common.agents.common.monitoring import AgentMonitor, MessageTracker

--- a/lib/idp_common_pkg/tests/unit/agents/orchestrator/test_conversational_orchestrator.py
+++ b/lib/idp_common_pkg/tests/unit/agents/orchestrator/test_conversational_orchestrator.py
@@ -15,24 +15,16 @@ Tests the create_conversational_orchestrator() method to ensure:
 # The above line disables E402 (module level import not at top of file) and I001 (import block sorting) for this file
 
 import os
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Mock strands modules before importing orchestrator modules
-sys.modules["strands"] = MagicMock()
-sys.modules["strands.models"] = MagicMock()
-sys.modules["strands.hooks"] = MagicMock()
-sys.modules["strands.hooks.events"] = MagicMock()
-sys.modules["strands.agent"] = MagicMock()
-sys.modules["strands.agent.conversation_manager"] = MagicMock()
-sys.modules["strands.tools"] = MagicMock()
-sys.modules["strands.tools.mcp"] = MagicMock()
-
-# Mock bedrock_agentcore modules
-sys.modules["bedrock_agentcore"] = MagicMock()
-sys.modules["bedrock_agentcore.tools"] = MagicMock()
+# `strands` and `bedrock_agentcore` are stubbed by tests/conftest.py, and ONLY
+# when genuinely absent. This module used to force MagicMocks into `sys.modules`
+# here instead, unconditionally and without ever restoring them — which replaced
+# a real installed `strands` for every test module imported after this one, so
+# whether the agentic tests ran against the real library depended on collection
+# order. See the note in tests/conftest.py.
 
 
 @pytest.fixture

--- a/lib/idp_common_pkg/tests/unit/extraction/agentic_idp/test_extraction.py
+++ b/lib/idp_common_pkg/tests/unit/extraction/agentic_idp/test_extraction.py
@@ -94,6 +94,12 @@ class License(BaseModel):
         return value
 
 
+# LIVE Bedrock: the s3_bucket fixture passes bedrock URLs through to real AWS,
+# and this one calls the model directly. Marked `integration` so the default
+# gate (`-m "not integration"`) excludes it — it costs money and needs
+# credentials. It previously carried only `agentic`, which nothing filters on,
+# so it was one unconditional stub away from billing CI five times per run.
+@pytest.mark.integration
 @pytest.mark.agentic
 @pytest.mark.parametrize("execution_number", range(5))
 @pytest.mark.skipif(not STRANDS_AVAILABLE, reason="strands package not available")
@@ -111,6 +117,7 @@ def test_structured_output_call_license(execution_number):
     assert result.expiration_date == "08/20/1970", result.expiration_date
 
 
+@pytest.mark.integration  # LIVE Bedrock — see the note above.
 @pytest.mark.agentic
 @pytest.mark.parametrize("execution_number", range(1))
 @pytest.mark.skipif(not STRANDS_AVAILABLE, reason="strands package not available")
@@ -119,7 +126,7 @@ def test_payslip(execution_number, s3_bucket):
     Test agentic extraction using lending_package.pdf sample config.
 
     This test validates the agentic extraction flow:
-    - Loads pattern-2 lending-package-sample config
+    - Loads the unified lending-package-sample config
     - Processes first page of lending_package.pdf (Payslip)
     - Verifies extraction results structure
     """
@@ -136,7 +143,10 @@ def test_payslip(execution_number, s3_bucket):
     config_path = (
         Path(__file__).parent.parent.parent.parent.parent.parent.parent
         / "config_library"
-        / "pattern-2"
+        # `pattern-2` was removed by the unification; the preset lives under
+        # `unified` now. The old path had rotted unnoticed because this test
+        # never ran.
+        / "unified"
         / "lending-package-sample"
         / "config.yaml"
     )

--- a/lib/idp_common_pkg/tests/unit/extraction/test_agentic_idp_unit.py
+++ b/lib/idp_common_pkg/tests/unit/extraction/test_agentic_idp_unit.py
@@ -286,20 +286,58 @@ class TestBuildModelConfig:
 
 
 class TestGetInferenceParams:
+    """`temperature` and `top_p` are mutually exclusive on Bedrock, and Claude
+    4.7+ rejects both.
+
+    These three tests spent their whole life skipped — ``strands`` was stubbed
+    unconditionally, so the module-level guard import saw a MagicMock and
+    reported the package as missing. In the meantime ``_get_inference_params``
+    gained a required ``model_id`` and they had rotted into a ``TypeError``.
+    """
+
+    # Not Claude 4.7+, so the mutual-exclusion rules apply.
+    SAMPLING_MODEL = "us.anthropic.claude-sonnet-4-6"
+
     def test_temperature_only(self):
-        params = _get_inference_params(temperature=0.0, top_p=None)
+        params = _get_inference_params(self.SAMPLING_MODEL, temperature=0.0, top_p=None)
         assert "temperature" in params
         assert "top_p" not in params
 
     def test_top_p_when_positive(self):
-        params = _get_inference_params(temperature=0.5, top_p=0.9)
+        params = _get_inference_params(self.SAMPLING_MODEL, temperature=0.5, top_p=0.9)
         assert "top_p" in params
         assert "temperature" not in params
 
     def test_top_p_zero_uses_temperature(self):
-        params = _get_inference_params(temperature=0.5, top_p=0.0)
+        """`top_p: 0.0` means "unset", not "top_p of zero" — a literal 0.0 would
+        make the model degenerate, and temperature=0 is the recommended way to
+        ask for deterministic output."""
+        params = _get_inference_params(self.SAMPLING_MODEL, temperature=0.5, top_p=0.0)
         assert "temperature" in params
         assert "top_p" not in params
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "us.anthropic.claude-opus-4-7",
+            "us.anthropic.claude-sonnet-5",
+            "us.anthropic.claude-opus-5",
+        ],
+    )
+    def test_claude_4_7_plus_gets_no_sampling_params_at_all(self, model_id):
+        """These models **reject** `temperature`/`top_p` outright, so passing
+        either fails the ConverseStream call with "`top_p` is deprecated for this
+        model" (#304). The helper must return an empty dict — the whole reason it
+        takes a model_id, and the behavior these tests could not see while they
+        were skipped."""
+        assert _get_inference_params(model_id, temperature=0.0, top_p=0.9) == {}
+
+    def test_a_nova_model_still_gets_sampling_params(self):
+        """Guard-the-guard: the 4.7+ exclusion must not swallow every model."""
+        params = _get_inference_params(
+            "us.amazon.nova-lite-v1:0", temperature=0.0, top_p=None
+        )
+        assert params, "Nova accepts temperature; an empty dict would be wrong"
 
 
 # ──────────────────────────────────────────────────────────────

--- a/lib/idp_common_pkg/tests/unit/test_suite_hygiene.py
+++ b/lib/idp_common_pkg/tests/unit/test_suite_hygiene.py
@@ -1,0 +1,204 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""Guards for two ways this suite silently stopped testing things.
+
+**1. A test module must not replace a real installed package globally.**
+Five modules under ``tests/unit/agents/`` did ``sys.modules["strands"] =
+MagicMock()`` at import time, unconditionally and without ever restoring it.
+``strands-agents`` is a real dependency of the ``[all]`` extra that both
+``make dev`` and CI install, so this replaced a working package for every test
+module imported *after* them. Consequences:
+
+* 42 agentic tests guarded by ``from strands... import ...`` saw a MagicMock,
+  reported "strands-agents package not installed", and skipped — permanently, in
+  every environment. Skipped reads as green, so the agentic extraction path
+  appeared covered while none of it executed.
+* Whether the remaining agentic tests ran against the real library depended on
+  **collection order**, which is why the same 18 tests passed under
+  ``pytest tests/unit/extraction`` and failed under ``pytest tests/unit``.
+
+Stubbing now happens once, in ``tests/conftest.py``, and only for packages that
+are genuinely absent.
+
+**2. A live-Bedrock test must be excluded from the default gate.** The gate runs
+``-m "not integration"``. Two tests that call real Bedrock (5+1 parametrized
+runs) carried only ``@pytest.mark.agentic``, which nothing filters on — so the
+only thing standing between them and a billed CI run was the very stub that was
+breaking everything else.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+import pytest
+
+TESTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+#: Packages a test module may never install a global stub for, because they are
+#: real dependencies of an extra the dev/CI environments install.
+_REAL_PACKAGES = ("strands", "bedrock_agentcore")
+
+#: ``conftest.py`` owns the conditional stubbing and is therefore exempt.
+_EXEMPT = {"conftest.py"}
+
+
+def _py_files():
+    for root, _dirs, files in os.walk(TESTS_DIR):
+        if "__pycache__" in root:
+            continue
+        for fn in files:
+            if fn.endswith(".py") and fn not in _EXEMPT:
+                yield os.path.join(root, fn)
+
+
+def _global_sysmodules_writes(path):
+    """``sys.modules["<pkg>"] = ...`` at MODULE level (not inside a function).
+
+    Module level is the part that matters: an assignment inside a test or fixture
+    is at least scoped to something, while a module-level one fires at import and
+    persists for the whole session. Parsed with ``ast`` so a mention in a comment
+    or docstring cannot trigger it.
+    """
+    with open(path) as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    hits = []
+    for node in tree.body:  # module level only
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Attribute)
+                and target.value.attr == "modules"
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                name = target.slice.value
+                root = name.split(".")[0]
+                if root in _REAL_PACKAGES:
+                    hits.append((name, node.lineno))
+    return hits
+
+
+@pytest.mark.unit
+def test_the_file_sweep_is_not_vacuous():
+    """Guard-the-guard: an empty walk would make the next test always pass."""
+    files = list(_py_files())
+    assert len(files) > 50, f"expected to sweep the test tree, found {len(files)} files"
+
+
+@pytest.mark.unit
+def test_no_module_globally_stubs_a_real_package():
+    offenders = {}
+    for path in _py_files():
+        hits = _global_sysmodules_writes(path)
+        if hits:
+            offenders[os.path.relpath(path, TESTS_DIR)] = hits
+    assert not offenders, (
+        "these modules replace a REAL installed package in sys.modules at import "
+        "time, which leaks into every module imported afterwards:\n"
+        + "\n".join(f"  {f}: {h}" for f, h in offenders.items())
+        + "\nLet tests/conftest.py stub conditionally instead, or scope the mock "
+        "with patch.dict(sys.modules, ...) inside the test."
+    )
+
+
+@pytest.mark.unit
+def test_strands_is_the_real_package_when_installed():
+    """The outcome the guard above protects. If ``strands`` is importable at all,
+    the suite must be running against it — not a mock that makes every agentic
+    test skip while reporting success."""
+    try:
+        import importlib.util
+
+        installed = importlib.util.find_spec is not None
+        import strands
+    except ImportError:
+        pytest.skip("strands-agents genuinely not installed in this environment")
+    assert installed
+    assert not str(type(strands)).endswith("MagicMock'>"), (
+        "strands is installed but the test suite replaced it with a MagicMock; "
+        "42 agentic tests will report 'package not installed' and skip"
+    )
+    # A MagicMock answers any attribute, so a real submodule import is the check
+    # that actually distinguishes them.
+    from strands.types.agent import AgentInput  # noqa: F401
+
+
+def _marker_names(node):
+    """Marker names on a function decorator list (``pytest.mark.<name>``)."""
+    names = set()
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        # pytest.mark.integration  ->  Attribute(attr='integration')
+        if isinstance(target, ast.Attribute):
+            names.add(target.attr)
+    return names
+
+
+def _modules_that_reach_real_bedrock():
+    """Modules whose moto setup lets Bedrock calls through to real AWS.
+
+    Detected from the ``passthrough`` URL config rather than from a marker,
+    because the marker is exactly the thing that goes missing.
+    """
+    out = []
+    for path in _py_files():
+        if os.path.abspath(path) == os.path.abspath(__file__):
+            continue  # this module names the pattern in order to detect it
+        with open(path) as fh:
+            src = fh.read()
+        # All three: a moto context, a URL passthrough list, and bedrock in it.
+        # Requiring all three keeps a module that merely mentions "bedrock" out.
+        if "mock_aws" in src and '"passthrough"' in src and "bedrock" in src:
+            out.append((path, src))
+    return out
+
+
+@pytest.mark.unit
+def test_live_bedrock_tests_are_excluded_from_the_default_gate():
+    """The gate runs ``-m "not integration"``, so a live-Bedrock test without
+    that marker is billed on every run.
+
+    ``agentic`` is NOT sufficient: in this suite it means "needs the real
+    ``strands`` package", which most tests under ``agentic_idp/`` legitimately do
+    without calling a model. Only the ones that actually reach AWS need
+    ``integration``.
+    """
+    offenders = {}
+    for path, src in _modules_that_reach_real_bedrock():
+        tree = ast.parse(src, filename=path)
+        module_marks = set()
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "pytestmark" for t in node.targets
+            ):
+                module_marks.add("pytestmark")
+        bad = [
+            node.name
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name.startswith("test_")
+            and "integration" not in _marker_names(node)
+            and not module_marks
+        ]
+        if bad:
+            offenders[os.path.relpath(path, TESTS_DIR)] = bad
+    assert not offenders, (
+        "these tests let Bedrock calls through to real AWS but are not marked "
+        f"`integration`, so the default gate runs them: {offenders}"
+    )
+
+
+@pytest.mark.unit
+def test_that_bedrock_sweep_found_the_known_live_module():
+    """Guard-the-guard: if the detection stops matching, the test above passes
+    for the wrong reason."""
+    found = [os.path.basename(p) for p, _ in _modules_that_reach_real_bedrock()]
+    assert "test_extraction.py" in found, (
+        "expected to detect the live agentic extraction module; the passthrough "
+        f"detection may have gone stale (found: {found})"
+    )


### PR DESCRIPTION
Follow-on from #741. That PR found a shipped bug because a feature's tests never went through the service; this one is the same shape at suite scale.

**42 agentic tests reported "strands-agents package not installed" and skipped — in every environment, including CI. It was installed the whole time.**

`strands-agents` is a dependency of the `[all]` extra that both `make dev` and CI (`make install-first-party` → `[all,dev,test]`) install. Six test modules did `sys.modules["strands"] = MagicMock()` at import time, unconditionally and without ever restoring it, replacing the real package for every module imported after them.

Two consequences, the second worse than the first:

1. **Those 42 tests could never fail.** Skipped reads as green, so the agentic extraction path — the most intricate code in the package — looked covered while none of it executed.
2. **Whether the *remaining* agentic tests ran against the real library depended on collection order.** That's why the same 18 tests passed under `pytest tests/unit/extraction` and failed under `pytest tests/unit`. Not flakiness — just which file got imported first.

Stubbing now happens once in `tests/conftest.py` and only for genuinely-absent packages (`_stub_if_absent`). `bedrock_agentcore` routes through the same helper so there's one mechanism instead of two.

| | passed | skipped |
|---|---|---|
| `develop` | 4291 | 55 |
| this branch | **4400** | **15** |

## Two real defects were hiding behind the skips

**1. `TestGetInferenceParams` had rotted into a `TypeError`.** The function gained a required `model_id` when Claude 4.7+/Sonnet 5 support landed — those models *reject* `temperature`/`top_p` (#304). Fixed, and extended to assert that model-dependent behavior, which is the entire reason the parameter exists and was untested until now, plus a Nova case so the exclusion can't swallow every model.

**2. Two tests that call real Bedrock ran in the default gate.** Their moto fixture passes bedrock URLs through to real AWS (`test_structured_output_call_license` × 5 params, `test_payslip`), and they carried only `@pytest.mark.agentic` — which nothing filters on. The only thing preventing billed CI runs was the very stub that was breaking everything else. Marked `integration`; their config path (`config_library/pattern-2/...`, removed by the pattern unification) fixed — rot that went unnoticed because the test never ran. `agentic` is now a registered marker documented as "always combine with `integration`".

> Note on `agentic`: in this suite it means "needs the real `strands` library", **not** "calls a model" — most `agentic_idp/` tests legitimately need the library without calling Bedrock. So the new guard keys on the moto passthrough config rather than on the marker, because the marker is the thing that goes missing.

## Guards

`tests/unit/test_suite_hygiene.py` (5 tests):
- No module may globally stub a real installed package (AST, module scope only — an assignment inside a test is at least scoped to something).
- `strands` must **be** the real package whenever it is importable.
- Any module whose moto config lets Bedrock through must be `integration`-marked.
- Two guard-the-guard tests so neither sweep can pass by finding nothing.

Each proven failing-without by re-injecting the defect, then restored and confirmed green.

## Verification

- `lib/idp_common_pkg/tests`: 4400 passed, 15 skipped
- **Full gate: all 58 roots pass** (`scripts/run_all_tests.py`)
- `make ruff-lint`, `make format` clean

No production code changes — test infrastructure and two test fixes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)