### PR TITLE
docs(benchmarking): correct my #653 conclusion — !769 validates the boundary block

### DIFF
--- a/benchmarks/results/v0.6.7/boundary-factorial/FINDINGS.md
+++ b/benchmarks/results/v0.6.7/boundary-factorial/FINDINGS.md
@@ -1,4 +1,33 @@
-# #653 boundary detection — the prompt change is unvalidated
+# #653 boundary detection — a Sonnet-5 factorial with no detection power
+
+> ## ⚠️ Superseded. Read this first.
+>
+> This file originally concluded that the #653 prompt block was **unvalidated** and
+> that the "0% → 60%" figure should be **retracted**. Both conclusions were wrong,
+> and the error was mine:
+>
+> * **The block is validated.** GitLab **!769** measured the same rules on
+>   **DocSplit-Poly-Seq** — 500 packets, 7,330 pages, 2,027 sections, 5,000
+>   packet-runs, five models, 0 failures. Split accuracy improves on four of five
+>   models (Qwen3-VL +0.117, Opus 5 +0.040, Nova 2 Lite +0.030, Sonnet 5 +0.013,
+>   all p<0.05) and **regresses on none**; under-split rate is 0.000 in all ten
+>   cells. On #653's reported 2-page form Sonnet 5 goes 6/24 → 10/10; on a 4-page
+>   packet of two copies of one form, 1/10 → 5/5. See
+>   [../boundary/FINDINGS.md](../boundary/FINDINGS.md) § Superseded by !769.
+> * **The 0% → 60% figure stands.** It was measured on **Nova 2 Lite** (the shipped
+>   default). This factorial ran on **Sonnet 5**. I retracted a Nova-2-Lite result
+>   because a Sonnet-5 run did not reproduce it — a cross-model comparison, which
+>   is not a retraction of anything. !769 independently measures the unpaginated
+>   case at **0/5 → 3/5**, i.e. the same 0% → 60%.
+> * **Why this run found nothing.** !769 puts Sonnet 5 at **+0.013**, the smallest
+>   significant effect of the five models. Three clean synthetic documents at n=5
+>   cannot resolve +0.013. This is a null result from an underpowered test, not
+>   evidence of absence — and the corpus limitation was already documented in the
+>   sibling findings file before I wrote this one.
+>
+> What still stands from this run, unaffected: the `split-disabled` result below,
+> and the fact that no arm loses rows.
+
 
 **Run:** 2026-09-03, stack `IDP1` (us-west-2, acct 912625584728), develop @ v0.6.7.dev5
 plus PR #744. Classification model `us.anthropic.claude-sonnet-5` throughout — the
@@ -27,24 +56,20 @@ Completeness recall was 1.0 in every run of every arm — no arm loses rows.
 where two are correct). So `sections_correct` does discriminate, and the 1.00s are
 a real result rather than a broken metric.
 
-## What this means, stated carefully
+## What this run does and does not show
 
-The honest conclusion is **not** "the #653 prompt block does nothing". It is:
+It shows that on **three clean synthetic documents at Sonnet 5**, the pre-fix and
+post-fix prompts are indistinguishable — 1.00 everywhere. Given !769 measures
+Sonnet 5's true effect at +0.013, that is the expected outcome of a test with no
+power at that effect size, and it should not have been written up as though the
+feature were unsupported.
 
-> **This corpus cannot reproduce the bug #653 reports, so it cannot validate the
-> fix either.** The prompt change shipped on-by-default and is currently supported
-> by no measurement.
+**The instrument is not vacuous.** In the same runs, `split-disabled` on
+`twodocs_2x20` scores **0.00 in every condition** (it emits one all-pages section
+where two are correct). So `sections_correct` does discriminate; the 1.00s are a
+real measurement of a real null, on documents both prompts handle.
 
-Two things follow:
-
-1. The `<boundary-detection-rules>` block (~652 tokens, inside the cacheable
-   classification prefix, sent per page) is **unjustified by evidence**. It is also
-   not harmful here: no regression on any shape, no row loss.
-2. An earlier, less controlled measurement in the development of PR #737 reported
-   the unpaginated 3-page case going 0% → 60%. **That does not reproduce.** It was
-   taken before #731 (classification confidence) and #740 (OCR dpi 150 → 300)
-   landed, and without the pre-fix control arm this factorial provides. Treat the
-   0% → 60% figure as retracted.
+Completeness recall was 1.0 in every run of every arm — no arm loses rows.
 
 ## Why the corpus probably cannot reproduce it
 
