### PR TITLE
test(extraction): stop the agentic conftest evicting the real PIL from sys.modules

### DIFF
--- a/lib/idp_common_pkg/tests/unit/extraction/agentic_idp/conftest.py
+++ b/lib/idp_common_pkg/tests/unit/extraction/agentic_idp/conftest.py
@@ -73,15 +73,21 @@ def pytest_configure(config):
         ):
             sys.modules.pop(module_name, None)
 
-    # Remove any modules that imported the mocked modules so they get re-imported fresh
+    # Remove any modules that imported the mocked modules so they get re-imported
+    # fresh. PIL is only ever popped when it is itself a mock: dropping the REAL
+    # `PIL.Image` from sys.modules while its plugin modules (PIL.PngImagePlugin,
+    # ...) stay cached yields a fresh Image module whose plugin registry is empty
+    # — `Image.open` then raises UnidentifiedImageError on a valid PNG for every
+    # later test in the session (seen as tests/unit/extraction/
+    # test_image_downscale_metadata.py failing only when tests/unit/assessment
+    # ran first). CI never hit it because this hook returns early there.
     modules_to_reload = [
         "idp_common.extraction.agentic_idp",
         "idp_common.extraction.service",
-        "PIL",
-        "PIL.Image",
-        "PIL.ImageEnhance",
-        "PIL.ImageOps",
     ]
+    for module_name in ("PIL", "PIL.Image", "PIL.ImageEnhance", "PIL.ImageOps"):
+        if isinstance(sys.modules.get(module_name), MagicMock):
+            modules_to_reload.append(module_name)
 
     for module_name in modules_to_reload:
         sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Problem

`tests/unit/extraction/agentic_idp/conftest.py`'s `pytest_configure` popped `PIL`, `PIL.Image`, `PIL.ImageEnhance` and `PIL.ImageOps` from `sys.modules` unconditionally. When PIL was never mocked, that evicts the **real** `PIL.Image` while its plugin modules stay cached, so the next `from PIL import Image` builds a fresh module with an **empty plugin registry** and `Image.open` raises `UnidentifiedImageError` on a valid PNG for the rest of the session.

Symptom: the two `tests/unit/extraction/test_image_downscale_metadata.py` tests from #841 fail locally only when `tests/unit/assessment` runs first in the same process (`make test` order). CI never hit it because the hook returns early when `CI` is set.

## Change

Pop the PIL modules only when they are `MagicMock` instances — the rule the hook already states for the strands modules. 10 lines, tests only.

## Verification

`tests/unit/assessment` + `tests/unit/extraction` + `tests/unit/image` + `tests/unit/discovery` in one process: **all passed, 0 failed** (was 2 failed). Root-caused by instrumenting the fit: `Image.OPEN` had 0 entries and `Image.ID` was empty during the polluted run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)