### PR TITLE
fix(ocr): the [all] extra gets xlrd too, so "everything" reads .xls

### DIFF
--- a/lib/idp_common_pkg/pyproject.toml
+++ b/lib/idp_common_pkg/pyproject.toml
@@ -231,6 +231,7 @@ all = [
   "requests==2.33.0",
   "pyarrow==23.0.1",
   "openpyxl==3.1.5",
+  "xlrd==2.0.2",
   "python-docx==1.2.0",
   "strands-agents==1.14.0; python_version>='3.10'",
   "strands-agents-tools==0.2.22; python_version>='3.10'",

--- a/lib/idp_common_pkg/uv.lock
+++ b/lib/idp_common_pkg/uv.lock
@@ -1237,6 +1237,7 @@ all = [
     { name = "stickler-eval" },
     { name = "strands-agents" },
     { name = "strands-agents-tools" },
+    { name = "xlrd" },
 ]
 appsync = [
     { name = "requests" },
@@ -1443,6 +1444,7 @@ requires-dist = [
     { name = "strands-agents-tools", marker = "extra == 'code-intel'", specifier = "==0.2.22" },
     { name = "tabulate", marker = "extra == 'agentic-extraction'", specifier = ">=0.9.0" },
     { name = "typer", marker = "extra == 'test'", specifier = ">=0.19.2" },
+    { name = "xlrd", marker = "extra == 'all'", specifier = "==2.0.2" },
     { name = "xlrd", marker = "extra == 'ocr'", specifier = "==2.0.2" },
     { name = "xlrd", marker = "extra == 'test'", specifier = "==2.0.2" },
     { name = "z3-solver", marker = "extra == 'rule-validation'", specifier = "==4.15.4.0" },


### PR DESCRIPTION
Follow-up you offered to take in the #800 review (item 1): `[all]` is a flat duplicate list and still lacked `xlrd`, so the "everything" install kept the blank-page behaviour. One line + `uv.lock`.

Verified by installing exactly `idp_common[all]` in a clean env and converting the `.xls` fixture — both sheets come back where it previously produced the "Error reading Excel file" page.

No CHANGELOG entry: the Unreleased xlrd entry from #800 already announces `.xls` support; this completes it for the `[all]` install path before it ships.