### PR TITLE
fix(assessment): count the alerts that were stored, not the ones discarded

### DIFF
--- a/lib/idp_common_pkg/idp_common/assessment/batching.py
+++ b/lib/idp_common_pkg/idp_common/assessment/batching.py
@@ -122,6 +122,19 @@ def dedupe_alerts(alerts: Any) -> Any:
     - Entries that are not dicts, or that carry no string ``attribute_name``,
       pass through untouched.
     - First-appearance order is preserved, and the collapse is idempotent.
+
+    PRECONDITION on the caller: within one list, a non-indexed path must
+    identify one finding. Every producer that reaches the current call sites
+    satisfies this by construction — they walk the assessment **dict**, and list
+    rows always carry an ``[i]`` suffix, so a single pass cannot emit the same
+    non-indexed path twice; repeats can only come from re-assessing the same
+    scalars. The BDA path is the counter-example and must NOT be routed here:
+    ``patterns/unified/src/bda_processresults_function/index.py`` builds alerts
+    by iterating *pages* and using the raw key-value key as ``attribute_name``,
+    so the same key found on two pages is two findings sharing one path.
+    (It assigns ``section.confidence_threshold_alerts`` directly and never
+    reaches this function; if that ever changes, put the page in the path
+    first.)
     """
     if not isinstance(alerts, list):
         return alerts

--- a/lib/idp_common_pkg/idp_common/extraction/service.py
+++ b/lib/idp_common_pkg/idp_common/extraction/service.py
@@ -5067,7 +5067,18 @@ Benefits: Faster, more accurate, handles OCR artifacts automatically.
 
         section.confidence_threshold_alerts = dedupe_alerts(merged_assessment_alerts)
         output_metadata["assessment_integrated_in_extraction"] = True
-        output_metadata["assessment_alert_count"] = len(merged_assessment_alerts)
+        # Counts the list that was actually STORED. Reading the pre-dedupe list
+        # here let the recorded count contradict the data next to it — a section
+        # carrying 16 alerts reported 2,603. The raw figure is still worth having
+        # when it differs, because the gap IS the duplication this path removes,
+        # so it is recorded under its own name rather than smuggled into this one.
+        output_metadata["assessment_alert_count"] = len(
+            section.confidence_threshold_alerts
+        )
+        if len(merged_assessment_alerts) != len(section.confidence_threshold_alerts):
+            output_metadata["assessment_alert_count_before_dedupe"] = len(
+                merged_assessment_alerts
+            )
 
     def _retry_missing_integrated_rows(
         self,

--- a/lib/idp_common_pkg/tests/unit/extraction/test_integrated_alert_count.py
+++ b/lib/idp_common_pkg/tests/unit/extraction/test_integrated_alert_count.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""The recorded alert count must describe the list that was actually stored.
+
+``_attach_explainability`` dedupes the integrated path's alerts before assigning
+them to the section (#814/#815), but recorded ``assessment_alert_count`` from the
+PRE-dedupe list — so a section carrying 16 alerts reported 2,603, and the number
+contradicted the data beside it. The raw figure is still worth having when it
+differs, because the gap IS the duplication this path removes, so it now travels
+under its own name instead of displacing the real count (#822).
+"""
+
+from typing import Any
+
+import pytest
+
+from idp_common.extraction.service import ExtractionService, SectionInfo
+from idp_common.models import Document
+
+pytestmark = pytest.mark.unit
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "$id": "Invoice",
+    "properties": {
+        "InvoiceTotal": {"type": "string"},
+        "Vendor": {"type": "string"},
+    },
+}
+
+
+class _Section:
+    """Only the attribute the method under test writes."""
+
+    def __init__(self) -> None:
+        self.confidence_threshold_alerts: list[dict[str, Any]] = []
+
+
+def _service() -> ExtractionService:
+    svc = ExtractionService(
+        region="us-west-2",
+        config={
+            # geometry off: the grounding branch needs real OCR pages, and it is
+            # not what these tests are about.
+            "extraction": {
+                "model": "us.amazon.nova-pro-v1:0",
+                "geometry": {"mode": "off"},
+            },
+            "classes": [SCHEMA],
+        },
+    )
+    svc._class_schema = SCHEMA
+    # The missing-row retry is a separate concern with its own tests; disabling it
+    # keeps the alert list exactly what this test hands in.
+    svc._integrated_assessment_enabled = lambda: False  # type: ignore[method-assign]
+    return svc
+
+
+def _section_info() -> SectionInfo:
+    return SectionInfo(
+        class_label="Invoice",
+        sorted_page_ids=["1"],
+        page_indices=[0],
+        output_bucket="bucket",
+        output_key="key",
+        output_uri="s3://bucket/key",
+        start_page=1,
+        end_page=1,
+    )
+
+
+def _alert(name: str, confidence: float) -> dict[str, Any]:
+    return {
+        "attribute_name": name,
+        "confidence": confidence,
+        "confidence_threshold": 0.8,
+    }
+
+
+def _attach(alerts: list[dict[str, Any]]) -> tuple[dict[str, Any], _Section]:
+    svc = _service()
+    section = _Section()
+    output_metadata: dict[str, Any] = {}
+    svc._attach_explainability(
+        output_metadata=output_metadata,
+        merged_assessment={"InvoiceTotal": {"confidence": 0.4}},
+        merged_assessment_alerts=alerts,
+        extracted_fields={"InvoiceTotal": "100.00", "Vendor": "Acme"},
+        document=Document(id="doc-1", input_key="doc.pdf"),
+        section=section,
+        section_info=_section_info(),
+    )
+    return output_metadata, section
+
+
+def test_the_count_matches_the_stored_alerts_when_duplicates_collapse():
+    """163 copies of one finding are stored as one, and counted as one."""
+    metadata, section = _attach([_alert("totals.total_overhead", 0.4)] * 163)
+
+    assert len(section.confidence_threshold_alerts) == 1
+    assert metadata["assessment_alert_count"] == 1
+    assert metadata["assessment_alert_count_before_dedupe"] == 163
+
+
+def test_the_raw_count_is_absent_when_nothing_was_collapsed():
+    """The extra key exists to explain a gap; with no gap it would be noise."""
+    metadata, section = _attach([_alert("Vendor", 0.5), _alert("InvoiceTotal", 0.6)])
+
+    assert len(section.confidence_threshold_alerts) == 2
+    assert metadata["assessment_alert_count"] == 2
+    assert "assessment_alert_count_before_dedupe" not in metadata
+
+
+def test_indexed_row_alerts_are_all_counted():
+    """Per-row alerts are never deduped (their indexes are slice-local, #813), so
+    the count must not shrink for them either."""
+    alerts = [_alert(f"Transactions[{i}].Amount", 0.5) for i in range(40)]
+
+    metadata, section = _attach(alerts)
+
+    assert len(section.confidence_threshold_alerts) == 40
+    assert metadata["assessment_alert_count"] == 40
+    assert "assessment_alert_count_before_dedupe" not in metadata
+
+
+def test_no_alerts_records_zero():
+    metadata, section = _attach([])
+
+    assert section.confidence_threshold_alerts == []
+    assert metadata["assessment_alert_count"] == 0
+    assert "assessment_alert_count_before_dedupe" not in metadata