@@ -61,14 +86,19 @@ them out as confounds, and both were ruled out.
 
 ## Recommended next step
 
-Do **not** draw a conclusion about the prompt from this. Either obtain a
-reproducing document and re-run this factorial against it, or revert the block as
-unjustified. Keeping it silently as "probably helps" is the one option the evidence
-does not support.
+**Keep the block.** !769 is the deciding evidence and it is overwhelming relative to
+this run.
 
-The `split-disabled` result is separately actionable and solid: **it is wrong by
-construction on multi-document files** (0/5, one section where two are correct), so
-it must not be recommended as a workaround for packets.
+The useful lesson here is about the corpus, not the fix: this synthetic corpus
+cannot detect a boundary-prompt effect at Sonnet 5, because its documents carry
+unambiguous opening header blocks, distinct account numbers per copy, and explicit
+`Page N of M` footers. Any future boundary work should be measured on
+DocSplit-Poly-Seq (or a corpus like it) rather than here, or on this corpus only at
+a model where the effect is large (Qwen3-VL, +0.117).
+
+The `split-disabled` result is separately actionable and unaffected: **it is wrong by
+construction on multi-document files** (0/5, one section where two are correct), so it
+must not be recommended as a workaround for packets.
 
 ## Reproducing
 

--- a/docs/benchmarking/config-guidance.md
+++ b/docs/benchmarking/config-guidance.md
@@ -104,7 +104,7 @@ metric each is judged on). Advice for the ones that have been measured is in §7
 | Forcing | `extraction.forced_tool.enabled` | yes — §7 |
 | Schema restatement | `extraction.agentic.restate_schema_in_system_prompt` | yes — §7 |
 | Section splitting | `classification.sectionSplitting` | yes — §7 |
-| Boundary prompt | `classification.task_prompt` (frozen variants, control only) | yes — §7 |
+| Boundary prompt | `classification.task_prompt` (frozen variants, control only) | yes, but underpowered here — !769 is the authority, §7 |
 | Classification confidence | `classification.confidence.mode` | not yet (cost unmeasured) |
 | Classification model | `classification.model` | held at Sonnet 5 for §7 only |
 | OCR DPI | `ocr.image.dpi` | as a control only — §7 |
@@ -426,17 +426,38 @@ packet** — it emits one all-pages section where two are correct, losing the sp
 (completeness recall stays 1.0, so nothing else reports it). Do not recommend it to avoid
 over-splitting.
 
-### The `<boundary-detection-rules>` prompt block (#653) — unvalidated
+### The `<boundary-detection-rules>` prompt block (#653) — keep it
 
-A full factorial of prompt × `classification.confidence.mode` × `ocr.image.dpi`, 90 runs,
-found **no difference on any shape**: all six arms score 1.00. An earlier, uncontrolled
-figure of 0% → 60% on the unpaginated document **does not reproduce and is retracted**.
+**Validated by GitLab !769**, which measured the same rules on **DocSplit-Poly-Seq**:
+500 packets, 7,330 pages, 2,027 sections, 5,000 packet-runs, five models, 0 failures.
+Split accuracy on multi-section packets improves on four of five models and regresses
+on none — Qwen3-VL +0.117, Opus 5 +0.040, Nova 2 Lite +0.030, Sonnet 5 +0.013 (all
+p<0.05), gpt-5.6-sol +0.004 (ns). Under-split rate is 0.000 in all ten cells, so the
+anti-over-merge clause holds at scale, and page-level *class* accuracy moves at most
+0.015 — the change touches boundaries only. On #653's reported 2-page form Sonnet 5
+goes 6/24 → 10/10; on a 4-page packet of two copies of one form, 1/10 → 5/5.
 
