### PR TITLE
fix(ci): raise Step 11's test-run wait to 600s to match Step 7

### DIFF
--- a/scripts/sdlc/codebuild_deployment.py
+++ b/scripts/sdlc/codebuild_deployment.py
@@ -1276,9 +1276,17 @@ def test_step11_test_compare(stack_name):
                 test_run_ids.append(test_run_id)
                 print(f"Test run {i + 1} ID: {test_run_id}")
 
-                # Wait for test run to complete before starting next one
+                # Wait for test run to complete before starting next one.
+                # 600s, matching Step 7's budget for the same fake-w2 test set:
+                # the wait spans queue -> OCR -> classify -> extract -> assess ->
+                # evaluate, and since eda68b256 moved this step into the parallel
+                # pool it competes with Steps 3-10/13-14 on the shared stack. The
+                # inherited 300s was tuned when it ran sequentially with the
+                # stack to itself and times out under that contention (a 2-doc
+                # run was still in flight at 303s while Step 7's 3-doc run on the
+                # same test set was likewise unfinished at 305s).
                 print(f"Waiting for test run {i + 1} to complete...")
-                cmd = f"idp-cli test-result --stack-name {stack_name} --test-run-id {test_run_id} --wait --timeout 300"
+                cmd = f"idp-cli test-result --stack-name {stack_name} --test-run-id {test_run_id} --wait --timeout 600"
                 result = run_command(cmd, check=False)
 
                 if result.returncode != 0:


### PR DESCRIPTION
## Problem

CI job `integration_tests` failed with a single real error:

```
IDPProcessingError: Timeout waiting for test run
Fake-W2-Tax-Forms-20260908-195245 to complete after 300s
```

Nothing was actually broken. The Step Functions failure list was empty (no
document workflow errored), `MaxConcurrentWorkflows` is 100 so nothing was
queue-bound, and the test run was still legitimately in flight when the wait
gave up at 302.9s.

## Root cause

Step 11's 300s budget dates from c28ec5a02, when the step ran **sequentially**
with the stack to itself. eda68b256 ("perf(cicd): overlap the two stack deploys;
parallelize Step 11") moved it into the parallel pool — where it contends with
Steps 3-10/13-14 on one shared stack — without revisiting the timeout.

The wait spans queue → OCR → classify → extract → assess → **evaluate** for two
documents. Under parallel contention (the same window had the BDA doc, a 3-doc
batch, Step 7's 3 `fake-w2` docs, two discovery agent loops, and Step 8's
17-page/532-row Nuveen doc all in flight) 300s is too tight.

Corroborating evidence from the same run: Step 7's 3-document run against the
**same** `fake-w2` test set began waiting within two seconds of Step 11's and
was *also* unfinished at ~305s. It simply had a 600s budget and would have
passed. Step 11 had the tightest document-processing budget in the suite and was
the only step to fail.

The other four red steps (agentic extraction, default config, rule validation,
pipeline hooks) all report `exit code -9` — SIGKILL from `_kill_running_commands()`
fail-fast collateral, not independent failures.

## Change

One line: `--timeout 300` → `--timeout 600`, matching Step 7's budget for the
same test set, plus a comment recording why so it isn't re-tightened.

## Testing

- `ruff format --check` — already formatted
- `ruff check` — the one reported error (TID251 at line 350) is pre-existing and
  identical at `HEAD`; unrelated to this change
- No CHANGELOG entry: CI-internal, no user-visible effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)