### PR TITLE
docs(skills): refresh the test-battery baseline and delete the stale failure allow-list

### DIFF
--- a/.claude/skills/full-test-battery.md
+++ b/.claude/skills/full-test-battery.md
@@ -3,26 +3,44 @@
 Use this skill when asked to "run the full battery of tests", validate a branch
 before/after a merge, or gate a release. It runs every unit suite `make test`
 covers, plus lint/typecheck, and — critically — tells you how to separate a **real
-regression** from the repo's **known pre-existing / environment-only failures** so
-a green-enough run isn't misread as broken.
+regression** from an **environment problem**, which is what nearly every surprising
+failure in this repo turns out to be.
 
 > This is a **read-only verification** skill. It does not deploy or commit. For the
 > deploy step (publish + CloudFormation update) see `.claude/skills/infrastructure.md`
 > and the "Deploy" note at the bottom.
 
-## Environment setup (do this first — two gotchas)
+## Environment setup (do this first — three gotchas)
 
-1. **Activate the repo venv** — it has all deps (pdfium, PIL, boto3, strands, …):
+1. **Install the pinned test extras BEFORE you believe any failure.** This is the
+   single biggest source of wasted time on this repo:
    ```bash
-   source /home/ec2-user/projects/idp1/.venv/bin/activate
+   cd lib/idp_common_pkg && pip install -e ".[test]"   # what CI's test-unit-cicd does
+   make install-first-party                            # from repo root, for the sibling packages
    ```
-   Bare `python3` may import a STALE `idp_common` from another checkout
-   (`/home/ec2-user/projects/idp2|idp3`). When running `idp_common` tests directly,
-   force the path:
+   A venv that predates the current `[test]` extra produces **~45 failures and ~17
+   collection errors** that look exactly like environment-only "known" failures —
+   stale `stickler-eval` (`No module named 'stickler.doc_split'`, `ImportError:
+   cannot import name 'aggregate_from_comparisons'`), plus missing `z3`, `xlrd`,
+   `sklearn` and `aws_xray_sdk`. They are not repo defects and there is nothing to
+   fix in the tests. Check before diagnosing anything:
    ```bash
-   export PYTHONPATH=/home/ec2-user/projects/idp1/lib/idp_common_pkg
+   python -c "import importlib.metadata as m; print(m.version('stickler-eval'))"  # must match the pin in pyproject [test]
+   python -c "import z3, xlrd, sklearn, aws_xray_sdk; print('deps ok')"
    ```
-2. **`publish.py` must run in a CLEAN env** — the venv on `PATH` breaks SAM's
+   `idp_cli`'s suite additionally errors with `No module named 'idp_sdk'` until
+   `make install-first-party` has run.
+2. **Activate the repo venv** — it has all deps (pdfium, PIL, boto3, strands, …):
+   ```bash
+   source <checkout>/.venv/bin/activate     # e.g. lib/idp_common_pkg/.venv
+   ```
+   Bare `python3` may import a STALE `idp_common` from another checkout (this repo
+   is commonly cloned side by side as `idp1`/`idp2`/`idp3`). When running
+   `idp_common` tests directly, force the path:
+   ```bash
+   export PYTHONPATH=<checkout>/lib/idp_common_pkg
+   ```
+3. **`publish.py` must run in a CLEAN env** — the venv on `PATH` breaks SAM's
    OpenSSL (`OPENSSL_3.4.0 not found` / `_sha2`). Build with:
    ```bash
    env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin AWS_PROFILE=default bash -lc \
@@ -41,61 +59,84 @@ make lint          # ruff-lint + format + ARN check + buildspec + UI lint + code
 make typecheck     # basedpyright
 ```
 
-Per-suite (isolated) — `PP=/home/ec2-user/projects/idp1/lib/idp_common_pkg`:
+`make typecheck` fails with `make: basedpyright: No such file or directory` if the
+tool is absent — it is not in the `[test]` extra. `pip install basedpyright` (CI
+installs it via `npm install -g basedpyright`). Compare its output against the
+baseline on `develop` rather than reading it absolutely: it reports **4 errors / 51
+warnings** on a clean tree (2026-09-11). Note **which files those errors land in
+shifts with the installed dependency set** — with `z3-solver` present they sit in
+`rule_validation/z3/z3_validator.py` and `calculate_capacity/index.py`, without it
+they move — so compare the **totals**, and check that no diagnostic names a file
+your change touched.
 
