### PR TITLE
fix(confidence): correct three over-sizing bugs in the list-batch derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ SPDX-License-Identifier: MIT-0
 
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Confidence scoring: three ways the rows-per-inference batch could be sized too large.** Long list fields are confidence-scored in batches, and the batch is derived from the confidence model's output cap, the row's column count and whether the geometry mode asks for a bounding box per cell — `extraction.confidence.list_batch_size` (default 25) is the ceiling on that derivation, not the batch itself. Three inputs to it were wrong. The column count was measured from the list's **first row alone**, so a first row that happened to be missing a key made a wide list look narrow and inflated the batch; it is now the widest row in the list. A confidence model whose output cap could not be resolved fell back to **trusting the configured ceiling** rather than sizing down; it now sizes from a conservative cap and logs a warning. And the "Auto confidence list-batch size" shown in the processing report and the Web UI's **Processing Report** tab was derived from the **extraction** model's output cap instead of the confidence model's, so a stack extracting with Sonnet 5 and scoring with Amazon Nova Lite displayed 50 rows while the code used 13.
+
+  Over-sizing matters because a batch that overruns the model's output cap truncates, the recovery ladder halves it and retries, and every retry is a fresh paid inference — on an 800-row statement that ladder ran the Assessment Lambda into its 900-second limit five times, about 6,200 seconds, before the document ended `ABORTED`. The per-row estimate was also duplicated between `bedrock/sizing.py` and `assessment/batching.py` and the two copies disagreed by a factor of the column count, because the flat per-row figure in the first was the per-cell formula evaluated at exactly one column; there is now a single estimator. Every change here can only make a batch **smaller**: across 151 (model × column count × geometry × ceiling) combinations, 148 are byte-identical to v0.6.7 and the 3 that differ are the two defects above ([#784](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/pull/784)).
+
 ## [0.6.7]
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,7 +318,8 @@ lists automatically**: it slices the largest list field into
 `extraction.confidence.list_batch_size` chunks (default **25**), scores each chunk
 sequentially, then reconciles so every list cell gets its own confidence and
 bounding box. A bounded missing-row retry re-scores any dropped rows so coverage
-reaches 100%. Lower `list_batch_size` if a chunk under-enumerates; raise it to cut
+reaches 100%. `list_batch_size` is a ceiling on a derived size: lower it if a chunk
+under-enumerates, but raising it does not cut
 inference count.
 
 ```yaml

--- a/docs/extraction-and-confidence.md
+++ b/docs/extraction-and-confidence.md
@@ -338,7 +338,7 @@ extraction:
     max_pages_per_shard: 5        # page ceiling per shard (timeout-critical; fixed default, not model-derived)
 ```
 
-- **Model-aware auto-sizing (default).** `shard_token_budget: 0` means the per-shard OCR-token budget is derived from the extraction model's context window minus `context_buffer` — a 1M-context model (`:1m`) shards much larger than a 200K one, automatically. The confidence list-batch size is likewise auto-derived from the confidence model's output cap. You set only `context_buffer`; the derived sizes are logged and shown in the **Processing Report**. Non-zero values pin an explicit override.
+- **Model-aware auto-sizing (default).** `shard_token_budget: 0` means the per-shard OCR-token budget is derived from the extraction model's context window minus `context_buffer` — a 1M-context model (`:1m`) shards much larger than a 200K one, automatically. The confidence list-batch size is also derived, but from the **confidence** model's *output* cap, the row's column count and the geometry mode — **not** from `context_buffer`, which governs only the input-window budgets. The derived sizes are logged and shown in the **Processing Report**. Non-zero values pin an explicit override.
 - **`max_pages_per_shard` is the timeout lever.** It stays a small fixed default (5) rather than model-derived: the 900s Lambda limit is about *sequential agent turns per shard* (wall-clock), not context tokens, so a roomy token budget must not collapse a large doc back into one giant shard. Fewer pages/shard ⇒ fewer turns ⇒ each shard Lambda finishes well under 900s.
 - **Advanced defaults to the resumable runtime.** `runtime: step_functions` is now the agentic default: each shard is its own Lambda iteration in a nested Step Functions **Distributed Map**, so a very large section is not bound by the single-Lambda 15-minute limit and Step Functions **retries only the incomplete shards** (completed shards are reused from S3). `in_process` (asyncio within one Lambda) remains available but is still bound by that one Lambda's 900s.
 - **Confidence *and* bounding-box grounding are sharded too.** Each shard runs its confidence assessment **and grounds its own rows' bounding boxes against only its own pages** — so both scale per-shard and run concurrently. The final merge only concatenates already-scored, already-grounded rows (plus a fast top-up for any rows the assessment LLM omitted); it does **not** re-assess or re-ground the whole section. This keeps the merge step fast even on very large tables (previously a single full-section grounding sweep over thousands of rows could approach the merge Lambda's 900s limit).
@@ -1153,9 +1153,11 @@ and the inline-confidence retry (`integrated`) all share one implementation:
    bounding box.
 
 So large lists are handled with no extra configuration regardless of the
-Simple/Advanced or separate/integrated choice. The one knob is `list_batch_size`
-— **lower** it if a model still struggles to enumerate a full chunk; **raise** it
-to reduce the number of inference calls.
+Simple/Advanced or separate/integrated choice. The one knob is `list_batch_size`,
+and it is a **ceiling**: the size actually used is derived per list from the
+confidence model's output cap, the row's column count and the geometry mode, and is
+only ever smaller. **Lower** it to force smaller batches than the derivation;
+raising it above the derived size has no effect.
 
 ```yaml
 extraction:
@@ -1174,10 +1176,13 @@ extraction:
 > `0.5` to every field and leave list rows unscored. Advanced mode now heals this
 > automatically, cheapest-first:
 >
-> 1. **Token-aware first-pass sizing.** The first batch is sized to the confidence
->    model's output cap — so Nova Lite + `llm_grounded` starts at ~6–9 rows
->    instead of truncating at 25. This only ever *shrinks* `list_batch_size`; a
->    large-output model keeps your configured size.
+> 1. **Token-aware first-pass sizing.** The first batch is sized from three inputs:
+>    the confidence model's output cap, the **column count** of the list's widest
+>    row, and whether the geometry mode adds a bounding box per cell. On Nova Lite
+>    (10,000-token cap) with `llm_grounded` that is 13 rows for a 3-column list and
+>    5 for 8 columns; without bounding boxes three times as many fit. This only ever
+>    *shrinks* `list_batch_size` — it never grows past your configured ceiling, so
+>    raising the ceiling above the derived size has no effect.
 > 2. **Recursive splitting.** Any batch that still truncates is halved and
 >    re-assessed until it fits.
 > 3. **Model escalation.** If rows are *still* unscored after shrinking + retries,
@@ -1958,7 +1963,7 @@ the system automatically adds `confidence_threshold` from configuration.
 3. **Model selection** — Claude Haiku/Sonnet class models with `temperature: 0` for deterministic scoring.
 4. **Risk-based thresholds** — 0.90+ for critical data, 0.75–0.85 global defaults, per-attribute overrides where needed.
 5. **Keep `ocr_only` geometry** (the default) unless you have a specific reason — it is cheaper and more accurate than LLM boxes.
-6. **Tune `list_batch_size`** for large lists — lower if a chunk under-enumerates, raise to cut inference count.
+6. **Lower `list_batch_size`** for large lists only if a chunk under-enumerates — it is a ceiling on a derived size, so raising it does not cut the inference count.
 7. **Route below-threshold fields to [Human Review](human-review.md).**
 
 ---

--- a/docs/idp-configuration-best-practices.md
+++ b/docs/idp-configuration-best-practices.md
@@ -1357,7 +1357,7 @@ Confidence results automatically appear in the web interface with color-coded di
 
 1. **Enable Selectively**: Disable confidence (`enabled: false` or `mode: off`) for non-critical document types to control costs
 2. **Use Advanced (agentic) for Complex Documents**: For very large documents and big tables, prefer agentic extraction — it shards both extraction and confidence assessment and yields the best-calibrated confidence
-3. **Tune `list_batch_size` for Large Lists**: Lower it if a chunk under-enumerates; raise it to cut inference count
+3. **Lower `list_batch_size` for Large Lists** if a chunk under-enumerates. It is a ceiling on a derived size, so raising it does not cut the inference count
 4. **Configure Appropriate Image Dimensions**: Use original resolution for maximum accuracy
 5. **Monitor Resource Usage**: Track processing time and costs when using confidence features
 

--- a/docs/migration-granular-retirement.md
+++ b/docs/migration-granular-retirement.md
@@ -57,6 +57,7 @@ extraction:
 ```
 
 - **Lower** `list_batch_size` if a model still struggles to enumerate a full chunk.
