### PR TITLE
fix(dynamodb): stop transact_write_items writing into the caller's payload

### DIFF
--- a/lib/idp_common_pkg/idp_common/dynamodb/client.py
+++ b/lib/idp_common_pkg/idp_common/dynamodb/client.py
@@ -5,6 +5,12 @@
 DynamoDB client for direct table operations.
 """
 
+# botocore types ClientError.response with not-required keys, but every read of
+# Error/Code/Message in this file happens inside an `except ClientError` block,
+# where botocore populates them. File pre-dates the typecheck gate.
+# pyright: reportTypedDictNotRequiredAccess=false
+
+import copy
 import logging
 import os
 from typing import Any, Dict, List, Optional
@@ -231,10 +237,13 @@ class DynamoDBClient:
             DynamoDBError: If the DynamoDB operation fails
         """
         try:
-            # Convert table references to use the table name
+            # Convert table references to use the table name. Deep-copied:
+            # a shallow copy shares the nested Put/Update/Delete dicts with
+            # the caller, so injecting TableName below would write into the
+            # caller's own payload.
             processed_items = []
             for item in transact_items:
-                processed_item = item.copy()
+                processed_item = copy.deepcopy(item)
                 if "Put" in processed_item:
                     processed_item["Put"]["TableName"] = self.table_name
                 elif "Update" in processed_item:

--- a/lib/idp_common_pkg/tests/unit/dynamodb/test_client_transactions.py
+++ b/lib/idp_common_pkg/tests/unit/dynamodb/test_client_transactions.py
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""`transact_write_items` must not write into the caller's payload.
+
+The method copies each transact item with a shallow `item.copy()`, so the nested
+`Put`/`Update`/`Delete` dicts stay shared with the caller — and
+`processed_item["Put"]["TableName"] = self.table_name` therefore writes the table
+name into the caller's own dict. The payload a caller builds, logs, or reuses
+gains keys it never put there.
+
+The nested `Item` values are safe today for a narrower reason worth pinning:
+boto3's DynamoDB high-level resource registers `copy_dynamodb_params` on
+`provide-client-params.dynamodb`, which deep-copies the parameters before the
+`TransformationInjector` serializes them to wire format. Only that handler stands
+between a retried payload and double serialization
+(`{"M": {"S": {"S": "doc#1"}}}` where `"doc#1"` belonged) — switching this call
+to a low-level client, or serializing manually, would lose it. The retry test
+locks the observable contract either way.
+"""
+
+from decimal import Decimal
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from idp_common.dynamodb.client import DynamoDBClient
+
+TABLE = "tracking-test-table"
+
+
+def _make_table():
+    boto3.resource("dynamodb", region_name="us-east-1").create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _payload():
+    return [
+        {
+            "Put": {
+                "Item": {
+                    "PK": "doc#1",
+                    "SK": "none",
+                    "Pages": Decimal(3),
+                }
+            }
+        }
+    ]
+
+
+@pytest.mark.unit
+@mock_aws
+def test_transact_write_items_does_not_mutate_the_callers_payload(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    _make_table()
+    client = DynamoDBClient(table_name=TABLE, region="us-east-1")
+
+    payload = _payload()
+    client.transact_write_items(payload)
+
+    assert "TableName" not in payload[0]["Put"], (
+        "the table name was injected into the caller's own Put dict"
+    )
+    assert payload == _payload(), "the transaction altered the caller's payload"
+
+
+@pytest.mark.unit
+@mock_aws
+def test_a_retried_transaction_stores_the_same_item(monkeypatch):
+    """A caller that retries the same payload after a `DynamoDBError` must write
+    the item it meant to write — not a re-serialization of the first attempt's
+    wire format."""
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    _make_table()
+    client = DynamoDBClient(table_name=TABLE, region="us-east-1")
+
+    payload = _payload()
+    client.transact_write_items(payload)
+    client.transact_write_items(payload)  # the retry
+
+    stored = client.table.get_item(Key={"PK": "doc#1", "SK": "none"})["Item"]
+    assert stored == {"PK": "doc#1", "SK": "none", "Pages": Decimal(3)}


### PR DESCRIPTION
**What.** `transact_write_items` copies each transact item with a shallow `item.copy()`, so the nested `Put`/`Update`/`Delete` dicts stay shared with the caller — and the `TableName` this method injects lands in the caller's own dict. A payload the caller builds, logs, retries, or reuses against another client gains a key it never put there. Deep-copy instead.

**Why the tests also pin the retry path.** The nested `Item` values are protected today only by boto3's `copy_dynamodb_params` handler, which deep-copies parameters before the resource's wire-format serialization; switching this call to a low-level client would lose that protection and a retried payload would double-serialize (`{"M": {"S": {"S": "doc#1"}}}` where `"doc#1"` belonged). The second test locks the observable contract (a retried transaction stores the same item) regardless of which layer provides it.

**Typecheck note.** `client.py` predates the incremental typecheck gate; touching it surfaces 32 pre-existing `reportTypedDictNotRequiredAccess` findings on the `except ClientError` handlers (botocore types those keys as not-required; they are present when `ClientError` is raised). Silenced with a scoped file-level rule comment to keep this change about the payload sharing — happy to fix them properly instead if you prefer.

**No CHANGELOG entry** — the only in-repo caller passes a payload it then discards, so no shipped behaviour changes. Happy to add one if you'd rather.