-| Suite | Command | Expected (2026-07-08 baseline) |
-|-------|---------|--------------------------------|
-| idp_common unit | `cd lib/idp_common_pkg && PYTHONPATH=$PP pytest tests/unit -q -p no:cacheprovider` | ~2214 pass, **26 fail (all pre-existing — see below)** |
-| idp_cli | `cd lib/idp_cli_pkg && pytest -q` | ~139 pass |
-| idp_sdk | `cd lib/idp_sdk && pytest -m "not integration" -q` | ~292 pass, **0 fail** (was 279 pass / 8 fail until the suite's `conftest` put the in-repo `idp_common` on `sys.path` — `test_config_operations.py` patches `idp_common.config.merge_utils.*` and cannot run without it) |
-| idp_feature_sdk | `cd lib/idp_feature_sdk && pytest -q` | ~64 pass (slow, ~65s) |
-| feature platform | `cd feature-platform/main-stack-extensions && pytest -q` | ~90 pass |
-| config library | `pytest config_library/test_config_library.py -q` | ~95 pass |
+Per-suite (isolated) — `PP=<checkout>/lib/idp_common_pkg`:
+
+| Suite | Command | Expected (2026-09-11 baseline, all green) |
+|-------|---------|-------------------------------------------|
+| idp_common unit | `cd lib/idp_common_pkg && PYTHONPATH=$PP pytest tests/unit -q -p no:cacheprovider` | **5682 pass, 13 skip, 0 fail** (~2.5 min) |
+| idp_cli | `cd lib/idp_cli_pkg && pytest -q` | 177 pass |
+| idp_sdk | `cd lib/idp_sdk && pytest -m "not integration" -q` | 471 pass (~2.5 min) |
+| idp_feature_sdk | `cd lib/idp_feature_sdk && pytest -q` | 140 pass (slow, ~75s) |
+| feature platform | `cd feature-platform/main-stack-extensions && pytest -q` | 207 pass |
+| pii-anonymizer hook | `cd feature-platform/pii-anonymizer/hook && pytest tests -q` | 17 pass |
+| config library | `pytest config_library/test_config_library.py -q` | 114 pass |
 | pipeline-hooks | `cd lib/idp_common_pkg && pytest tests/unit/lambdas/test_pipeline_hooks_dispatcher.py -q` | 6 pass |
-| capacity Lambda | `cd src/lambda/calculate_capacity && pytest -q` | ~33 pass |
-| chat-with-document | `pytest src/lambda/chat_with_document_processor/tests ... -q` | ~13 pass |
-| chat-stream | `cd src/lambda/chat_stream_processor && pytest tests -q` | ~6 pass |
+| capacity Lambda | `cd src/lambda/calculate_capacity && pytest -q` | 33 pass |
+| chat-with-document | `cd src/lambda/chat_with_document_processor && pytest tests -q` | 17 pass |
+| chat-stream | `cd src/lambda/chat_stream_processor && pytest tests -q` | 6 pass |
 
-## Known pre-existing failures — DO NOT treat as regressions
+## There is no standing failure set — green means green
 
-These fail on **pristine `develop`** (verified via a `git worktree add /tmp/x github/develop`
-run), not because of your change. Confirm any failure is in this set before
-worrying; anything OUTSIDE this set is a real regression to investigate.
+**A correctly installed tree passes every suite above with zero failures**
+(verified on `develop` at `3101aeeb`, 2026-09-11). So treat **any** failure as a
+real regression until you have proved otherwise.
 
-**Genuinely failing on develop (env / test-harness, not runtime code):**
-- `tests/unit/config/test_configuration_sync.py::TestSyncCustomWithNewDefault` — 6 tests (config-merge semantics).
-- `tests/unit/discovery/test_embedding_service.py` — 2 (image/embedding env deps).
-- `tests/unit/discovery/test_discovery_agent.py` — 1.
-- `tests/unit/test_publish.py::TestIDPPublisherEnvironmentSetup` — 4 (mock a method not in the installed `idp_sdk`).
-- `tests/unit/assessment/test_assessment_enabled_property.py::...::test_assessment_missing_config_section` — 1 (config-defaults expectation).
+This section previously listed ~26 "known pre-existing failures — DO NOT treat as
+regressions", covering `test_configuration_sync.py`, `test_embedding_service.py`,
+`test_discovery_agent.py`, `test_publish.py`, `test_assessment_enabled_property.py`,
+`test_pdf_page_extraction.py`, `test_document_compression.py` and
+`workflow_tracker/test_notify_circuit_breaker.py`. **All of them now pass**, and the
+list has been removed rather than trimmed, because a stale allow-list is worse than
+none: it invites you to wave through a genuine regression that happens to land in a
+file it names. Two lessons worth keeping:
 
-**Order-dependent (PASS in isolation, fail only in the full `tests/unit` run):**
-- `tests/unit/discovery/test_pdf_page_extraction.py` — 7.
-- `tests/unit/test_document_compression.py::...::test_unique_s3_keys_generated` — 1.
-  → Re-run the file alone (`pytest <file> -q`) to confirm it's pollution, not a defect.
+- Most of that list was an **environment artifact, not a repo state** — the symptom
+  of a venv missing the pinned `[test]` extras (see gotcha 1). Reach for
+  `pip install -e ".[test]"` before you reach for this section.
+- Order-dependent pollution is still a real phenomenon. If a test fails in the full
+  run, re-run the file alone (`pytest <file> -q`) before concluding anything.
 
-**PYTHONPATH-sensitive Lambda tests** (need the exact `make test` invocation; fail
-standalone with `ModuleNotFoundError: No module named 'idp_common.document_versions'`
-because they mock `idp_common` as a bare module):
-- `src/lambda/workflow_tracker/test_notify_circuit_breaker.py` — 4 errors when run
-  outside `make test`. Run via `make test` (or with the module's own conftest) to get them green.
+If you do find a genuine standing failure, add it here **with the date and the
+verified cause** — and delete it the moment it stops reproducing.
 
 ## How to verify a suspected regression is real (not inherited)
 
-```bash
-git worktree add -q /tmp/dev-check github/develop
-cd /tmp/dev-check/lib/idp_common_pkg
-PYTHONPATH=/tmp/dev-check/lib/idp_common_pkg pytest <the failing test> -q -p no:cacheprovider
-cd - && git worktree remove /tmp/dev-check --force
-```
-If it fails on pristine develop too → pre-existing, not yours.
+Order matters — check the cheap explanation first:
+
+1. **Read the error.** `ModuleNotFoundError` / `ImportError` on a third-party name
+   (`stickler.*`, `z3`, `xlrd`, `sklearn`, `aws_xray_sdk`, `idp_sdk`) is an install
+   problem, not a regression. Fix the environment (gotcha 1) and re-run.
+2. **Re-run the file alone** to rule out order-dependent pollution.
+3. **Only then** compare against pristine `develop`:
+   ```bash
+   git worktree add -q /tmp/dev-check github/develop
+   cd /tmp/dev-check/lib/idp_common_pkg
+   pip install -e ".[test]"          # the worktree needs the deps too, or you prove nothing
+   PYTHONPATH=/tmp/dev-check/lib/idp_common_pkg pytest <the failing test> -q -p no:cacheprovider
+   cd - && git worktree remove /tmp/dev-check --force
+   ```
+   If it fails on pristine develop with a correct install → pre-existing, not yours.
+   (Note `/tmp` worktrees may belong to a sibling checkout — verify the git dir
+   before running git commands there.)
 
 ## Reporting
 
-State totals per suite, then explicitly: "N failures, all in the known
-pre-existing/env set (list), 0 new regressions" — or name any failure outside the
-set as a real regression with its error. Never report a raw "26 failed" without
-that classification; it reads as broken when it isn't.
+State totals per suite, then explicitly: "0 failures across N suites" — or name each
+failure with its error and which of the three checks above you applied. Two things
+never to do: report a raw failure count without saying whether the environment was
+correctly installed (a stale venv reads as a broken repo), and describe a failure as
+"pre-existing" without having reproduced it on `develop` **with the test extras
+installed**.
 
 ## Deploy (separate step, when asked to update the stack)
 


### PR DESCRIPTION
## Why this is a docs PR and not a test fix

I opened this expecting to fix failing tests. **There are none.** With a correctly
installed environment, every suite on `develop` is green — 0 failures. The ~45
failures and ~17 collection errors I had reported were entirely a stale local venv.

What *was* broken is the thing that made me believe otherwise:
`.claude/skills/full-test-battery.md` carried a **2026-07-08** baseline of
"~2214 pass, **26 fail** (all pre-existing — **DO NOT treat as regressions**)".
Every test in that allow-list now passes, and the pass count has since more than
doubled. A stale allow-list is worse than no allow-list: it invites the next reader
(human or agent) to wave through a *genuine* regression that happens to land in a
file it names.

## Verified baseline

On `develop` @ `3101aeeb`, with the pinned `[test]` extras installed:

| Suite | Result | | Suite | Result |
|---|---|---|---|---|
| idp_common unit | **5682 pass**, 13 skip | | idp_sdk | 471 pass |
| idp_cli | 177 pass | | idp_feature_sdk | 140 pass |
| feature platform | 207 pass | | pii-anonymizer hook | 17 pass |
| config library | 114 pass | | capacity Lambda | 33 pass |
| chat-with-document | 17 pass | | chat-stream | 6 pass |

Every entry in the deleted allow-list re-run explicitly: `test_configuration_sync.py::TestSyncCustomWithNewDefault`,
`test_embedding_service.py`, `test_discovery_agent.py`, `test_publish.py::TestIDPPublisherEnvironmentSetup`,
`test_assessment_enabled_property.py`, `test_pdf_page_extraction.py`,
`test_document_compression.py` and `workflow_tracker/test_notify_circuit_breaker.py`
→ **69 passed** together, and the workflow_tracker file passes standalone despite the
note claiming it needs the exact `make test` invocation.

## The actual root cause, now documented as gotcha 1

A venv predating the current `[test]` extra produces failures that mimic
environment-only "known" failures almost perfectly:

| Symptom | Cause |
|---|---|
| `No module named 'stickler.doc_split'`, `cannot import name 'aggregate_from_comparisons'` | `stickler-eval` 0.1.4 installed vs `0.5.0` pinned — the module is *present*, just old, so it doesn't read as "missing dependency" |
| `No module named 'z3'` / `'xlrd'` / `'sklearn'` / `'aws_xray_sdk'` | absent; `z3-solver` and `xlrd` **are** in `[test]`, the other two arrive transitively |
| `No module named 'idp_sdk'` (idp_cli suite) | needs `make install-first-party` |

The fix is `pip install -e ".[test]"`, not a code change. Two one-line checks are
now in the skill so this is ruled out **before** anything is diagnosed.

## Changes

- **Deleted** the known-pre-existing-failures section; replaced with "there is no
  standing failure set — green means green", keeping the two lessons worth having
  (most of that list was an environment artifact; order-dependent pollution is
  still real) and instructions to re-add a genuine standing failure *with its date
  and verified cause*, and delete it when it stops reproducing.
- **Refreshed** every per-suite expected count, and added the pii-anonymizer hook
  suite which was missing from the table.
- **Reordered regression triage cheapest-first:** read the error for a third-party
  `ModuleNotFoundError` → re-run the file alone for pollution → only then diff
  against a `develop` worktree, which must itself have the extras installed or it
  proves nothing. (The old recipe omitted that install, so it would have
  "confirmed" any of these as pre-existing.)
- **Reporting rules** now forbid describing a failure as "pre-existing" without
  having reproduced it on `develop` with the extras installed, and forbid quoting a
  failure count without saying whether the environment was correctly installed.
- **Recorded the basedpyright baseline** (4 errors / 51 warnings) and noted the tool
  is *not* in the `[test]` extra — `make typecheck` dies with
  `basedpyright: No such file or directory` otherwise. Also noted that which files
  those errors land in **shifts with the installed dependency set** (with
  `z3-solver` present, two move into `z3_validator.py`), so compare totals rather
  than locations.
- Replaced hardcoded `/home/ec2-user/projects/idp1` paths with `<checkout>`, since
  the skill is used from several side-by-side checkouts.

## Risk

Documentation only — one file, no code, no template, no test touched. `.cline/skills/`
has no symlink for this skill, so nothing else needs updating.