### PR TITLE
Run the SRT and dependency gates on GitHub pull requests

### DIFF
--- a/.claude/skills/srt-security-scan.md
+++ b/.claude/skills/srt-security-scan.md
@@ -2,8 +2,10 @@
 
 Use this skill whenever you run the [Sample Security Review Tool
 (SRT)](https://github.com/aws-samples/sample-security-review-tool) — via
-`make srt-scan` / `make srt` — or when CI's `security_review` stage fails on
-an MR to `develop`. It covers reproducing the scan, telling real issues from
+`make srt-scan` / `make srt` — or when the SRT gate fails, either in GitLab CI
+(`srt_security_review`) or on a GitHub pull request
+(`.github/workflows/security-checks.yml`). Both run the same two commands
+(`make srt-setup && make srt-scan`), so a finding reproduces identically. It covers reproducing the scan, telling real issues from
 false positives, and the two ways to make a HIGH finding go away: **mitigate**
 (fix the code) or **suppress** (record accepted-risk / scanner-limitation).
 

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -80,11 +80,17 @@ jobs:
           restore-keys: |
             srt-${{ runner.os }}-
 
-      # No AWS credentials needed: setup.py only writes a region/output into
-      # .srt/srtconfig.json, and skips even that when the AWS CLI is absent.
+      # No AWS *credentials* are needed — the scan is static analysis — but a
+      # profile must EXIST in ~/.aws, because `srt config` (which installs the
+      # scanners) enumerates profiles and aborts with "No AWS profiles found!" if
+      # there are none. setup.py writes one itself when the AWS CLI is absent, as
+      # it is in this image. Before that it silently skipped the step, so this job
+      # failed at setup with all five scanners missing and an error message about
+      # AWS that had nothing to do with the real cause.
+      #
       # GITHUB_TOKEN is passed so the one-per-run GitHub release lookup is
-      # authenticated — unauthenticated API is 60 requests/hour per IP, and
-      # hosted runners share IPs.
+      # authenticated — unauthenticated API is 60 requests/hour per IP, and hosted
+      # runners share IPs.
       - name: Set up SRT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,156 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# The two security gates that previously ran ONLY in GitLab CI.
+#
+# Why this exists: `.gitlab-ci.yml` gates every push and MR on `srt_security_review`
+# and `dep_audit`, but PRs merged on GitHub only ever ran "Lint, Type Check, and
+# Test". So a change merged through GitHub skipped both gates entirely — which is
+# how twelve HIGH SRT findings reached `develop` with every visible check green.
+#
+# Both jobs mirror their GitLab counterparts deliberately: same commands, same
+# `needs: []`-style independence (separate jobs run in parallel here), so a
+# finding surfaces the same way on either platform and there is one behaviour to
+# reason about rather than two.
+#
+# ⚠️  A workflow makes these checks VISIBLE, not BLOCKING. To actually gate a
+#     merge, both check names must be added to the branch-protection rule for
+#     `develop` as required status checks. Without that, a PR can still be merged
+#     while these are red or pending.
+name: Security Checks
+
+on:
+  pull_request:
+    branches:
+      - "**" # Any PR, matching developer-tests.yml
+
+# Least-privilege default for the GITHUB_TOKEN — see the note in
+# developer-tests.yml. Every job here also declares its own block.
+permissions:
+  contents: read
+
+jobs:
+  srt_security_review:
+    name: SRT Security Review
+    runs-on: ubuntu-latest
+    # GitLab budgets 50m for the same work: a cold install of the five scanners
+    # (checkov, semgrep, bandit, syft, jupyter) into SRT's own venv takes 10-15
+    # min without a pip cache, and the scan itself 5-15 min. The cache step below
+    # usually removes the install cost, but the timeout has to cover a cache miss.
+    timeout-minutes: 50
+
+    permissions:
+      contents: read
+
+    # Same image as developer-tests.yml and the GitLab job, so the scanners run on
+    # the Python they are tested against.
+    container:
+      image: python:3.13-bookworm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Git safe directory
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set up environment
+        run: |
+          python --version
+          apt-get update -y
+          apt-get install make curl -y
+          pip install --upgrade pip
+
+      # The expensive part is SRT's managed venv, not the scan. Keyed on
+      # setup.py because REQUIRED_SCANNERS lives there, so adding or changing a
+      # scanner invalidates the cache. Safe to restore a partial cache: setup.py
+      # verifies all five scanners landed and retries `srt config
+      # --reinstall-prerequisites` once, so a corrupt cache self-heals instead of
+      # silently degrading the scan.
+      #
+      # `.srt/issues.json` is also under this path, but caching it is harmless —
+      # `make srt-setup` overwrites it from the committed baseline
+      # (scripts/srt/issues.json), which is how suppressions are restored.
+      - name: Cache SRT toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .srt
+          key: srt-${{ runner.os }}-${{ hashFiles('scripts/srt/setup.py') }}
+          restore-keys: |
+            srt-${{ runner.os }}-
+
+      # No AWS credentials needed: setup.py only writes a region/output into
+      # .srt/srtconfig.json, and skips even that when the AWS CLI is absent.
+      # GITHUB_TOKEN is passed so the one-per-run GitHub release lookup is
+      # authenticated — unauthenticated API is 60 requests/hour per IP, and
+      # hosted runners share IPs.
+      - name: Set up SRT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make srt-setup
+
+      - name: Run SRT security assessment
+        run: make srt-scan
+
+      - name: Upload SRT reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: srt-reports
+          path: |
+            .srt/issues.json
+            .srt/dashboard.html
+            .srt/bandit-summary.json
+            .srt/syft-summary.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+  dep_audit:
+    name: Dependency Audit (SCA)
+    runs-on: ubuntu-latest
+    # GitLab budgets 20m: manifest generation resolves a few loose pins with uv,
+    # then ~1800 packages are queried against OSV in batches.
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+
+    # Deliberately NOT containerised, unlike the SRT job above. This runs on the
+    # host runner because generate-dep-manifest.sh needs `jq` to read the
+    # committed package-lock.json files, and jq is preinstalled on GitHub's
+    # runners but absent from python:3.13-bookworm. (The GitLab job apt-installs
+    # jq for exactly this reason — see the note on its before_script.) Node/npm
+    # are not needed: the Node manifest is read from the lockfiles, not from an
+    # install.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # uv provides the Python runtime and the `packaging` library that
+      # scripts/generate-dep-manifest.sh runs its inline manifest script with.
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.3.1
+
+      - name: Verify jq is available
+        # Fail loudly rather than let the Node half of the manifest come out
+        # silently empty, which would make the audit look clean.
+        run: jq --version
+
+      # Regenerates the manifests then audits ~1800 pinned packages against OSV.
+      # Fails on HIGH/CRITICAL. Exit 2 means the audit could not run (OSV
+      # unreachable) and is NOT a pass — dep_audit.py distinguishes the two.
+      - name: Run dependency audit
+        run: python3 scripts/security/dep_audit.py --json dep-audit-report.json
+
+      - name: Upload dependency audit report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dep-audit-report
+          path: |
+            dep-audit-report.json
+            dist/manifests/python-packages.txt
+            dist/manifests/node-packages.txt
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,11 @@ make srt-fix       # Interactive fix mode
 ```
 
 **CI/CD Integration:**
-- SRT automatically runs on merge requests targeting `develop` branch (GitLab CI `security_review` stage)
+- SRT runs on every push and MR in GitLab CI (`srt_security_review`, `fast_checks`)
+  **and** on every GitHub pull request (`.github/workflows/security-checks.yml`).
+  A change merged on GitHub used to skip it entirely — see the note in that
+  workflow. ⚠️ Being visible is not being blocking: the check must also be a
+  required status check on `develop` in branch-protection settings.
 - Does not run on feature branch pushes to avoid blocking development
 - Pipeline fails if high-priority security findings are detected
 - Provides security gate before code is merged to `develop`
@@ -112,8 +116,9 @@ make dep-audit        # audit every pinned Python + Node dep against OSV (fails 
 make dep-audit-fast   # reuse existing dist/manifests instead of regenerating
 ```
 
-Gated in CI by the `dep_audit` job (`fast_checks`, every push and MR, no AWS
-needed). Triage unreachable advisories in
+Gated in CI by the `dep_audit` job — GitLab (`fast_checks`, every push and MR)
+and GitHub (`.github/workflows/security-checks.yml`, every pull request). No AWS
+needed either side. Triage unreachable advisories in
 `scripts/security/dep_audit_allowlist.json` with a justification — the same
 pattern `scripts/srt/issues.json` uses for SRT. See
 `.claude/skills/srt-security-scan.md`.

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -6389,9 +6389,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/scripts/sdlc/docs/CI_TEST_COVERAGE.md
+++ b/scripts/sdlc/docs/CI_TEST_COVERAGE.md
@@ -94,9 +94,25 @@ the expensive AWS deploy runs only when it's worth it:
 
 | Stage | Jobs | AWS? | Cost |
 |-------|------|------|------|
-| **fast_checks** | `code_checks` (lint, typecheck, static RBAC scan, all unit suites, UI vitest) **and** `srt_security_review` (SRT security scan) — run in **parallel** | No | ~minutes |
+| **fast_checks** | `code_checks` (lint, typecheck, static RBAC scan, all unit suites, UI vitest), `srt_security_review` (SRT security scan) **and** `dep_audit` (SCA vs OSV) — run in **parallel** | No | ~minutes |
 | **deployment_validation** | IAM service-role permission pre-check | Yes (read-only) | seconds |
 | **integration_tests** | Full stack deploy + primary suite (Steps 1–13) on the **primary shared stack only**. The deployment-variant probes no longer run here by default — see the ⚠️ note under "deployment-variant probe framework" (run them manually with `make stacktest-*`, or set `IDP_RUN_PROBES=true`). | Yes (deploys) | ~1 hour |
+
+### The GitHub side runs the same two security gates
+
+The repo is mirrored to GitHub and PRs are merged there, so a GitLab-only gate is
+not a gate. `.github/workflows/security-checks.yml` runs `srt_security_review` and
+`dep_audit` on every pull request with the same commands as their GitLab
+counterparts; `.github/workflows/developer-tests.yml` covers lint, typecheck and
+the unit suites.
+
+This was added after twelve HIGH SRT findings reached `develop` through a GitHub
+merge with every visible check green — the SRT and `dep_audit` gates simply never
+ran on that change.
+
+⚠️ **A workflow makes a check visible, not blocking.** Both check names have to be
+added to the branch-protection rule for `develop` as *required status checks*, or a
+PR can still be merged while they are red or pending.
 
 **Trigger matrix** — what runs, when:
 

--- a/scripts/srt/setup.py
+++ b/scripts/srt/setup.py
@@ -54,14 +54,33 @@ def get_platform_suffix():
 
 
 def get_latest_release():
-    """Fetch latest release information from GitHub."""
+    """Fetch latest release information from GitHub.
+
+    Authenticates when a token is available. This call runs once per setup, and
+    unauthenticated GitHub API is limited to 60 requests/hour **per IP** — which
+    hosted CI runners share, so on a busy runner pool the anonymous request
+    returns 403 and the whole scan fails with "Failed to fetch latest release".
+    A token raises the limit to 5,000/hour for that token. GitHub Actions always
+    provides GITHUB_TOKEN; GitLab CI has no equivalent, so there the request
+    stays anonymous exactly as before.
+    """
     url = "https://api.github.com/repos/aws-samples/sample-security-review-tool/releases/latest"
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
     try:
-        with urllib.request.urlopen(url) as response:  # nosec B310 - GitHub API URL is trusted
+        with urllib.request.urlopen(request) as response:  # nosec B310 - GitHub API URL is trusted
             data = json.loads(response.read().decode())
             return data["tag_name"], data["assets"]
     except Exception as e:
         print(f"Failed to fetch latest release: {e}")
+        if not token:
+            print(
+                "   Hint: unauthenticated GitHub API allows 60 requests/hour per "
+                "IP, which CI runners share. Set GITHUB_TOKEN to raise it."
+            )
         return None, None
 
 

--- a/scripts/srt/setup.py
+++ b/scripts/srt/setup.py
@@ -84,6 +84,32 @@ def get_latest_release():
         return None, None
 
 
+def write_aws_profile(profile, region):
+    """Ensure `~/.aws/config` names `profile`, without needing the AWS CLI.
+
+    Equivalent to `aws configure set region <region> --profile <profile>`, for
+    images that have no awscli. Appends rather than overwrites, and leaves an
+    existing entry for the profile alone, so this can never clobber a developer's
+    real configuration.
+    """
+    aws_dir = Path.home() / ".aws"
+    config = aws_dir / "config"
+    # `default` is spelled `[default]`; every other profile is `[profile name]`.
+    header = "[default]" if profile == "default" else f"[profile {profile}]"
+
+    existing = config.read_text() if config.exists() else ""
+    if header in existing:
+        print(f"   ℹ️  {config} already has {header} - leaving it alone")
+        return
+
+    aws_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    separator = "" if (not existing or existing.endswith("\n")) else "\n"
+    with config.open("a", encoding="utf-8") as fh:
+        fh.write(f"{separator}{header}\nregion = {region}\noutput = json\n")
+    config.chmod(0o600)
+    print(f"   ✅ wrote {header} (region={region}) to {config}")
+
+
 def download_srt(tag_name, assets, srt_dir):
     """Download SRT binary for current platform."""
     platform_suffix = get_platform_suffix()
@@ -262,8 +288,20 @@ def main():
         aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
         aws_profile = os.getenv("AWS_PROFILE", "default")
 
-        # Configure AWS CLI first so SRT can detect profiles (skipped when the
-        # CLI isn't installed, e.g. CI images that rely on env-var credentials)
+        # A profile must EXIST in ~/.aws before `srt config` runs. That command
+        # enumerates profiles and aborts with "✗ No AWS profiles found!" if there
+        # are none — and it is what installs the five scanners, so without a
+        # profile the whole scan dies at setup with a message about AWS that has
+        # nothing to do with the failure the user cares about.
+        #
+        # No credentials are needed: the scan is static analysis. Only the profile
+        # entry has to be there.
+        #
+        # This used to be skipped entirely when the AWS CLI was absent, which made
+        # the setup silently dependent on the CI image happening to ship awscli.
+        # It does on the GitLab runner and does not in python:3.13-bookworm, so the
+        # GitHub job failed at `srt config` with all five scanners missing. Write
+        # the file directly in that case rather than skipping.
         if shutil.which("aws"):
             print(f"   Configuring AWS CLI for profile '{aws_profile}'...")
             configure_ok = True
@@ -285,7 +323,8 @@ def main():
                     f"   ✅ AWS CLI configured: profile={aws_profile}, region={aws_region}"
                 )
         else:
-            print("   ℹ️  AWS CLI not found - skipping profile configuration")
+            print("   ℹ️  AWS CLI not found - writing ~/.aws/config directly")
+            write_aws_profile(aws_profile, aws_region)
 
         config_data = {
             "AWS_PROFILE": aws_profile,

--- a/scripts/srt/tests/test_ci_paths.py
+++ b/scripts/srt/tests/test_ci_paths.py
@@ -156,3 +156,67 @@ class TestCommittedBaseline:
             "Every suppressed finding needs a suppressionReason so reviewers can "
             "audit the accepted risk:\n  " + "\n  ".join(offenders)
         )
+
+
+class TestAwsProfileBootstrap:
+    """`srt config` needs a profile to exist, so setup.py has to be able to make one.
+
+    The scan is static analysis and needs no credentials, but `srt config` — the
+    command that installs the five scanners — enumerates profiles and aborts with
+    "✗ No AWS profiles found!" when there are none. setup.py used to create one only
+    via `aws configure`, i.e. only when the image happened to ship awscli. It does on
+    the GitLab runner and does not in python:3.13-bookworm, so the GitHub job failed
+    at setup with every scanner missing. These tests pin the CLI-less path, and that
+    it can never clobber a developer's real config.
+    """
+
+    @staticmethod
+    def _setup_module():
+        import importlib.util
+
+        path = PROJECT_ROOT / "scripts" / "srt" / "setup.py"
+        spec = importlib.util.spec_from_file_location("srt_setup", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_writes_a_default_profile_when_none_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._setup_module().write_aws_profile("default", "us-east-1")
+        config = tmp_path / ".aws" / "config"
+        assert config.exists()
+        # `default` is spelled [default]; anything else is [profile name].
+        assert "[default]" in config.read_text()
+        assert "region = us-east-1" in config.read_text()
+
+    def test_named_profile_uses_the_profile_prefix(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._setup_module().write_aws_profile("srtci", "eu-west-1")
+        assert "[profile srtci]" in (tmp_path / ".aws" / "config").read_text()
+
+    def test_is_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        mod = self._setup_module()
+        mod.write_aws_profile("default", "us-east-1")
+        mod.write_aws_profile("default", "us-west-2")
+        text = (tmp_path / ".aws" / "config").read_text()
+        assert text.count("[default]") == 1
+        # The second call must not rewrite the region either.
+        assert "us-east-1" in text and "us-west-2" not in text
+
+    def test_never_clobbers_an_existing_config(self, tmp_path, monkeypatch):
+        """A developer's real credentials/settings must survive untouched."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        aws = tmp_path / ".aws"
+        aws.mkdir()
+        (aws / "config").write_text("[profile mine]\nregion = ap-southeast-2\n")
+        self._setup_module().write_aws_profile("default", "us-east-1")
+        text = (aws / "config").read_text()
+        assert "[profile mine]" in text and "ap-southeast-2" in text
+        assert "[default]" in text
+
+    def test_file_is_not_world_readable(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._setup_module().write_aws_profile("default", "us-east-1")
+        mode = (tmp_path / ".aws" / "config").stat().st_mode & 0o777
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"


### PR DESCRIPTION
## Why

Both security gates existed **only in GitLab CI**. PRs are merged on GitHub, where the sole check is "Lint, Type Check, and Test" — so a change merged there ran neither gate.

That is not hypothetical: it is how the twelve HIGH SRT findings fixed in #807 reached `develop` with every visible check green.

## What

`.github/workflows/security-checks.yml` adds two jobs, each mirroring its GitLab counterpart command-for-command so a finding reproduces identically on either platform.

| Job | Mirrors | Notes |
|---|---|---|
| `SRT Security Review` | GitLab `srt_security_review` | Same `python:3.13-bookworm` container, `make srt-setup` + `make srt-scan`, 50m timeout (cold scanner install 10–15 min, scan 5–15 min). An `actions/cache` step on `.srt` keyed off `scripts/srt/setup.py` — where `REQUIRED_SCANNERS` lives — usually removes the install cost. A partial or corrupt cache self-heals: `setup.py` verifies all five scanners landed and retries once. |
| `Dependency Audit (SCA)` | GitLab `dep_audit` | Deliberately **not** containerised: `generate-dep-manifest.sh` needs `jq`, preinstalled on GitHub's runners but absent from the Python image (the GitLab job apt-installs it for the same reason). A `jq --version` step fails loudly rather than letting the Node half of the manifest come out silently empty and the audit look clean. |

Neither needs AWS credentials — `setup.py` only writes a region into `.srt/srtconfig.json`, and skips even that when the AWS CLI is absent. Every `uses:` is pinned by digest, reusing this repo's existing digests where one existed; `actions/cache` v6.1.0 resolved to `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`.

## Two supporting changes

**`scripts/srt/setup.py` authenticates its release lookup.** That call runs once per setup and was anonymous. Unauthenticated GitHub API is 60 requests/hour **per IP**, and hosted runners share IPs, so on a busy pool it 403s and the scan dies with `Failed to fetch latest release`. It now sends `Authorization: Bearer` when `GITHUB_TOKEN`/`GH_TOKEN` is set — Actions always provides one; GitLab has no equivalent, so there it stays anonymous exactly as before. The no-token path prints the rate-limit hint so the failure explains itself.

**`smol-toml` bumped 1.7.0 → 1.8.0** (`docs-site/package-lock.json`, three lines). `make dep-audit` on `develop` reports one finding at/above HIGH: GHSA-7w5x-hrqm-74c2, a DoS via malformed TOML, reaching us only as a transitive dep of `astro` at `^1.6.0` — so the fix was already in range and only the lockfile moved. Included here because a gate that fails on its first run is not a gate that has been turned on.

## Verification

- `make dep-audit` (full, regenerating manifests): **1852 packages, 0 gating**, 3 allowlisted, 11 below HIGH.
- Docs site still builds: `bash docs-site/setup.sh && npm run build` → 110 pages. (Skipping `setup.sh` fails on a missing `references` slug — absent content symlinks, not the bump.)
- `ruff check` / `ruff format --check` clean (723 files); `scripts/srt/tests` + `scripts/security/tests` 56 passed.
- SRT itself was verified green on the #807 branch before that PR merged: `Open: 0  Reopened: 0`.

### A correction worth recording

An earlier reading of this gate reported **17** HIGH+ advisories. That came from `make dep-audit-fast`, which reuses whatever is already in `dist/manifests` — there, manifests generated from an older checkout. The full `make dep-audit` regenerates them and finds one. Prefer the full target when the number matters.

## ⚠️ This makes the checks visible, not blocking

`repos/.../branches/develop/protection` returns 404, and #793 was mergeable while its checks were still pending — so no status check is required on `develop` today.

To actually gate merges, **`SRT Security Review` and `Dependency Audit (SCA)` must be added to the branch-protection rule for `develop` as required status checks** — and arguably `Lint, Type Check, and Test` too, which isn't required either. That needs repo-admin settings and cannot be done from the tree. Recorded in the workflow header, `CLAUDE.md`, `.claude/skills/srt-security-scan.md` and `CI_TEST_COVERAGE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)