### PR TITLE
docs(config): correct the system-defaults guidance, and stop configuration.md implying it lists every setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,32 @@ classes:
 
 All other settings (OCR, classification, extraction, assessment, evaluation, summarization, discovery, agents) are inherited from the pattern's system defaults.
 
+### The system defaults are the canonical list of every setting
+
+This page is organized by topic and covers the settings people ask about most — it is
+**not** an exhaustive key reference, and a newly added option may not be described here
+yet. The authoritative enumeration is the `system_defaults/` directory itself:
+
+| file | covers |
+|---|---|
+| `base.yaml` | top-level keys shared by every pattern |
+| `base-ocr.yaml` | OCR backends and image handling |
+| `base-classification.yaml` | classification, `sectionSplitting`, `contextPagesCount` |
+| `base-extraction.yaml` | extraction, `agentic.*`, `forced_tool.*`, `multi_instance_detection.*` |
+| `base-confidence.yaml` | assessment / confidence |
+| `base-evaluation.yaml`, `base-summarization.yaml`, `base-discovery.yaml`, `base-agents.yaml`, `base-chat.yaml`, `base-geometry.yaml`, `base-rule-validation.yaml`, `base-rule-discovery.yaml`, `base-classes.yaml`, `base-notes.yaml` | the remaining stages |
+| `pattern-1.yaml` / `pattern-2.yaml` | which of the above compose for BDA vs Pipeline mode |
+
+Every key in those files carries its shipped default and an inline comment explaining
+what it does, when to change it, and — where it has been measured — the evidence. Reading
+them is the reliable way to find out what is tunable; they are also what the **Web UI
+shows** for `Config#default`, so what you read there is what the UI presents.
+
+For **measured** guidance on which settings are worth changing — including the ones added
+most recently — see the [Configuration Guidance paper](./benchmarking/config-guidance.md).
+Its §7 covers the current release's options with the A/B numbers behind each
+recommendation, and states plainly where a setting was measured to buy nothing.
+
 ### Override Example
 
 To override specific settings while keeping others at defaults:

--- a/lib/idp_common_pkg/idp_common/config/system_defaults/base-extraction.yaml
+++ b/lib/idp_common_pkg/idp_common/config/system_defaults/base-extraction.yaml
@@ -57,10 +57,20 @@ extraction:
     # OFF by default — but not because it works badly. Measured on two real
     # labeled corpora (80 paired Test Studio runs):
     #
-    #   * It is EXCELLENT at the job. On 40 bank-check images with committed
-    #     ground truth it found all 18 multi-check images, raised 0 false alarms
-    #     on the 22 single-check images, and got the count exactly right on all
-    #     18 (2 to 8 checks). Precision and recall both 1.000.
+    #   * It COUNTS accurately. On 40 bank-check images with committed ground
+    #     truth it found all 18 multi-check images, raised 0 false alarms on the
+    #     22 single-check images, and got the count exactly right on all 18 (2 to
+    #     8 checks). Precision and recall both 1.000.
+    #   * But a WARNING IS NOT EVIDENCE OF LOSS, and that same run is the
+    #     cautionary example. Counting the extracted rows afterwards: 0 checks
+    #     missing, in both arms. BANK_CHECK's schema is a single `checks` array,
+    #     so the class already modelled several checks per sheet and nothing was
+    #     collapsing. The warning fired because instance_extracted_count is 1 for
+    #     a class that declares no instance axis — true whether the records are
+    #     ABSENT or PRESENT INSIDE A DECLARED ARRAY. The predicate cannot tell
+    #     those apart, so when this fires, look at the extracted data before
+    #     concluding anything was dropped. (There it was a real configuration
+    #     finding: the fix was x-aws-idp-instance-array: checks.)
     #   * Token cost is negligible: input +1.8%, output -0.5%.
     #   * On a corpus with NO multi-record documents to find, it is pure cost:
     #     RealKIE-FCC-Verified lost ~1.3 accuracy points (0.7678 -> 0.7552, worse
@@ -68,9 +78,22 @@ extraction:
     #     across four attributes rather than any one failure mode.
     #
     # A default has to be safe for the corpus that gets no benefit, so it ships
-    # off. TURN IT ON, per configuration profile, whenever one section can hold
-    # several documents of the same class — there the measurement says it will be
-    # right, and the alternative is shipping one record out of N with no signal.
+    # off.
+    #
+    # TURN IT ON, per configuration profile, when one section can hold several
+    # documents of the same class AND THE CLASS SCHEMA DESCRIBES ONLY ONE. That
+    # conjunction is what loses records; either half alone does not. A class that
+    # already declares a record array (see x-aws-idp-instance-array) is not
+    # losing anything — it just is not reporting its count.
+    #
+    # Also worth running ONCE as a pure diagnostic on any new corpus, then
+    # turning off: that is how a missing instance axis was found in the shipped
+    # ocr-benchmark preset. Two distinct uses, and only the second is a setting
+    # you leave on:
+    #   * diagnostic  — run once, act on what it names, turn off.
+    #   * standing guard — a corpus that keeps producing merged same-class
+    #     sections, where you want a warning on every affected section.
+    #
     # Detection NEVER changes the extracted data or a class's schema flags.
     # Simple extraction only (prompt and forced-tool paths).
     enabled: false