### PR DESCRIPTION
Fixes #822 — the two hygiene items from the #815 review.

**1. The count contradicted the data.** `_attach_explainability` dedupes the integrated path's alerts before assigning them to the section, but recorded `assessment_alert_count` from the pre-dedupe list, so a section carrying 16 alerts reported 2,603. It now counts the stored list. The raw figure is genuinely informative — the gap *is* the duplication this path removes — so it is kept as `assessment_alert_count_before_dedupe`, and only when the two differ, so an ordinary document's metadata is unchanged.

**2. `dedupe_alerts` had an unstated precondition.** Within one list, a non-indexed path must identify one finding. Every producer that reaches the current call sites satisfies that by construction: they walk the assessment **dict**, and list rows always carry an `[i]` suffix, so one pass cannot emit the same non-indexed path twice. The BDA path is the counter-example — `bda_processresults_function/index.py` iterates *pages* and uses the raw key-value key as `attribute_name`, so one key found on two pages is two findings sharing a path. It assigns `section.confidence_threshold_alerts` directly and never reaches the helper, so nothing is broken today; the note exists because #815's stated rationale for guarding the section boundaries invites exactly that future change.

**Tests.** New `test_integrated_alert_count.py` (4 cases): the collapse case counts 1 and records 163 raw; no-duplicates records the count and omits the raw key; 40 indexed per-row alerts are all counted (they are never deduped — #813); empty records 0. Verified red before the change (`assert 163 == 1`) and green after. `tests/unit/extraction` + `tests/unit/assessment` pass (1302 passed, 2 skipped), `ruff` check/format and `basedpyright` clean.

**No CHANGELOG entry** — `assessment_alert_count` has no reader anywhere in the repo (written into the extraction result metadata, never consumed), and the user-facing dedupe behaviour is already announced by #815's `[Unreleased]` entry, which has not shipped. Happy to add one if you'd rather.

Leaves #821 (the list is still unbounded) and #813 (slice-local row indexes) open — both are separate changes.