+  It is a ceiling on a derived size, so raising it has no effect.
 - **Raise** it to reduce the number of inference calls.
 
 See [Large-list batching](extraction-and-confidence.md#large-list-batching-list_batch_size)

--- a/lib/idp_common_pkg/idp_common/assessment/README.md
+++ b/lib/idp_common_pkg/idp_common/assessment/README.md
@@ -139,7 +139,9 @@ extraction:
     top_k: 5
     top_p: 0.1
     reasoning_effort: low               # only if a reasoning-capable model is selected
-    list_batch_size: 25                 # rows per assessment batch for large lists
+    list_batch_size: 25                 # CEILING on rows per batch; the size used is
+                                        # derived from the confidence model's output
+                                        # cap, column count and geometry mode
     # NOTE: no max_tokens knob — the confidence pass always requests the model's
     # maximum output (resolved from config_library/model_config_limits.yaml) so
     # long list assessments are never truncated.
@@ -197,8 +199,9 @@ depend on granular assessment for large lists.
 `process_document_section` runs the assessment through the shared
 `idp_common.assessment.batching.assess_results_batched`, which:
 
-1. Finds the single largest list field whose length exceeds
-   `extraction.confidence.list_batch_size` (default 25).
+1. Finds the single largest list field whose length exceeds the effective batch
+   size (derived, and never larger than the `extraction.confidence.list_batch_size`
+   ceiling, default 25).
 2. Slices that list into `list_batch_size` chunks and assesses each chunk
    **sequentially**, passing the SAME scalars/context every time so scalar
    assessments and the document context are preserved (scalars come from the first
@@ -260,14 +263,28 @@ left 34/68 transaction rows with `confidence: null`). Two additions make advance
 mode complete correctly on the first try:
 
 1. **Token-aware first-pass sizing** (`compute_token_aware_batch_size`). Before
-   the first call, the effective batch size is derived from the confidence
-   model's output cap (`bedrock.model_utils.get_model_max_output_tokens`) and an
-   estimate of per-row output tokens (`extraction.sharding.estimate_tokens` ×
-   a confidence-envelope multiplier × a larger bbox multiplier for
-   `geometry.mode` `llm`/`llm_grounded`). The result **only ever shrinks**
-   `list_batch_size` (never grows it past your ceiling), so a small-cap model
-   (Nova Lite, 10K) starts at ~6–9 rows instead of truncating at 25. Unknown
-   models fall back to the configured size. Recorded as `derived_batch_size`.
+   the first call the batch size is derived from three inputs: the confidence
+   model's output cap (`bedrock.model_utils.get_model_max_output_tokens`), the
+   **column count** of the list's widest sampled row, and whether `geometry.mode`
+   is `llm`/`llm_grounded` (a per-cell bounding box roughly triples per-row
+   output). The estimator itself lives in `bedrock.sizing`
+   (`confidence_rows_per_call`) so this module and `compute_sizing_plan` cannot
+   drift apart. Recorded as `derived_batch_size`.
+
+   There is no correct fixed value. On Nova Lite (10,000-token cap) with bounding
+   boxes the batch that fits is 41 rows for a 1-column list, 13 for 3 columns and
+   5 for 8; on a 128K-output model the reliability cap of 50 bounds the derivation
+   instead of the token math. `list_batch_size` is therefore a **ceiling** on the
+   derived size (default 25), never a target — and an *explicit* ceiling is honoured
+   in full, so a deliberate pin above 50 is not clamped.
+
+   Two behaviours changed after v0.6.7, both in the safe direction. The column
+   count is measured across a sample of rows rather than off `rows[0]`, because a
+   first row missing a key made a wide list look narrow and inflated the batch.
+   And an unknown model, or a row shape whose width cannot be measured, now sizes
+   from a conservative fallback cap instead of returning the configured value —
+   silently trusting a permissive configured value on a small-cap model is how a
+   25-row batch reached Nova Lite in the first place.
 
 2. **Model-escalation ladder** (`extraction.confidence.escalation_*`). When rows
    are *still* unscored after token-aware shrink + same-model retries, the

--- a/lib/idp_common_pkg/idp_common/assessment/batching.py
+++ b/lib/idp_common_pkg/idp_common/assessment/batching.py
@@ -39,36 +39,24 @@ from idp_common import utils
 
 logger = logging.getLogger(__name__)
 
-# --- Token-aware batch sizing constants (see compute_token_aware_batch_size) ---
-# Fraction of the model's output cap we let a single assessment call target. A
-# batch sized to the FULL cap would truncate on any per-row estimate error, so we
-# leave headroom for the scalar/group assessments that ride every call and for
-# the model being chattier than our chars/4 estimate.
-# Target only HALF the model's output cap on the first pass (was 0.7). Confidence
-# output is variable — the model occasionally over-generates on a heavy multimodal
-# prompt — so a 50% target leaves real headroom for the first call to FIT instead
-# of sitting on the truncation edge and relying on the adaptive splitter to bisect
-# (each bisection doubles the sequential call count and, under slow Bedrock, was
-# what ran shard Lambdas into their 900s wall).
-_OUTPUT_SAFETY_FRACTION = 0.5
-# The confidence output per row is driven by the row's COLUMN COUNT, not by the
-# length of the extracted values: each scalar column emits a fixed-ish leaf like
-# ``"ColumnName": {"confidence": 0.97},`` (column-name tokens + the envelope),
-# plus an occasional short ``confidence_reason`` for the low-confidence cells.
-# Empirically (Nova Lite, live-measured on a 6-column financial row) a clean
-# per-cell cost is ~28 output tokens; we budget ~40 to leave headroom for the
-# column name, the reason allowance on sub-0.9 cells, and the model being
-# chattier than a chars/4 estimate. Sizing by columns is what makes a WIDE table
-# (many columns) correctly shrink the first-pass batch, where the old
-# value-length-based heuristic under-counted.
-_PER_CELL_CONFIDENCE_TOKENS = 40.0
+# --- Token-aware batch sizing (see compute_token_aware_batch_size) ------------
+# The per-row/per-cell token estimate, the output safety fraction and the absolute
+# batch ceiling now live in ``idp_common.bedrock.sizing`` and are imported here, so
+# there is ONE estimator. They used to be duplicated between the two modules, and
+# the copies disagreed by a factor of the column count.
 # Legacy value-length-based multiplier, kept ONLY as the fallback estimate for
 # scalar/opaque rows where per-column counting doesn't apply (non-dict rows).
 _CONFIDENCE_ENVELOPE_MULTIPLIER = 8.0
-# ``geometry.mode`` in {"llm", "llm_grounded"} appends a per-cell bounding-box
-# instruction, so each confidence leaf also emits ``bbox``/``page`` coordinates —
-# the investigation measured ~3× the output. Applied ON TOP of the envelope.
-_BBOX_GEOMETRY_MULTIPLIER = 3.0
+# Bounding-box multiplier for that same opaque-row fallback. Mirrors
+# ``bedrock.sizing._BBOX_GEOMETRY_MULTIPLIER``; kept local because the fallback
+# applies it to a value-length estimate rather than to a per-column one.
+_BBOX_GEOMETRY_MULTIPLIER_FALLBACK = 3.0
+# Rows are not guaranteed uniform — an extraction can omit a key on some rows — and
+# sizing off row 0 alone under-counts the width of every other row, which inflates
+# the batch. Counting keys over EVERY row is O(rows x columns) on data already in
+# memory, so there is no sampling window: a window would just move the same bug
+# from row 0 to the first N rows (an 800-row statement whose first 25 rows are
+# narrow would still be sized as if the whole list were narrow).
 
 # Wall-clock safety reserve (seconds). Before starting a NEW escalation round —
 # the slow, big-model call — the ladder checks that an estimated round fits in
@@ -454,6 +442,33 @@ def _schema_field_mismatch_reason(
     return None
 
 
+def count_row_columns(rows: Any) -> int | None:
+    """Widest scalar column count across a list's rows, or None if not countable.
+
+    Takes the whole row list (not one row) and returns the MAXIMUM count over
+    EVERY dict row. Sizing off ``rows[0]`` alone under-counts whenever extraction
+    omitted a key on that row, and under-counting the width inflates the batch —
+    the direction that truncates. A bare dict is accepted and treated as a single
+    row. Returns None when no dict row is found, which tells the caller to use the
+    value-length fallback.
+    """
+    if isinstance(rows, dict):
+        candidates: list[Any] = [rows]
+    elif isinstance(rows, (list, tuple)):
+        candidates = list(rows)
+    else:
+        return None
+    widest = 0
+    for row in candidates:
+        if not isinstance(row, dict):
+            continue
+        widest = max(
+            widest,
+            sum(1 for v in row.values() if not isinstance(v, (dict, list))),
+        )
+    return widest or None
+
+
 def compute_token_aware_batch_size(
     model_id: str | None,
     sample_row: Any,
@@ -462,83 +477,118 @@ def compute_token_aware_batch_size(
 ) -> int:
     """Derive a list-batch size that fits the confidence model's output cap.
 
-    The static ``list_batch_size`` (default 25) is a guess that ignores the
-    model. When the confidence model has a small output ceiling (Nova Lite:
-    10K) and each row emits a large confidence payload — tripled again by the
-    per-cell bounding-box block in ``geometry.mode: llm``/``llm_grounded`` — a
-    25-row batch overruns the cap and the response truncates (the exact failure
-    that left 34/68 rows unscored). Sizing the FIRST pass to the model's budget
-    means it fits without needing the adaptive splitter to bisect down from 25.
+    ``sample_row`` should be the list's ROW LIST; a single dict is accepted and
+    treated as one row. The column count is measured across a sample of rows
+    (:func:`count_row_columns`) rather than off row 0.
 
-    Estimation (all reused pieces): resolve the output cap from
-    ``get_model_max_output_tokens`` (falls back to ``configured_batch_size`` on
-    an unknown model), estimate per-row output tokens as
-    ``estimate_tokens(json.dumps(sample_row))`` × a confidence-envelope
-    multiplier × a bbox multiplier (only for LLM-box geometry modes), then
-    ``derived = floor(cap × 0.7 / per_row_tokens)``. The result is clamped to
-    ``[1, configured_batch_size]`` — this only ever SHRINKS the configured size
-    (never grows it past the user's ceiling) and never returns 0.
+    Why this exists: when the confidence model has a small output ceiling (Nova
+    Lite: 10,000) and each row emits a confidence leaf per column — tripled again
+    by the per-cell bounding-box block under ``geometry.mode: llm``/
+    ``llm_grounded`` — a 25-row batch overruns the cap and the response truncates.
+    That is the failure that left 34/68 rows unscored, and the failure whose
+    recovery ladder ran an Assessment Lambda into its 900-second wall five times
+    and lost a document. Sizing the FIRST pass to the model's real budget means it
+    fits without the adaptive splitter having to bisect down from 25.
+
+    ``configured_batch_size`` is a user CEILING, not a target: the result is never
+    larger. Pass 0 (or any non-positive value) for "no user ceiling", in which case
+    only the absolute reliability ceiling applies. The result is never 0.
+
+    An unknown model, or a row shape whose width cannot be measured, now yields a
+    CONSERVATIVE derived size rather than the configured value — previously either
+    case silently returned the configured 25, which is how a permissive default
+    reached a small-cap model.
     """
-    if not model_id or configured_batch_size <= 1:
-        return max(1, configured_batch_size)
+    from idp_common.bedrock.sizing import (
+        confidence_per_row_tokens,
+        confidence_rows_for_per_row_tokens,
+        confidence_rows_per_call,
+    )
 
-    from idp_common.bedrock.model_utils import get_model_max_output_tokens
-    from idp_common.extraction.sharding import estimate_tokens
+    ceiling = configured_batch_size if configured_batch_size > 0 else None
+    if ceiling is not None and ceiling <= 1:
+        return 1
 
-    try:
-        output_cap = get_model_max_output_tokens(model_id)
-    except Exception as e:  # noqa: BLE001 - unknown model → keep configured size
-        logger.debug(
-            "compute_token_aware_batch_size: unknown output cap for %s (%s); "
-            "using configured batch size %d",
-            model_id,
-            e,
+    output_cap: int | None = None
+    if model_id:
+        from idp_common.bedrock.model_utils import get_model_max_output_tokens
+
+        try:
+            output_cap = get_model_max_output_tokens(model_id)
+        except Exception as e:  # noqa: BLE001 - unknown model → conservative cap
+            logger.warning(
+                "compute_token_aware_batch_size: no output cap known for "
+                "confidence model %s (%s); sizing conservatively instead of "
+                "trusting the configured batch size %s",
+                model_id,
+                e,
+                configured_batch_size,
+            )
+    else:
+        logger.warning(
+            "compute_token_aware_batch_size: no confidence model id supplied; "
+            "sizing conservatively instead of trusting the configured batch "
+            "size %s",
             configured_batch_size,
         )
-        return max(1, configured_batch_size)
 
-    # Estimate per-row CONFIDENCE OUTPUT tokens. The output is driven by the row's
-    # column count (each scalar column emits a fixed-ish confidence leaf), NOT by
-    # the length of the extracted values — so count the row's scalar sub-fields and
-    # budget a realistic per-cell cost. This is what makes a WIDE table correctly
-    # shrink the first-pass batch; the old ``json.dumps(row) × 8`` heuristic scaled
-    # with value length and under-counted wide rows of short values (the exact
-    # Truist case: 6 short columns estimated ~256 tok but really produced ~170-400,
-    # sitting on the 10K truncation edge at batch=25).
-    if isinstance(sample_row, dict):
-        num_scalar_cols = sum(
-            1 for v in sample_row.values() if not isinstance(v, (dict, list))
+    num_columns = count_row_columns(sample_row)
+    if num_columns is not None:
+        result = confidence_rows_per_call(
+            output_cap, num_columns, geometry_mode, ceiling
         )
-        num_scalar_cols = max(1, num_scalar_cols)
-        per_row_tokens = num_scalar_cols * _PER_CELL_CONFIDENCE_TOKENS
+        per_row_tokens = confidence_per_row_tokens(num_columns, geometry_mode)
     else:
-        # Scalar/opaque row element: fall back to the value-length heuristic.
+        # Scalar/opaque rows: per-column counting does not apply, so fall back to
+        # the value-length heuristic on the first element.
+        from idp_common.extraction.sharding import estimate_tokens
+
+        first = (
+            sample_row[0]
+            if isinstance(sample_row, (list, tuple)) and sample_row
+            else sample_row
+        )
         try:
             per_row_tokens = (
-                estimate_tokens(json.dumps(sample_row, default=str))
+                estimate_tokens(json.dumps(first, default=str))
                 * _CONFIDENCE_ENVELOPE_MULTIPLIER
             )
-        except Exception:  # noqa: BLE001 - unserializable row → keep configured size
-            return max(1, configured_batch_size)
-    if per_row_tokens <= 0:
-        return max(1, configured_batch_size)
+        except Exception:  # noqa: BLE001 - unserializable row → assumed width
+            per_row_tokens = 0.0
+        if per_row_tokens <= 0:
+            # Unmeasurable row: fall back to the assumed column width rather than
+            # to the configured ceiling.
+            per_row_tokens = confidence_per_row_tokens(None, geometry_mode)
+        else:
+            if (geometry_mode or "").lower() in ("llm", "llm_grounded"):
+                per_row_tokens *= _BBOX_GEOMETRY_MULTIPLIER_FALLBACK
+            # FLOOR the value-length estimate at the cost of one confidence leaf.
+            # ``json.dumps("Robert Smith")`` is ~3 tokens, so the x8 envelope
+            # predicts ~24 output tokens for a row that really emits 40-120 — about
+            # 5x optimistic, and optimism here means a batch that truncates. Even a
+            # scalar row emits at least one leaf, so the per-cell figure is a valid
+            # floor. Without this the estimate is also non-monotonic: a 1-character
+            # scalar estimates 0 and lands on the conservative assumed width, while
+            # a 12-character scalar estimates low enough to reach the ceiling.
+            per_row_tokens = max(
+                per_row_tokens, confidence_per_row_tokens(1, geometry_mode)
+            )
+        result = confidence_rows_for_per_row_tokens(output_cap, per_row_tokens, ceiling)
 
-    if (geometry_mode or "").lower() in ("llm", "llm_grounded"):
-        per_row_tokens *= _BBOX_GEOMETRY_MULTIPLIER
-
-    derived = math.floor(output_cap * _OUTPUT_SAFETY_FRACTION / per_row_tokens)
-    result = max(1, min(configured_batch_size, derived))
-    if result < configured_batch_size:
-        logger.info(
-            "Token-aware batch sizing: model=%s cap=%d geometry=%s per_row~%d "
-            "-> batch %d (configured %d)",
-            model_id,
-            output_cap,
-            geometry_mode,
-            int(per_row_tokens),
-            result,
-            configured_batch_size,
-        )
+    # Logged unconditionally. Previously suppressed when the result equalled the
+    # configured value, which hid the sizing decision from exactly the operator most
+    # likely to be debugging it — someone who pinned a ceiling.
+    logger.info(
+        "Token-aware batch sizing: model=%s cap=%s geometry=%s cols=%s "
+        "per_row~%d -> batch %d (configured ceiling %s)",
+        model_id or "(none)",
+        output_cap if output_cap else "unknown",
+        geometry_mode,
+        num_columns if num_columns is not None else "n/a",
+        int(per_row_tokens),
+        result,
+        ceiling if ceiling is not None else "none",
+    )
     return result
 
 
@@ -629,8 +679,11 @@ def merge_split_stats(
         if v is not None
     ]
     merged["derived_batch_size"] = min(derived) if derived else None
-    merged["configured_batch_size"] = a.get("configured_batch_size") or b.get(
-        "configured_batch_size"
+    # ``is not None``, not ``or``: a legitimate configured value can be falsy, and
+    # ``or`` would silently discard it in favour of the other shard's.
+    _cfg_a = a.get("configured_batch_size")
+    merged["configured_batch_size"] = (
+        _cfg_a if _cfg_a is not None else b.get("configured_batch_size")
     )
     merged["escalation_model"] = a.get("escalation_model") or b.get("escalation_model")
     merged["deadline_reached"] = bool(
@@ -1203,18 +1256,27 @@ def assess_results_batched(
     split_stats = _new_split_stats()
     split_stats["configured_batch_size"] = batch_size
 
-    # 1.1 Token-aware first-pass sizing: shrink the batch to fit the confidence
-    # model's output cap BEFORE the first call, so a small-cap model (Nova Lite,
-    # 10K) does not truncate a 25-row batch (esp. with bbox geometry ~3× output).
-    # Only ever shrinks; a large-output model keeps the configured size.
-    effective_batch_size = batch_size
+    # 1.1 Token-aware first-pass sizing: fit the batch to the confidence model's
+    # output cap BEFORE the first call, so a small-cap model (Nova Lite, 10K) does
+    # not truncate (bbox geometry roughly triples the per-row output). ``batch_size``
+    # is a user CEILING and may be 0 meaning "no ceiling, derive it".
     all_list_fields_probe = [
         v for v in extraction_results.values() if isinstance(v, list) and v
     ]
-    if confidence_model_id and all_list_fields_probe:
-        sample_row = max(all_list_fields_probe, key=len)[0]
+    # Pass the whole row list: the widest row governs the batch, and rows are not
+    # guaranteed uniform. Sized even when confidence_model_id is empty, so a missing
+    # model falls back to a conservative size rather than to the configured ceiling.
+    #
+    # Only sized when there IS a list. With no list fields nothing below slices rows,
+    # so the derived value would be unused — and computing it would import
+    # ``extraction.sharding`` for the opaque-row fallback, pulling the whole
+    # extraction package (and strands) into the Assessment Lambda for a number it
+    # never reads.
+    effective_batch_size = batch_size
+    if all_list_fields_probe:
+        widest_list = max(all_list_fields_probe, key=len)
         effective_batch_size = compute_token_aware_batch_size(
-            confidence_model_id, sample_row, geometry_mode, batch_size
+            confidence_model_id, widest_list, geometry_mode, batch_size
         )
         split_stats["derived_batch_size"] = effective_batch_size
 
@@ -1260,7 +1322,7 @@ def assess_results_batched(
         if all_list_fields_probe:
             escalation_batch_size = compute_token_aware_batch_size(
                 ladder_escalation_model,
-                max(all_list_fields_probe, key=len)[0],
+                max(all_list_fields_probe, key=len),
                 geometry_mode,
                 batch_size,
             )

--- a/lib/idp_common_pkg/idp_common/bedrock/sizing.py
+++ b/lib/idp_common_pkg/idp_common/bedrock/sizing.py
@@ -42,10 +42,45 @@ logger = logging.getLogger(__name__)
 # ~(w*h)/750; a full-page image lands around this figure.
 _TOKENS_PER_IMAGE = 1600
 
-# Per-row confidence OUTPUT token estimate (mirrors assessment.batching): a
-# confidence leaf per column + a short reason. Larger under bbox geometry.
-_CONF_ROW_TOKENS = 40
-_CONF_ROW_TOKENS_BBOX = 120
+# --- Per-row confidence OUTPUT token estimate -------------------------------
+# These used to be duplicated: this module carried a flat per-ROW figure (40, or
+# 120 under bbox geometry) while assessment.batching carried a per-CELL figure
+# and multiplied by the row's column count. The two disagreed by a factor of the
+# column count, because the flat 120 IS the per-cell formula evaluated at exactly
+# one column (1 x 40 x 3.0) frozen as if it were universal. This module now owns
+# the single estimator (``confidence_rows_per_call``) and assessment.batching
+# imports it, so a wide table can never be sized as if it were one column wide.
+#
+# Fraction of the model's output cap a single assessment call may target. A batch
+# sized to the FULL cap truncates on any per-row estimate error, so leave
+# headroom for the scalar/group assessments that ride every call and for the
+# model being chattier than a chars/4 estimate. 0.5 (was 0.7) because confidence
+# output is variable — the model over-generates on a heavy multimodal prompt — and
+# sitting on the truncation edge makes the first call rely on the adaptive
+# splitter to bisect, which doubles the sequential call count and, under slow
+# Bedrock, ran shard Lambdas into their 900s wall.
+_OUTPUT_SAFETY_FRACTION = 0.5
+# Confidence output per row is driven by the row's COLUMN COUNT, not by the length
+# of the extracted values: each scalar column emits a fixed-ish leaf like
+# ``"ColumnName": {"confidence": 0.97},`` (column-name tokens + envelope), plus an
+# occasional short ``confidence_reason`` on low-confidence cells. Empirically
+# (Nova Lite, live-measured on a 6-column financial row) a clean per-cell cost is
+# ~28 output tokens; budget ~40 for the column name, the reason allowance on
+# sub-0.9 cells, and model chattiness.
+_PER_CELL_CONFIDENCE_TOKENS = 40.0
+# ``geometry.mode`` in {"llm", "llm_grounded"} appends a per-cell bounding-box
+# instruction, so each leaf also emits ``bbox``/``page`` coordinates — measured at
+# ~3x the output. Applied ON TOP of the per-cell cost.
+_BBOX_GEOMETRY_MULTIPLIER = 3.0
+# Column count assumed when the caller cannot supply one (``compute_sizing_plan``
+# runs per section BEFORE extraction, so no rows exist yet). Six is the width of a
+# typical transaction table and is deliberately not 1: under-estimating the width
+# is what produced a permissive batch size. The AUTHORITATIVE size is recomputed
+# from the real rows at assessment time by ``compute_token_aware_batch_size``.
+_ASSUMED_LIST_COLUMNS = 6
+# Output cap assumed when the model is unknown or its limits lookup fails. Small
+# on purpose: an unknown model must batch conservatively rather than optimistically.
+_FALLBACK_CONFIDENCE_OUTPUT_CAP = 8_000
 
 # Fallbacks when the model is unknown (limits lookup fails). Conservative so an
 # unknown model still shards rather than trying a giant single call.
@@ -159,6 +194,73 @@ def _resolve_limits(model_id: str | None) -> tuple[int, int, bool]:
     return max_in, max_out, (resolved_in and resolved_out)
 
 
+def confidence_per_row_tokens(
+    num_columns: int | None, geometry_mode: str | None
+) -> float:
+    """Estimated confidence OUTPUT tokens for one list row.
+
+    ``num_columns`` is the row's scalar column count; ``None``/non-positive falls
+    back to :data:`_ASSUMED_LIST_COLUMNS`. Bounding-box geometry modes multiply
+    the per-cell cost because each leaf also emits coordinates.
+    """
+    cols = num_columns if (num_columns and num_columns > 0) else _ASSUMED_LIST_COLUMNS
+    per_row = cols * _PER_CELL_CONFIDENCE_TOKENS
+    if (geometry_mode or "").lower() in ("llm", "llm_grounded"):
+        per_row *= _BBOX_GEOMETRY_MULTIPLIER
+    return per_row
+
+
+def confidence_rows_for_per_row_tokens(
+    output_cap: int | None,
+    per_row_tokens: float,
+    ceiling: int | None = None,
+) -> int:
+    """Rows that fit one confidence call, given a per-row output-token estimate.
+
+    ``floor(output_cap x _OUTPUT_SAFETY_FRACTION / per_row_tokens)``, clamped to
+    ``[_MIN_LIST_BATCH, ceiling]``. ``ceiling`` defaults to
+    :data:`_ABS_MAX_LIST_BATCH`; a caller with a user-configured ceiling passes the
+    smaller of the two. An unknown ``output_cap`` uses
+    :data:`_FALLBACK_CONFIDENCE_OUTPUT_CAP` rather than trusting a configured value.
+    """
+    cap = (
+        int(output_cap)
+        if (output_cap and output_cap > 0)
+        else _FALLBACK_CONFIDENCE_OUTPUT_CAP
+    )
+    # _ABS_MAX_LIST_BATCH applies ONLY when auto-deriving (no explicit ceiling). An
+    # explicit ceiling is a deliberate user choice and is honoured in full: clamping
+    # it here would silently turn a pinned 75 into 50, which earlier releases did
+    # not do on the path that decides the real batch. The reliability cap therefore
+    # bounds what the SYSTEM picks, never what the operator asked for.
+    if ceiling is not None:
+        limit = max(_MIN_LIST_BATCH, ceiling)
+    else:
+        limit = _ABS_MAX_LIST_BATCH
+    if per_row_tokens <= 0:
+        return limit
+    derived = int(cap * _OUTPUT_SAFETY_FRACTION // per_row_tokens)
+    return max(_MIN_LIST_BATCH, min(limit, derived))
+
+
+def confidence_rows_per_call(
+    output_cap: int | None,
+    num_columns: int | None,
+    geometry_mode: str | None,
+    ceiling: int | None = None,
+) -> int:
+    """Rows one confidence call can score without truncating.
+
+    There is no single correct constant here — the answer is a function of the
+    model's output cap, the geometry mode and the column count. On Nova Lite
+    (10,000 cap) with bounding boxes it is 41 rows for a 1-column list, 13 for 3
+    columns and 5 for 8; on Sonnet 5 (128,000) the reliability ceiling binds first.
+    """
+    return confidence_rows_for_per_row_tokens(
+        output_cap, confidence_per_row_tokens(num_columns, geometry_mode), ceiling
+    )
+
+
 def compute_sizing_plan(
     *,
     model_id: str | None,
@@ -166,6 +268,14 @@ def compute_sizing_plan(
     geometry_mode: str | None = None,
     max_images_per_agent: int = 20,
     default_max_pages_per_shard: int = 5,
+    # The model that runs the CONFIDENCE pass. Defaults to ``model_id`` only for
+    # back-compat; callers should pass ``extraction.confidence.model``, because the
+    # list-batch figure is meaningless when derived from the extraction model.
+    confidence_model_id: str | None = None,
+    # Scalar column count of the list being scored, when known. ``compute_sizing_plan``
+    # runs before extraction, so this is normally None and a conservative width is
+    # assumed; the authoritative value is recomputed from real rows at assessment time.
+    list_columns: int | None = None,
     # Explicit overrides (None = auto-derive). Kept so power users / tests can pin.
     shard_token_budget_override: int | None = None,
     max_pages_per_shard_override: int | None = None,
@@ -209,13 +319,19 @@ def compute_sizing_plan(
     )
 
     # --- Output (list-batch) budget ---
-    per_row = (
-        _CONF_ROW_TOKENS_BBOX
-        if (geometry_mode or "").lower() in ("llm", "llm_grounded")
-        else _CONF_ROW_TOKENS
-    )
-    derived_list_batch = max(
-        _MIN_LIST_BATCH, min(_ABS_MAX_LIST_BATCH, usable_output // per_row)
+    # This is a CONFIDENCE-pass figure, so it must be derived from the confidence
+    # model's output cap, not the extraction model's. It previously used
+    # ``usable_output`` (the extraction model), which on a Sonnet-5-extracts /
+    # Nova-Lite-scores setup computed 128,000 x 0.7 / 120 = 746, clamped to 50, and
+    # reported "50 rows" while the assessment path actually used 13. The value here
+    # is an UPPER-BOUND estimate for the processing report: the authoritative size
+    # is recomputed per field from the real rows by
+    # ``assessment.batching.compute_token_aware_batch_size``.
+    conf_model = confidence_model_id or model_id
+    _, conf_max_out, conf_resolved = _resolve_limits(conf_model)
+    per_row = confidence_per_row_tokens(list_columns, geometry_mode)
+    derived_list_batch = confidence_rows_per_call(
+        conf_max_out if conf_resolved else None, list_columns, geometry_mode
     )
     list_batch_size = (
         int(list_batch_size_override)
@@ -253,8 +369,9 @@ def compute_sizing_plan(
         "Model-aware sizing (%s): model=%s resolved=%s buffer=%.2f "
         "input_window=%d output_cap=%d | usable_in=%d usable_out=%d "
         "image_reserve=%d(%dimg) output_reserve=%d -> shard_token_budget=%d "
-        "max_pages_per_shard=%d | per_row_out=%d(geometry=%s) -> "
-        "list_batch_size=%d | overrides=%s",
+        "max_pages_per_shard=%d | confidence_model=%s(cap=%d resolved=%s) "
+        "cols=%s per_row_out=%d(geometry=%s) -> list_batch_size=%d(estimate) "
+        "| overrides=%s",
         log_label,
         plan.model_id,
         resolved,
@@ -268,6 +385,10 @@ def compute_sizing_plan(
         output_reserve,
         shard_token_budget,
         max_pages_per_shard,
+        conf_model or "(unknown)",
+        conf_max_out,
+        conf_resolved,
+        list_columns if list_columns else f"assumed {_ASSUMED_LIST_COLUMNS}",
         per_row,
         geometry_mode,
         list_batch_size,

--- a/lib/idp_common_pkg/idp_common/config/models.py
+++ b/lib/idp_common_pkg/idp_common/config/models.py
@@ -833,15 +833,17 @@ class ConfidenceConfig(BaseModel):
         default=25,
         gt=0,
         description=(
-            "Max list rows assessed per inference in the in-shard assessment path "
-            "(agentic extraction). A single assessment call over a large list (e.g. "
-            "75 transaction rows) is unreliable — the model under-enumerates or omits "
-            "the list, leaving rows unassessed. When a shard's extracted list exceeds "
-            "this size, the assessment is run in batches of this many rows and "
-            "concatenated, so every row gets a confidence. Lower = more reliable "
-            "enumeration but more inferences; raise for capable models. NOTE: this is "
-            "an UPPER bound — the self-healing ladder derives a smaller token-aware "
-            "first-pass size when the confidence model's output cap would truncate it."
+            "UPPER BOUND on list rows assessed per inference. A single assessment call "
+            "over a large list (e.g. 75 transaction rows) is unreliable — the model "
+            "under-enumerates or omits the list, leaving rows unassessed — so the list "
+            "is scored in batches and the results concatenated, giving every row a "
+            "confidence. This is a CEILING, not a target: the batch actually used is "
+            "derived per list from the confidence model's output cap, the row's column "
+            "count and whether the geometry mode adds a bounding box per cell, and is "
+            "only ever smaller than this. On Nova Lite (10,000-token output cap) with "
+            "bounding boxes the derived size is 13 rows for a 3-column list and 5 for "
+            "8 columns. Lower this to force smaller batches than the derivation; "
+            "raising it above the derived size has no effect."
         ),
     )
     escalation_enabled: bool = Field(

--- a/lib/idp_common_pkg/idp_common/extraction/service.py
+++ b/lib/idp_common_pkg/idp_common/extraction/service.py
@@ -78,6 +78,14 @@ from idp_common.utils import extract_json_from_text, repair_truncated_json
 
 logger = logging.getLogger(__name__)
 
+# The shipped default of ``extraction.confidence.list_batch_size``. The field is
+# ``gt=0`` so it cannot express "unset", and its default is persisted into
+# ``Config#default`` on every stack update — so it cannot simply be changed to 0
+# without wedging a rollback to any release whose validator still requires > 0.
+# This constant lets ``_get_sizing_plan`` treat exactly the default as "the user
+# did not choose this" when deciding whether to report a manual override.
+_LEGACY_LIST_BATCH_DEFAULT = 25
+
 
 # Pydantic models for internal data transfer
 class SectionInfo(BaseModel):
@@ -665,21 +673,30 @@ class ExtractionService:
         # Explicit (non-zero) config values act as overrides; 0 => auto-size.
         stb = getattr(agentic, "shard_token_budget", 0) or None
         lbs = getattr(ex.confidence, "list_batch_size", 0) or None
-        # list_batch_size has a legacy non-zero default (25); treat the legacy
-        # default as "not an explicit override" so auto-sizing applies unless the
-        # user genuinely changed it. We can't perfectly detect that, so honor any
-        # value <= 0 as auto and otherwise pass it as an override only when the
-        # confidence model is unknown (auto-size can't help). Simplest robust
-        # rule: always auto-size list batch, but never EXCEED the configured
-        # ceiling — handled in assess_results_batched's token-aware sizing.
+        # ``list_batch_size`` has a non-zero legacy default (25) and the field is
+        # ``gt=0``, so there is no in-band way to say "unset". Treat exactly the
+        # legacy default as "not an explicit override" so the reported figure shows
+        # a derived value rather than "manual override in effect" for a number
+        # nobody chose. This sentinel cannot be removed by defaulting the field to
+        # 0: the default is written into ``Config#default`` on every stack update,
+        # and a 0 there is REJECTED by every release up to and including v0.6.7
+        # (``gt=0``), which wedges a rollback — the same trap as
+        # `pricing-units-rollback-deadlock`.
+        #
+        # Note the plan's list_batch_size is a report-only ESTIMATE (no column count
+        # is available before extraction); the authoritative per-field size is
+        # derived at assessment time from the real rows.
         plan = compute_sizing_plan(
             model_id=(self._pending_extraction_model or ex.model),
             context_buffer=getattr(ex, "context_buffer", 0.30),
             geometry_mode=ex.geometry.mode,
             max_images_per_agent=getattr(agentic, "max_images_per_agent", 20),
             default_max_pages_per_shard=self._max_pages_per_shard(),
+            confidence_model_id=getattr(ex.confidence, "model", None),
             shard_token_budget_override=stb,
-            list_batch_size_override=lbs if (lbs and lbs != 25) else None,
+            list_batch_size_override=lbs
+            if (lbs and lbs != _LEGACY_LIST_BATCH_DEFAULT)
+            else None,
             log_label="extraction",
         )
         self._sizing_plan = plan
@@ -4875,15 +4892,16 @@ Benefits: Faster, more accurate, handles OCR artifacts automatically.
         for field, _missing in targets.items():
             rows = extracted_fields[field]
             # 1.1 Token-aware first-pass size for this field's confidence model.
-            sample_row = rows[0] if rows else None
+            # Pass the whole row list — the widest row governs the batch, and rows
+            # are not guaranteed to carry the same keys.
             batch_size = compute_token_aware_batch_size(
-                confidence_cfg.model, sample_row, geometry_mode, configured_batch_size
+                confidence_cfg.model, rows, geometry_mode, configured_batch_size
             )
             if split_stats["derived_batch_size"] is None:
                 split_stats["derived_batch_size"] = batch_size
             esc_batch = (
                 compute_token_aware_batch_size(
-                    escalation_model, sample_row, geometry_mode, configured_batch_size
+                    escalation_model, rows, geometry_mode, configured_batch_size
                 )
                 if escalation_one_call is not None
                 else batch_size

--- a/lib/idp_common_pkg/tests/unit/assessment/test_confidence_batch_sizing.py
+++ b/lib/idp_common_pkg/tests/unit/assessment/test_confidence_batch_sizing.py
@@ -1,0 +1,294 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""Token-aware confidence list-batch sizing.
+
+These tests exist because a wrong value here has already cost a document: a
+simple-mode run extracted all 800 rows of a transaction list, then the Assessment
+step truncated on a 25-row batch, the recovery ladder bisected, and Step Functions
+retried the 900-second Lambda five times (~6,200s) before the document ended
+ABORTED.
+
+The central property under test is that there is NO correct constant. The batch
+size that fits one confidence call is a function of three inputs — the confidence
+model's output cap, the row's column count, and whether the geometry mode adds a
+per-cell bounding box — so any fixed number is right for one shape and wrong for
+the rest. ``extraction.confidence.list_batch_size`` is therefore a CEILING on the
+derivation, never a target.
+
+Deliberately NOT changed here: the shipped default stays 25. Defaulting it to 0
+would be written into ``Config#default`` on every stack update, and every release
+up to and including v0.6.7 rejects 0 (``gt=0``) — which wedges a rollback the same
+way an empty pricing block did. Adopting a derived-by-default ceiling needs its own
+change, with a live upgrade test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from idp_common.assessment.batching import (
+    compute_token_aware_batch_size,
+    count_row_columns,
+)
+from idp_common.bedrock.sizing import (
+    _ABS_MAX_LIST_BATCH,
+    confidence_per_row_tokens,
+    confidence_rows_per_call,
+)
+
+NOVA_LITE = "us.amazon.nova-lite-v1:0"  # 10,000-token output cap
+SONNET5_1M = "us.anthropic.claude-sonnet-5:1m"  # 128,000-token output cap
+CLAUDE3 = "us.anthropic.claude-3-haiku-20240307-v1:0"  # 8,192-token output cap
+
+
+def _row(n_cols: int) -> dict[str, str]:
+    return {f"Column{i}": "value" for i in range(n_cols)}
+
+
+# ---------------------------------------------------------------------------
+# The arithmetic: floor(cap * 0.5 / (cols * 40 * bbox_mult)), capped at 50
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cap", "cols", "geometry", "expected"),
+    [
+        # Nova Lite (10,000). Bounding boxes triple the per-cell cost.
+        (10_000, 1, "llm_grounded", 41),
+        (10_000, 3, "llm_grounded", 13),
+        (10_000, 6, "llm_grounded", 6),
+        (10_000, 8, "llm_grounded", 5),
+        # Same model without bounding boxes: three times as many rows fit.
+        (10_000, 3, "ocr_only", 41),
+        (10_000, 8, "ocr_only", 15),
+        # A smaller cap shrinks everything.
+        (8_192, 3, "llm_grounded", 11),
+        # A large cap hits the reliability ceiling, not the token math.
+        (128_000, 3, "llm_grounded", _ABS_MAX_LIST_BATCH),
+    ],
+)
+def test_rows_per_call_arithmetic(cap, cols, geometry, expected):
+    """Pins the derived value for each (cap, columns, geometry) combination.
+
+    The spread in this table IS the point: 41 rows and 5 rows are both correct
+    answers for the same model, so neither the historical pinned default of 25 nor
+    the historical derived value of 50 can be right for both.
+    """
+    assert confidence_rows_per_call(cap, cols, geometry) == expected
+
+
+@pytest.mark.unit
+def test_no_single_constant_satisfies_the_table():
+    """Guards the reasoning, not just the numbers: assert that the correct value
+    genuinely varies, so a future 'simplification' back to a constant fails."""
+    values = {
+        confidence_rows_per_call(10_000, cols, "llm_grounded") for cols in (1, 3, 6, 8)
+    }
+    assert len(values) > 1
+
+
+# ---------------------------------------------------------------------------
+# Column counting across rows, not off row 0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_column_count_uses_the_widest_row_not_the_first():
+    """Extraction does not guarantee uniform rows. Measuring only ``rows[0]``
+    under-counts the width, which INFLATES the batch — the direction that
+    truncates. A narrow first row must not shrink the measured width."""
+    rows = [{"Date": "2024-01-05"}] + [_row(3) for _ in range(9)]
+    assert count_row_columns(rows) == 3
+    assert compute_token_aware_batch_size(NOVA_LITE, rows, "llm_grounded", 25) == 13
+
+
+@pytest.mark.unit
+def test_null_values_still_count_as_columns():
+    """A null cell still emits a confidence leaf, so it must not reduce the count."""
+    assert count_row_columns([{"A": None, "B": None, "C": None}]) == 3
+
+
+@pytest.mark.unit
+def test_nested_values_are_not_counted_as_scalar_columns():
+    assert count_row_columns([{"A": "x", "B": {"nested": 1}, "C": [1, 2]}]) == 1
+
+
+@pytest.mark.unit
+def test_bare_dict_is_accepted_as_a_single_row():
+    """Back-compat: callers used to pass one row."""
+    assert count_row_columns(_row(4)) == 4
+    assert compute_token_aware_batch_size(
+        NOVA_LITE, _row(3), "llm_grounded", 25
+    ) == compute_token_aware_batch_size(NOVA_LITE, [_row(3)], "llm_grounded", 25)
+
+
+@pytest.mark.unit
+def test_opaque_scalar_rows_are_floored_at_one_confidence_leaf():
+    """For non-dict rows the width cannot be counted, so the estimate falls back to
+    value length x8. ``json.dumps("Robert Smith")`` is ~3 tokens, predicting ~24
+    output tokens for a row that really emits 40-120 — about 5x optimistic, and
+    optimism here means a batch that truncates. The estimate is floored at the cost
+    of one confidence leaf so a list of short strings cannot reach the ceiling."""
+    short = ["Robert Smith"] * 200
+    bbox = compute_token_aware_batch_size(CLAUDE3, short, "llm_grounded", 25)
+    plain = compute_token_aware_batch_size(CLAUDE3, short, "ocr_only", 25)
+    # Floored at 1 column: 8,192 x 0.5 / (1 x 40 x 3) = 34 -> ceiling 25 binds;
+    # without bbox 8,192 x 0.5 / 40 = 102 -> ceiling 25 binds. The floor's job is to
+    # stop the x8 estimate producing something ABOVE these.
+    assert bbox <= 25 and plain <= 25
+    assert bbox <= plain
+    # Monotonic: a longer scalar must not yield a LARGER batch than a short one.
+    longer = ["Robert Smith " * 40] * 200
+    assert compute_token_aware_batch_size(
+        CLAUDE3, longer, "llm_grounded", 25
+    ) <= compute_token_aware_batch_size(CLAUDE3, short, "llm_grounded", 25)
+
+
+@pytest.mark.unit
+def test_column_count_scans_every_row_not_a_window():
+    """There is no sampling window. A window would move the row-0 bug to the first N
+    rows: an 800-row statement whose first 25 rows are narrow would still be sized as
+    if the whole list were narrow."""
+    rows = [{"Date": "x"}] * 25 + [_row(10)] * 775
+    assert count_row_columns(rows) == 10
+    # Sized for 10 columns (12), not for 1 column (which would reach the ceiling).
+    assert compute_token_aware_batch_size(NOVA_LITE, rows, "ocr_only", 25) == 12
+
+
+@pytest.mark.unit
+def test_non_dict_rows_report_no_countable_columns():
+    assert count_row_columns(["a", "b"]) is None
+    assert count_row_columns(None) is None
+    assert count_row_columns([]) is None
+
+
+# ---------------------------------------------------------------------------
+# The configured value is a ceiling, and 0 means "no ceiling"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_configured_value_is_a_ceiling_never_a_target():
+    """A ceiling BELOW the derived size wins; the derivation never grows past it."""
+    rows = [_row(3) for _ in range(40)]
+    # ocr_only 3-column derives 41, which is above the shipped ceiling of 25, so the
+    # ceiling binds and the batch stays at 25 rather than growing.
+    assert confidence_rows_per_call(10_000, 3, "ocr_only") == 41
+    assert compute_token_aware_batch_size(NOVA_LITE, rows, "ocr_only", 25) == 25
+    # With bounding boxes the derivation (13) is below the ceiling and wins.
+    assert compute_token_aware_batch_size(NOVA_LITE, rows, "llm_grounded", 25) == 13
+
+
+@pytest.mark.unit
+def test_explicit_ceiling_above_the_reliability_cap_is_honoured():
+    """``_ABS_MAX_LIST_BATCH`` bounds what the SYSTEM picks when auto-deriving, not
+    what an operator asked for. Clamping a deliberate pin of 75 down to 50 would be
+    a silent regression against the behaviour earlier releases shipped."""
+    rows = [_row(1) for _ in range(200)]
+    assert compute_token_aware_batch_size(SONNET5_1M, rows, "ocr_only", 75) == 75
+
+
+@pytest.mark.unit
+def test_no_ceiling_falls_back_to_the_reliability_cap():
+    """With no ceiling supplied the reliability cap is the only bound."""
+    rows = [_row(1) for _ in range(200)]
+    assert (
+        compute_token_aware_batch_size(SONNET5_1M, rows, "ocr_only", 0)
+        == _ABS_MAX_LIST_BATCH
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ceiling", [0, 1, 25, 50, 1000])
+def test_result_is_always_at_least_one(ceiling):
+    """A zero batch size would make the caller's row slicing step by zero."""
+    rows = [_row(30) for _ in range(5)]
+    assert compute_token_aware_batch_size(NOVA_LITE, rows, "llm_grounded", ceiling) >= 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cols", "geometry"),
+    [
+        (130, "ocr_only"),  # 130 x 40 = 5,200 > 10,000 x 0.5
+        (42, "llm_grounded"),  # 42 x 40 x 3 = 5,040 > 10,000 x 0.5
+        (400, "ocr_only"),
+    ],
+)
+def test_floor_engages_when_a_single_row_exceeds_the_output_budget(cols, geometry):
+    """The ``max(_MIN_LIST_BATCH, ...)`` floor is only reachable when ONE row costs
+    more than the whole output budget, which needs ~42 columns with bounding boxes or
+    ~126 without. Narrower rows derive >= 1 anyway, so a test using them cannot fail
+    if the floor is deleted — verified by mutation. Extracted rows this wide exist
+    (wide forms, multi-instance records), so this is the case that pins it."""
+    rows = [_row(cols) for _ in range(4)]
+    raw = int(10_000 * 0.5 // confidence_per_row_tokens(cols, geometry))
+    assert raw == 0, "test input no longer exercises the floor"
+    assert compute_token_aware_batch_size(NOVA_LITE, rows, geometry, 25) == 1
+
+
+@pytest.mark.unit
+def test_ceiling_of_one_is_respected():
+    assert compute_token_aware_batch_size(SONNET5_1M, [_row(2)], "ocr_only", 1) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unknown model / unmeasurable rows must be conservative, not permissive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unknown_model_sizes_conservatively_rather_than_trusting_the_ceiling():
+    """Previously an unresolvable output cap returned ``configured_batch_size``
+    unchanged, which is how a permissive default reached a small-cap model. It must
+    now derive from the conservative fallback cap instead."""
+    rows = [_row(3) for _ in range(40)]
+    result = compute_token_aware_batch_size(
+        "some.unknown.model-v9:0", rows, "llm_grounded", 25
+    )
+    assert result < 25
+    assert result >= 1
+
+
+@pytest.mark.unit
+def test_missing_model_id_sizes_conservatively():
+    rows = [_row(3) for _ in range(40)]
+    assert compute_token_aware_batch_size(None, rows, "llm_grounded", 25) < 25
+    assert compute_token_aware_batch_size("", rows, "llm_grounded", 25) < 25
+
+
+@pytest.mark.unit
+def test_no_rows_still_yields_a_usable_size():
+    """``assess_results_batched`` sizes before it knows there are rows; a 0 here
+    would make the row slicing step by zero."""
+    assert compute_token_aware_batch_size(NOVA_LITE, None, "llm_grounded", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Model comparison
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_bigger_output_cap_allows_a_bigger_batch():
+    rows = [_row(8) for _ in range(40)]
+    small = compute_token_aware_batch_size(CLAUDE3, rows, "llm_grounded", 0)
+    large = compute_token_aware_batch_size(SONNET5_1M, rows, "llm_grounded", 0)
+    assert large > small
+
+
+@pytest.mark.unit
+def test_reliability_ceiling_binds_on_a_huge_output_model():
+    """The absolute ceiling is retained deliberately: models under-enumerate very
+    long lists regardless of whether the tokens fit."""
+    rows = [_row(2) for _ in range(200)]
+    assert (
+        compute_token_aware_batch_size(SONNET5_1M, rows, "ocr_only", 0)
+        == _ABS_MAX_LIST_BATCH
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/lib/idp_common_pkg/tests/unit/assessment/test_self_healing_batching.py
+++ b/lib/idp_common_pkg/tests/unit/assessment/test_self_healing_batching.py
@@ -65,13 +65,21 @@ def test_token_aware_bbox_shrinks_more_than_ocr_only():
     assert with_bbox <= without_bbox
 
 
-def test_token_aware_unknown_model_falls_back():
-    """An unknown model (no entry in model_config_limits) → keep configured size."""
+def test_token_aware_unknown_model_sizes_conservatively():
+    """An unknown model (no entry in model_config_limits) must NOT keep the
+    configured size — trusting a permissive configured value on a model whose cap
+    is unknown is how a 25-row batch reached a 10,000-token model. It sizes from a
+    conservative fallback cap instead, and never exceeds the configured ceiling."""
     sample = {"date": "2020-01-01", "amount": "1.00"}
     derived = compute_token_aware_batch_size(
         "some.unknown.model-v9:0", sample, "ocr_only", configured_batch_size=25
     )
-    assert derived == 25
+    assert 1 <= derived <= 25
+    # With bbox geometry the same unknown model must size down further still.
+    bbox = compute_token_aware_batch_size(
+        "some.unknown.model-v9:0", sample, "llm_grounded", configured_batch_size=25
+    )
+    assert bbox < derived
 
 
 def test_token_aware_never_returns_zero():
@@ -81,9 +89,10 @@ def test_token_aware_never_returns_zero():
     assert derived >= 1
 
 
-def test_token_aware_no_model_keeps_configured():
-    """No model id → cannot resolve a cap → keep the configured size."""
-    assert compute_token_aware_batch_size(None, {"a": 1}, "ocr_only", 25) == 25
+def test_token_aware_no_model_sizes_conservatively():
+    """No model id → cannot resolve a cap → size conservatively, do NOT fall back to
+    the configured size (see test_token_aware_unknown_model_sizes_conservatively)."""
+    assert 1 <= compute_token_aware_batch_size(None, {"a": 1}, "ocr_only", 25) <= 25
 
 
 def test_token_aware_sizes_by_column_count_not_value_length():

--- a/lib/idp_common_pkg/tests/unit/bedrock/test_sizing.py
+++ b/lib/idp_common_pkg/tests/unit/bedrock/test_sizing.py
@@ -27,25 +27,60 @@ def test_larger_input_window_gives_larger_shard_budget():
 
 
 def test_context_buffer_reduces_budgets():
-    """A larger context buffer leaves less usable window → smaller budgets."""
+    """A larger context buffer leaves less usable window → smaller shard budget.
+
+    The list batch is deliberately NOT buffer-dependent: it is bounded by the
+    confidence model's OUTPUT cap and its own safety fraction, not by the
+    extraction model's context window, so the buffer must not move it."""
     low = compute_sizing_plan(model_id=SONNET5_1M, context_buffer=0.15)
     high = compute_sizing_plan(model_id=SONNET5_1M, context_buffer=0.6)
     assert high.shard_token_budget < low.shard_token_budget
-    assert high.list_batch_size <= low.list_batch_size
+    assert high.list_batch_size == low.list_batch_size
 
 
 def test_bbox_geometry_shrinks_list_batch():
     """Per-row output is larger with bbox geometry → smaller list batch.
 
-    Use a high context buffer so the derived sizes land below the reliability
-    cap (otherwise both clamp to the cap and the geometry effect is hidden)."""
-    ocr = compute_sizing_plan(
-        model_id=NOVA_LITE, geometry_mode="ocr_only", context_buffer=0.85
-    )
-    bbox = compute_sizing_plan(
-        model_id=NOVA_LITE, geometry_mode="llm_grounded", context_buffer=0.85
-    )
+    This assertion used to need ``context_buffer=0.85`` to mean anything: with a
+    flat per-ROW token figure, Nova Lite derived 58 rows under bbox and 175
+    without, and BOTH clamped to the reliability cap of 50 — so the geometry
+    effect was invisible at any realistic buffer and the test passed vacuously.
+    Sizing per CELL puts both values below the cap, so the effect is real."""
+    ocr = compute_sizing_plan(model_id=NOVA_LITE, geometry_mode="ocr_only")
+    bbox = compute_sizing_plan(model_id=NOVA_LITE, geometry_mode="llm_grounded")
     assert bbox.list_batch_size < ocr.list_batch_size
+    assert bbox.list_batch_size < 50 and ocr.list_batch_size < 50
+
+
+def test_list_batch_uses_the_confidence_model_not_the_extraction_model():
+    """Regression: the list batch is a CONFIDENCE-pass figure.
+
+    It used to be derived from ``usable_output`` of the EXTRACTION model, so a
+    Sonnet-5-extracts / Nova-Lite-scores stack computed 128,000 x 0.7 / 120 = 746,
+    clamped to 50, and reported "50 rows" while the assessment path actually used
+    13. Passing the confidence model must dominate the extraction model."""
+    nova_scores = compute_sizing_plan(
+        model_id=SONNET5_1M, confidence_model_id=NOVA_LITE, geometry_mode="llm_grounded"
+    )
+    sonnet_scores = compute_sizing_plan(
+        model_id=SONNET5_1M,
+        confidence_model_id=SONNET5_1M,
+        geometry_mode="llm_grounded",
+    )
+    assert nova_scores.list_batch_size < sonnet_scores.list_batch_size
+    # Same extraction model in both, so the difference is entirely the scorer.
+    assert nova_scores.max_input_tokens == sonnet_scores.max_input_tokens
+
+
+def test_more_columns_shrink_the_list_batch():
+    """A wide row costs more output per row, so fewer rows fit in one call."""
+    narrow = compute_sizing_plan(
+        model_id=NOVA_LITE, confidence_model_id=NOVA_LITE, list_columns=3
+    )
+    wide = compute_sizing_plan(
+        model_id=NOVA_LITE, confidence_model_id=NOVA_LITE, list_columns=12
+    )
+    assert wide.list_batch_size < narrow.list_batch_size
 
 
 def test_list_batch_capped_for_reliability():


### PR DESCRIPTION
> **Scope reduced after review.** This originally changed `extraction.confidence.list_batch_size` to default to `0` (auto-size). Two reviewers found that this (a) wedges a stack rollback and (b) makes batches *larger* on the default path, unvalidated. **The default is unchanged at 25 and the schema is untouched.** This is now purely a set of correctness fixes to the derivation. See "What was deliberately dropped".

## What this fixes

Long list fields are confidence-scored in batches. The batch is derived from the confidence model's output cap, the row's column count, and whether `extraction.geometry.mode` asks for a bounding box per cell — `extraction.confidence.list_batch_size` (default **25**, unchanged) is the *ceiling* on that derivation, not the batch itself.

Three inputs to that derivation were wrong, all of them in the direction that over-sizes:

1. **The column count came from the list's first row alone.** A first row missing a key made a wide list look narrow and inflated the batch. It is now the widest row in the list. There is deliberately no sampling window — a window would just move the same bug from row 0 to the first N rows, and an 800-row statement whose first 25 rows happen to be narrow would still be sized as if the whole list were narrow.
2. **An unresolvable output cap fell back to trusting the configured ceiling.** That is how a permissive configured value reaches a small-cap model. It now sizes from a conservative fallback cap and logs a warning.
3. **The opaque/scalar-row estimate had no effective bound.** Value-length × 8 is about 5× optimistic for short strings (`json.dumps("Robert Smith")` is ~3 tokens, predicting ~24 output tokens for a row that really emits 40–120). Floored at the cost of one confidence leaf.

Over-sizing matters because a batch that overruns the output cap truncates, the recovery ladder halves it and retries, and every retry is a fresh paid inference. On an 800-row statement that ladder ran the Assessment Lambda into its 900-second limit **five times — about 6,200 seconds** — before the document ended `ABORTED`.

## Two structural defects fixed alongside

**The per-row estimate was duplicated and the copies disagreed.** `bedrock/sizing.py` carried a flat per-*row* figure (40, or 120 under bounding-box geometry) while `assessment/batching.py` carried a per-*cell* figure multiplied by the column count. The flat 120 **is** the per-cell formula evaluated at exactly one column (`1 × 40 × 3.0`), frozen as though universal — so the two disagreed by a factor of the column count. One estimator now lives in `bedrock/sizing.py` and `assessment/batching.py` imports it.

**The reported figure came from the wrong model.** `bedrock/sizing.py` derived it from the *extraction* model's output cap, so a stack extracting with Sonnet 5 and scoring with Nova Lite computed `128,000 × 0.7 / 120 = 746`, clamped to 50, and displayed "Auto confidence list-batch size: 50 rows" in the processing report and the Web UI's **Processing Report** tab while the code actually used 13. It now takes `confidence_model_id`.

## No batch gets larger

This is the property that makes the change safe to merge without a live run. Verified by running `develop`'s sizer and this branch's side by side over 151 combinations of model × column count × geometry × configured ceiling:

| outcome | cases |
|---|---|
| identical to `develop` | 148 |
| **larger than `develop`** | **0** |
| smaller than `develop` | 3 |

The three that shrink are exactly the defects above: a ragged 10-column list (25 → 12 without boxes, 25 → 4 with), and an unknown model (25 → 11).

An explicit ceiling above the reliability cap of 50 is honoured in full rather than clamped to 50, which is also what `develop` did on this path — clamping it would have silently reduced a deliberate pin of 75.

## What was deliberately dropped

**The default stays 25 and the field stays `gt=0` / `minimum: 1`.** Defaulting it to 0 is written into `Config#default` by `UpdateDefaultConfig` on every stack update, and every release up to and including v0.6.7 rejects 0. `ConfigurationManager.get_configuration` has no tolerant path — it logs and returns `None` — so a later stack update that rolls the Lambda code back to 0.6.7 while DynamoDB still holds `0` leaves every step unable to load config until someone hand-edits DynamoDB. Verified directly against the v0.6.7 tree. This is the same failure class as the empty pricing-units rollback deadlock.

Separately, on the shipped default `geometry.mode: ocr_only` a derived-by-default ceiling would have *raised* a 3-column list from 25 to 41 rows and a 1–2-column list to 50. That is a real efficiency win, but it is unvalidated, `_ABS_MAX_LIST_BATCH = 50` would be the only remaining enumeration guard, and the incident this PR is about is evidence the estimator can under-predict a real row by 2× or more. Adopting it needs its own change with a live upgrade test and a benchmark arm.

## Tests

`test_bbox_geometry_shrinks_list_batch` was **passing vacuously**: with a flat per-row figure, Nova Lite derived 58 rows with boxes and 175 without, and both clamped to the cap of 50, so the assertion could not fail at any realistic context buffer. Both values now sit below the cap.

Two tests in `test_self_healing_batching.py` asserted that the unknown-model path *keeps* the configured size — the behaviour being removed. They passed only by coincidence and would have masked a regression; rewritten.

`test_result_is_always_at_least_one` did not exercise the floor it names — proved by deleting the clamp and watching the suite still pass. Reaching zero needs a row costing more than the whole output budget: ≥42 columns with boxes or ≥126 without. Added.

New `tests/unit/assessment/test_confidence_batch_sizing.py` pins the arithmetic table, ceiling-not-target semantics, an explicit ceiling above the reliability cap, widest-row counting with no window, the opaque-row floor and its monotonicity, and the conservative unknown-model path.

## Verification

- Full unit suite: **5,030 passed, 13 skipped, 0 failed**
- `make ruff-lint`, `ruff format --check`, type check on changed files: clean (one pre-existing unrelated warning — `RuleValidationConfig(model=...)` in `config/models.py`, present on `develop`, where that class has no `model` field)
- `patterns/unified/template.yaml`, `base-confidence.yaml` and the `list_batch_size` field constraints are **byte-identical to `develop`**; only the field's help text changed
- Not run on a live stack. The root cause of why the original incident used 25 where the code computes 13 remains unconfirmed — the stacks and their log groups are gone — so this fixes every over-sizing input path rather than one proven trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)