--- a/lib/idp_common_pkg/tests/unit/config/test_system_defaults_doc_parity.py
+++ b/lib/idp_common_pkg/tests/unit/config/test_system_defaults_doc_parity.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""`docs/configuration.md` points at `system_defaults/` as the canonical key list.
+
+That claim is load-bearing in two directions, which is why it is pinned here rather
+than left as prose:
+
+* **For readers.** `configuration.md` is organized by topic and does not describe
+  every key — a newly added option often lands in `system_defaults/` and in a
+  feature doc, and never in `configuration.md`. Measured at the time this was
+  written: of the release's new options, `configuration.md` mentioned **none** of
+  `multi_instance_detection`, `forced_tool`, `restate_schema_in_system_prompt` or
+  `contextPagesCount`. The fix was to stop implying the page is exhaustive and name
+  the directory that is.
+
+* **For agents reading the bundled source.** The accelerator's `docs/`, `lib/` and
+  `config_library/` trees are shipped read-only inside the auto-optimizer extension
+  image, which greps and reads them to decide what to tune. A table that names a
+  file that has been renamed sends it to a dead path, and a defaults file absent
+  from the table is a setting it will not find.
+
+So: the mapping must stay complete in both directions.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO = pathlib.Path(__file__).resolve().parents[5]
+_DEFAULTS = (
+    _REPO / "lib" / "idp_common_pkg" / "idp_common" / "config" / "system_defaults"
+)
+_DOC = _REPO / "docs" / "configuration.md"
+
+
+def _named_in_doc() -> set[str]:
+    """Every ``base-*.yaml`` / ``pattern-*.yaml`` named in backticks in the doc."""
+    return set(re.findall(r"`((?:base|pattern)-?[a-z0-9-]*\.yaml)`", _DOC.read_text()))
+
+
+def test_every_defaults_file_is_named_in_the_configuration_doc():
+    """A defaults file missing from the table is a whole stage's settings that a
+    reader — or the extension agent grepping the bundled docs — will not discover."""
+    on_disk = {p.name for p in _DEFAULTS.glob("*.yaml")}
+    assert on_disk, f"no defaults files found under {_DEFAULTS}"
+    missing = sorted(on_disk - _named_in_doc())
+    assert not missing, (
+        "these system_defaults files are not named in docs/configuration.md, so "
+        f"their settings are undiscoverable from it: {missing}"
+    )
+
+
+def test_every_file_named_in_the_doc_exists():
+    """The other direction: a renamed defaults file leaves the doc pointing at a
+    path that is not there, which is worse than saying nothing."""
+    stale = sorted(n for n in _named_in_doc() if not (_DEFAULTS / n).exists())
+    assert not stale, (
+        f"docs/configuration.md names defaults files that do not exist: {stale}"
+    )
+
+
+def test_the_doc_disclaims_being_exhaustive_and_points_somewhere_useful():
+    """The specific failure this guards is a reader concluding an option does not
+    exist because this page does not mention it."""
+    text = _DOC.read_text()
+    assert "not** an exhaustive key reference" in text, (
+        "docs/configuration.md must not imply it lists every setting"
+    )
+    assert "config-guidance.md" in text, (
+        "it should point at the measured guidance paper for which settings to change"
+    )


### PR DESCRIPTION
Follow-up to #768, found by verifying a claim I made about the auto-optimizer extension.

## Why this exists

I told the user the auto-optimizer "can't discover" this release's new settings. **That was wrong** — the extension bundles the accelerator's `docs/`, `lib/`, `config_library/`, `patterns/` and `template.yaml` read-only into its image and can grep and read all of it. Verifying it properly turned up two real gaps on *our* side.

## 1. `base-extraction.yaml` still had the guidance #768 retracted

This is the **most-read copy** of that text: the Web UI renders it for `Config#default`, and it is where the extension's own suggested `path_filter` values (`"extraction"`, `"config"`) land. It still said:

> TURN IT ON, per configuration profile, whenever one section can hold several documents of the same class — … the alternative is shipping one record out of N with no signal.

That is exactly the overclaim #768 retracted. On the bank-check corpus that produced the 18 warnings, **0 checks were missing in either arm**. Now corrected to what the measurement supports:

- turn it on when a section can hold several documents **and the class schema describes only one** — the conjunction is what loses records;
- a warning **cannot distinguish** "records absent" from "records present inside an undeclared array", because `instance_extracted_count` is 1 either way — so look at the extracted data before concluding loss;
- the diagnostic-vs-standing-guard split, with the `BANK_CHECK` case as the worked example.

The `question:` text is untouched, so the byte-identical drift guard against `DEFAULT_INSTANCE_QUESTION` still passes.

## 2. `docs/configuration.md` mentioned none of this release's new options

Measured across the bundled docs:

| setting | in `configuration.md`? | documented elsewhere? |
|---|---|---|
| `extraction.multi_instance_detection` | **no** | yes (3 files) |
| `x-aws-idp-multi-instance` | **no** | yes (4 files) |
| `x-aws-idp-instance-array` | **no** | yes (4 files) |
| `extraction.forced_tool` | **no** | yes (3 files) |
| `agentic.restate_schema_in_system_prompt` | **no** | yes (2 files) |
| `classification.contextPagesCount` | **no** | yes (2 files) |

The page is organized by topic and was never meant to be exhaustive, but it reads as though it is — so a reader can reasonably conclude an option does not exist. Rather than duplicate every key, it now **says** it is not exhaustive and names `system_defaults/` as the canonical enumeration, with a file→stage table and a pointer to the measured guidance paper.

**This helps every new setting, not just this one.** The same gap would have hidden the packet-splitting and schema-enforcement options equally well.

## Test

`test_system_defaults_doc_parity.py` pins the table in **both** directions:

- a defaults file missing from it is a whole stage's settings nobody can discover;
- a file named in it that has since been renamed sends readers — and a grepping agent — to a dead path.

Plus an assertion that the page keeps disclaiming exhaustiveness and keeps pointing somewhere useful, since that disclaimer is the whole fix.

## Scope

No behaviour change: comments, docs, one new test. `make lint` exit 0; `idp_common` unit suite **4969 passed / 13 skipped / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