-The defensible conclusion is not "the block does nothing" but that **this corpus cannot
-reproduce the bug the block addresses, so it cannot validate it either** — the generator
-writes clean documents with unambiguous header blocks and explicit `Page N of M` footers,
-and both prompts handle those. Full write-up and reproduction commands:
-`benchmarks/results/v0.6.7/boundary-factorial/FINDINGS.md`.
+⚠️ **Still incomplete**: an unpaginated multi-page document is split roughly 40% of the
+time even with the fix, because the rules lean on pagination markers — corpora whose
+scans lack them benefit least. Raising `classification.contextPagesCount` is not the
+answer (0/5 on the 4-page two-copies packet, by merging all four pages). The block sits
+inside the prompt-cache prefix, so it is not re-billed per page.
+
+⚠️ **A customized `classification.task_prompt` wins over the default**, so a stored
+custom prompt does not receive this fix — re-apply it or reset to the default. The
+presets that pin their own prompt are synced, with a guard test
+(`scripts/tests/test_classification_prompt_copies_in_sync.py`).
+
+> **A local factorial here found nothing, and that was a measurement failure, not a
+> result.** 90 runs over prompt × `classification.confidence.mode` × `ocr.image.dpi`
+> scored 1.00 in all six arms — but on **Sonnet 5**, whose true effect !769 puts at
+> +0.013, across three clean synthetic documents at n=5. That test has no power at
+> that effect size. It also led me to "retract" a 0% → 60% figure that had been
+> measured on **Nova 2 Lite**, which was a cross-model comparison rather than a
+> retraction; !769 independently measures that case at 0/5 → 3/5. Details and the
+> corrected write-up:
+> `benchmarks/results/v0.6.7/boundary-factorial/FINDINGS.md`. Measure boundary work on
+> DocSplit-Poly-Seq, not on this corpus.
 
 ### Not yet measured
 


### PR DESCRIPTION
Self-correction. In the commit that landed with #744 I wrote up a 90-run factorial as showing the #653 `<boundary-detection-rules>` block was **unvalidated**, and retracted the earlier 0% → 60% figure. Both conclusions were wrong.

## The block is validated

GitLab **!769** (@mmiakashs) measured the same rules on **DocSplit-Poly-Seq** — 500 packets, 7,330 pages, 2,027 sections, 5,000 packet-runs, five models, 0 failures:

| model | Δ split accuracy | |
|---|---|---|
| Qwen3-VL | +0.117 | p<0.05 |
| Opus 5 | +0.040 | p<0.05 |
| Nova 2 Lite | +0.030 | p<0.05 |
| **Sonnet 5** | **+0.013** | p<0.05 |
| gpt-5.6-sol | +0.004 | ns |

No model regresses. Under-split rate 0.000 in all ten cells. Class accuracy moves ≤0.015. On #653's reported 2-page form Sonnet 5 goes **6/24 → 10/10**; on a 4-page packet holding two copies of one form, **1/10 → 5/5** — the exact shape I had claimed could not be tested.

## Two errors, both mine

**1. I compared across models.** The 0% → 60% figure was measured on **Nova 2 Lite** (the shipped default). My factorial ran on **Sonnet 5**. A Sonnet-5 run failing to reproduce a Nova-2-Lite result is not a retraction of it. !769 independently measures that case at **0/5 → 3/5** — the same 0% → 60%. The original number stands.

**2. The test had no power.** !769 puts Sonnet 5 at **+0.013**, the smallest significant effect of the five. Three clean synthetic documents at n=5 cannot resolve that. My generator writes unambiguous opening header blocks, distinct account numbers per copy, and explicit `Page N of M` footers — both prompts handle those, so the comparison was always going to be flat. A null from an underpowered test is not evidence of absence.

**Compounding it:** `benchmarks/results/v0.6.7/boundary/FINDINGS.md` already carried a "Superseded by !769" section stating precisely this, so the file I added sat next to a sibling it contradicted. It is now a forward pointer instead.

## What survives from that run

Orthogonal to the prompt, and unchanged:

- **`sectionSplitting: disabled` is not a safe workaround** — 0.00 in every condition on a two-document file (one all-pages section where two are correct), and completeness recall stays 1.0 so nothing else reports it.
- **No arm loses rows** — recall 1.0 throughout.

The instrument was sound; the corpus was the problem. Recorded as guidance: measure boundary work on DocSplit-Poly-Seq, or on this corpus only at a model where the effect is large.

## Changes

- `benchmarks/results/v0.6.7/boundary-factorial/FINDINGS.md` — superseded banner, corrected conclusions, retitled to what it actually is (a Sonnet-5 factorial with no detection power).
- `docs/benchmarking/config-guidance.md` §7 — "keep it", with !769's numbers, the residual ~40% unpaginated limitation, the `contextPagesCount` non-fix, and the warning that a customized `task_prompt` overrides the default.

Correction also posted to #653.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)