### PR TITLE
fix(extraction): coerce stringified schema constraints once, at the entry point

### DIFF
--- a/lib/idp_common_pkg/idp_common/extraction/service.py
+++ b/lib/idp_common_pkg/idp_common/extraction/service.py
@@ -53,6 +53,7 @@ from idp_common.extraction.validation import (
     ValidationReport,
     build_empty_list_feedback,
     build_subset_schema,
+    coerce_numeric_schema_keywords,
     find_empty_declared_lists,
     required_null_paths,
     select_escalated_fields,
@@ -313,6 +314,17 @@ class ExtractionService:
         knowing about it. The transform is a no-op (returning the same object)
         for every unflagged class, which is all of them by default.
 
+        For the same reason, stringified numeric constraints are coerced back to
+        numbers here. The Configuration table stores every numeric scalar as a
+        string and nothing converts them on read (``classes`` is
+        ``List[Dict[str, Any]]``, so validation never descends into it), so a
+        class authored in the Web UI arrives with ``minItems: "100"`` — which
+        raised ``TypeError`` in the one reader that compared it without a guard
+        and cost that section its whole completeness report (#797). Coercing at
+        this single entry point means readers do not each need their own guard;
+        the ones that already have one keep it, since they are also reachable
+        with a schema that did not come through here.
+
         Args:
             class_label: The document class name
 
@@ -330,7 +342,7 @@ class ExtractionService:
                 X_AWS_IDP_DOCUMENT_TYPE, ""
             )
             if class_id.lower() == class_label.lower():
-                return wrap_class_schema(class_obj)
+                return coerce_numeric_schema_keywords(wrap_class_schema(class_obj))
 
         return {}
 

--- a/lib/idp_common_pkg/idp_common/extraction/validation.py
+++ b/lib/idp_common_pkg/idp_common/extraction/validation.py
@@ -185,6 +185,72 @@ def _coerce_numeric_keyword(key: str, value: Any) -> Any:
     return value
 
 
+def coerce_numeric_schema_keywords(schema: Any) -> Any:
+    """Return ``schema`` with every stringified numeric constraint made numeric.
+
+    ``ConfigurationRecord._stringify_values`` turns every numeric scalar into a
+    string on the way into the Configuration table ("avoids Decimal conversion
+    issues") and it recurses into a class's ``json_schema``; nothing coerces them
+    back on read, because ``classes`` is typed ``List[Dict[str, Any]]`` so
+    validation never descends into it. A class authored in the Web UI therefore
+    arrives with ``minItems: "100"``.
+
+    Readers that compare such a value against a number raise ``TypeError``, and
+    the ones that guard themselves do it one site at a time — five separate
+    implementations of this rule had accumulated (this module, the Stickler
+    mapper, and three ad-hoc guards in ``extraction.service``) before a sixth
+    reader crashed on the constraint it was supposed to enforce (#797). Calling
+    this once where the schema enters the service gives every reader numbers.
+
+    Returns the input object unchanged when there was nothing to coerce, so the
+    common case allocates nothing and callers can keep sharing the config's own
+    dict. Never mutates its input. A value that cannot be read as a number is
+    left exactly as it is and logged at WARNING: the constraint is then ignored
+    by the guards downstream, and "constraint silently ignored" is the failure
+    mode that let #797 hide, so it must not be silent here too.
+    """
+    coerced, changed = _coerce_numerics(schema, "")
+    return coerced if changed else schema
+
+
+def _coerce_numerics(node: Any, path: str) -> tuple[Any, bool]:
+    """Recursive worker for :func:`coerce_numeric_schema_keywords`.
+
+    Returns ``(value, changed)`` so an untouched subtree can be handed back by
+    identity rather than rebuilt.
+    """
+    if isinstance(node, dict):
+        out: dict[Any, Any] = {}
+        changed = False
+        for key, value in node.items():
+            here = f"{path}.{key}" if path else str(key)
+            new_value, sub_changed = _coerce_numerics(value, here)
+            if isinstance(key, str) and key in _NUMERIC_SCHEMA_KEYWORDS:
+                candidate = _coerce_numeric_keyword(key, new_value)
+                if candidate is not new_value:
+                    new_value, sub_changed = candidate, True
+                elif isinstance(new_value, str):
+                    logger.warning(
+                        "Schema constraint %s at '%s' is not a number (%r); it "
+                        "will be ignored rather than enforced",
+                        key,
+                        here,
+                        new_value,
+                    )
+            out[key] = new_value
+            changed = changed or sub_changed
+        return (out, True) if changed else (node, False)
+    if isinstance(node, list):
+        items = []
+        changed = False
+        for index, item in enumerate(node):
+            new_item, sub_changed = _coerce_numerics(item, f"{path}[{index}]")
+            items.append(new_item)
+            changed = changed or sub_changed
+        return (items, True) if changed else (node, False)
+    return node, False
+
+
 def _strip_idp_extensions(schema: Any) -> Any:
     """Recursively drop ``x-aws-idp-*`` keys so only standard JSON Schema remains.
 

--- a/lib/idp_common_pkg/tests/unit/extraction/test_schema_numeric_coercion.py
+++ b/lib/idp_common_pkg/tests/unit/extraction/test_schema_numeric_coercion.py
@@ -1,0 +1,191 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""Stringified numeric schema constraints are coerced once, where the schema enters.
+
+``ConfigurationRecord._stringify_values`` converts every numeric scalar to a string
+on the way into the Configuration table and recurses into a class's ``json_schema``;
+nothing coerces them back on read, because ``classes`` is ``List[Dict[str, Any]]`` so
+validation never descends into it. A class authored in the Web UI therefore arrives
+with ``minItems: "100"``, and the reader that compared it without a guard raised
+``TypeError`` and lost its section's whole completeness report (#797).
+
+Five separate implementations of the same coercion had accumulated before that
+happened. These tests pin the single one: ``_get_class_schema`` is where every
+reader in the extraction service obtains a schema, so coercing there covers all of
+them — and an uncoercible value stays put and gets logged, because "constraint
+silently ignored" is exactly the failure mode that let #797 hide (#823).
+
+Scope note, so these tests are not read as proving more than they do: no shipping
+reader is broken by the string form *today*. #798's guard coerces ``"100"``
+successfully (it only treats an unreadable value as absent), and both the
+generated Pydantic model and the ``jsonschema`` path tolerate the string as well
+(verified directly — datamodel-code-generator coerces it, and
+``_strip_idp_extensions`` already coerces). What this covers is the next reader
+added without a guard, and the constraint that cannot be read as a number at all.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+from idp_common.extraction.service import ExtractionService
+from idp_common.extraction.validation import coerce_numeric_schema_keywords
+
+pytestmark = pytest.mark.unit
+
+
+def _stringified_class() -> dict[str, Any]:
+    """A class as it comes back from the Configuration table: numbers as strings."""
+    return {
+        "$id": "BankStatement",
+        "type": "object",
+        "properties": {
+            "AccountNumber": {"type": "string", "minLength": "8", "maxLength": "20"},
+            "Transactions": {
+                "type": "array",
+                "minItems": "100",
+                "maxItems": "5000",
+                "items": {"$ref": "#/$defs/Txn"},
+            },
+        },
+        "$defs": {
+            "Txn": {
+                "type": "object",
+                "properties": {"Amount": {"type": "number", "minimum": "0"}},
+            }
+        },
+    }
+
+
+def _service(class_obj: dict[str, Any]) -> ExtractionService:
+    return ExtractionService(
+        region="us-west-2",
+        config={
+            "extraction": {"model": "us.amazon.nova-pro-v1:0"},
+            "classes": [class_obj],
+        },
+    )
+
+
+class TestThroughTheServiceEntryPoint:
+    def test_every_constraint_arrives_numeric(self):
+        """Including the ones nested in ``items`` and behind a ``$ref`` in ``$defs``."""
+        schema = _service(_stringified_class())._get_class_schema("BankStatement")
+
+        props = schema["properties"]
+        assert props["Transactions"]["minItems"] == 100
+        assert props["Transactions"]["maxItems"] == 5000
+        assert props["AccountNumber"]["minLength"] == 8
+        assert props["AccountNumber"]["maxLength"] == 20
+        assert schema["$defs"]["Txn"]["properties"]["Amount"]["minimum"] == 0
+        assert all(
+            not isinstance(v, str)
+            for v in (
+                props["Transactions"]["minItems"],
+                props["AccountNumber"]["minLength"],
+            )
+        )
+
+    def test_the_completeness_check_gets_a_number_from_config(self):
+        """The #797 composition end to end: a class as the Configuration table
+        returns it, straight into the reader that crashed on it. This passes on
+        `develop` too, because #798 gave that reader its own coercion — the point
+        here is that the constraint is enforced without relying on it, so the
+        reader's guard becomes belt-and-braces rather than the only thing standing
+        between a UI-authored `minItems` and a TypeError."""
+        svc = _service(_stringified_class())
+        schema = svc._get_class_schema("BankStatement")
+
+        check = svc._check_completeness_detailed(
+            extracted_fields={"Transactions": [{"Amount": 1}, {"Amount": 2}]},
+            schema=schema,
+            tool_used=False,
+        )
+
+        assert check["schema_constraints_met"] is False
+        assert check["violations"][0]["shortfall"] == 98
+
+    def test_the_stored_config_is_not_mutated(self):
+        """The coercion hands back a copy: the config object is shared with every
+        other consumer, several of which round-trip it back to DynamoDB."""
+        class_obj = _stringified_class()
+        svc = _service(class_obj)
+
+        svc._get_class_schema("BankStatement")
+
+        assert class_obj["properties"]["Transactions"]["minItems"] == "100"
+        assert svc.config.classes[0]["properties"]["Transactions"]["minItems"] == "100"
+
+    def test_a_class_with_nothing_to_coerce_is_handed_back_unchanged(self):
+        """Identity against the object the service holds, not just equality — the
+        common case must not rebuild the schema on every section. (``IDPConfig``
+        validation copies the caller's dict, so the config's own object is the one
+        to compare with.)"""
+        svc = _service(
+            {
+                "$id": "Receipt",
+                "type": "object",
+                "properties": {"Total": {"type": "string"}},
+            }
+        )
+
+        assert svc._get_class_schema("Receipt") is svc.config.classes[0]
+
+
+class TestTheCoercionItself:
+    def test_already_numeric_values_are_left_alone(self):
+        schema = {"properties": {"L": {"type": "array", "minItems": 3}}}
+
+        assert coerce_numeric_schema_keywords(schema) is schema
+
+    def test_a_float_constraint_survives_as_a_float(self):
+        coerced = coerce_numeric_schema_keywords({"multipleOf": "0.25"})
+
+        assert coerced["multipleOf"] == 0.25
+
+    def test_a_negative_bound_survives(self):
+        coerced = coerce_numeric_schema_keywords({"minimum": "-5"})
+
+        assert coerced["minimum"] == -5
+
+    def test_only_the_numeric_keywords_are_touched(self):
+        """A stringified value under a non-numeric keyword is data, not a bound."""
+        coerced = coerce_numeric_schema_keywords(
+            {"description": "100", "default": "3", "minItems": "3"}
+        )
+
+        assert coerced["description"] == "100"
+        assert coerced["default"] == "3"
+        assert coerced["minItems"] == 3
+
+    def test_an_uncoercible_constraint_is_left_alone_and_logged(self, caplog):
+        """It must not raise, must not silently vanish, and must not be guessed at.
+        The guards downstream then ignore that one constraint — which is the
+        pre-existing behaviour — but now there is a record of it."""
+        schema = {"properties": {"L": {"type": "array", "minItems": "many"}}}
+
+        with caplog.at_level(logging.WARNING):
+            coerced = coerce_numeric_schema_keywords(schema)
+
+        assert coerced["properties"]["L"]["minItems"] == "many"
+        assert "minItems" in caplog.text
+        assert "properties.L.minItems" in caplog.text
+
+    def test_lists_are_walked(self):
+        """``anyOf``/``oneOf`` branches and tuple-form ``items`` are lists."""
+        coerced = coerce_numeric_schema_keywords(
+            {"anyOf": [{"type": "array", "minItems": "2"}, {"type": "null"}]}
+        )
+
+        assert coerced["anyOf"][0]["minItems"] == 2
+
+    def test_idempotent(self):
+        once = coerce_numeric_schema_keywords(_stringified_class())
+
+        assert coerce_numeric_schema_keywords(once) is once
+
+    def test_non_dict_input_passes_through(self):
+        assert coerce_numeric_schema_keywords(None) is None
+        assert coerce_numeric_schema_keywords("nope") == "nope"


### PR DESCRIPTION
Fixes #823 — the root cause #798 worked around.

**The mechanism.** `ConfigurationRecord._stringify_values` converts every numeric scalar to a string on the way into the Configuration table ("avoids Decimal conversion issues") and recurses into a class's `json_schema`. Nothing coerces them back on read, because `classes` is typed `List[Dict[str, Any]]` so pydantic validation never descends into it. A class authored in the Web UI therefore arrives with `minItems: "100"`, and the rule for handling that had been implemented **five** times — `extraction/validation.py`, `evaluation/stickler_backend/mapper.py`, and three ad-hoc guards in `extraction/service.py` — before a sixth reader crashed on the constraint it was meant to enforce (#797).

**The change.** `_get_class_schema` is the single point every reader in the extraction service gets a schema from, so the coercion happens there, reusing the existing `_NUMERIC_SCHEMA_KEYWORDS` set instead of adding a sixth copy. The per-site guards stay — they are also reachable with a schema that did not come through this method. The helper returns the input object unchanged when there is nothing to coerce, so the common case allocates nothing and does not rebuild the schema on every section, and it never mutates the config's own dict.

**What this does and does not fix — I checked rather than assuming.** It fixes no live crash:

- #798's guard coerces `"100"` successfully; it only treats an *unreadable* value as absent. So `minItems` from the UI is already enforced today.
- The generated Pydantic model enforces a stringified `minItems` too — datamodel-code-generator coerces it (verified by building the model both ways and validating a short list).
- The `jsonschema` path already coerces in `_strip_idp_extensions`.

What it buys is (a) the next reader added without a guard cannot reintroduce #797, and (b) one new diagnostic: a constraint that cannot be read as a number is logged at **WARNING** with its schema path, instead of being silently dropped by every guard downstream — "constraint silently ignored" being the failure mode that let #797 hide in the first place. If you would rather not carry a preventive change, closing this and #823 is a perfectly reasonable call; the argument for it is the five-implementations count, not a broken document.

**Tests.** New `test_schema_numeric_coercion.py` (12 cases): every constraint arrives numeric including nested in `items` and behind a `$ref` in `$defs`; the #797 composition end to end; the stored config is not mutated; a class with nothing to coerce is returned by identity; floats and negative bounds survive; only the numeric keywords are touched (a stringified `description`/`default` is data, not a bound); an uncoercible value is left alone and logged; lists (`anyOf`, tuple-form `items`) are walked; idempotent; non-dict passes through. The service-entry test is red without the wiring. Full `tests/unit` run: 5,233 passed, 1 failed — `test_convert_legacy_xls_to_pages`, which fails only because my local venv predates #800 and has no `xlrd`; unrelated to this change and green in CI, which installs the `[test]` extra. `ruff` and `basedpyright` clean.

**No CHANGELOG entry** — no user-visible behaviour changes. Happy to add one if you'd prefer the WARNING to be announced.