### PR TITLE
chore(dynamodb): drop the inert pyright suppression from client.py

### DIFF
--- a/lib/idp_common_pkg/idp_common/dynamodb/client.py
+++ b/lib/idp_common_pkg/idp_common/dynamodb/client.py
@@ -5,11 +5,6 @@
 DynamoDB client for direct table operations.
 """
 
-# botocore types ClientError.response with not-required keys, but every read of
-# Error/Code/Message in this file happens inside an `except ClientError` block,
-# where botocore populates them. File pre-dates the typecheck gate.
-# pyright: reportTypedDictNotRequiredAccess=false
-
 import copy
 import logging
 import os


### PR DESCRIPTION
The follow-up you suggested in the #803 review. Reproduced your observation both ways: with the project venv (botocore installed, no `py.typed`, no stubs declared) basedpyright reports **0 errors on this file with and without the comment** — and without a venv it falls back to its bundled typeshed stubs and reports the 32 findings that motivated the comment in the first place. That environment is not the one the gate runs in, so the comment only pre-disabled the rule for a future in which stubs are added deliberately. Removed.

No behavior change; `ruff` and the dynamodb unit tests pass.