### PR TITLE
docs(feature-platform): EnableFeaturePlatform cannot be turned on by a stack update (#845)

### DIFF
--- a/docs/feature-platform.md
+++ b/docs/feature-platform.md
@@ -15,6 +15,18 @@ title: "Feature Platform"
 > Marketplace/entitlement path (`FeaturePlatformSimulatorEndpoint`,
 > Subscribe → Active flow) is wired but unused until paid extensions ship. Set
 > `EnableFeaturePlatform=false` to remove the platform entirely.
+>
+> ⚠️ **Known limitation: decide at create time.** `EnableFeaturePlatform` can be
+> turned **off** on an existing stack, but it cannot be turned back **on** by a
+> stack update: the update fails with `Export with name <StackName>-TrackingTableName
+> is already exported by stack <StackName>` and rolls back cleanly. The main
+> template exports that name while the platform is off and the nested platform
+> stack exports it while the platform is on; CloudFormation creates the nested
+> stack (and its export) during the resource phase but only retires the parent's
+> export at the end of the update, so on the `false` → `true` transition both
+> exist at once. To adopt the platform on a stack created with it off, deploy a
+> new stack with the default `true`. Tracked in
+> [#845](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/845).
 
 The Feature Platform turns the IDP Accelerator main stack into a **host** for
 *installable extensions* — add-ons that are discovered and installed at runtime
@@ -694,6 +706,9 @@ The default brings up:
 To turn the feature platform off entirely, set `EnableFeaturePlatform=false` —
 no platform resources are created, and the Extensions nav section is empty
 (apart from the Browse catalog link, whose page reports no extensions).
+Turning it off is a one-way change on a live stack: setting the parameter back
+to `true` later fails on the `TrackingTableName` export collision described at
+the top of this page ([#845](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws/issues/845)).
 
 ### Tear-down
 


### PR DESCRIPTION
## Summary

Documents the limitation reported in #845: `EnableFeaturePlatform` can be turned **off** on an existing stack, but flipping it back **on** by a stack update fails deterministically with `Export with name <StackName>-TrackingTableName is already exported by stack <StackName>` and rolls back.

The note is added in two places in `docs/feature-platform.md`: the status callout at the top of the page, and next to the existing "turn the feature platform off" instructions. It explains the mechanism in one paragraph (parent exports the name while off, nested platform stack exports it while on, and CloudFormation retires the parent's export only at the end of the update) and gives the workaround (deploy a new stack with the default `true`).

## Why docs only, for this release

The naive fix (parent exports unconditionally, nested stack stops re-exporting) would break upgrades of every default-configured stack with an installed feature, because the shipped extensions import `${Stack}-TrackingTableName` from the nested stack and CloudFormation refuses to remove an imported export. The analysis and the constraints for a real fix are on #845; the fix stays tracked there for a post-release change.

## Test plan

- [x] Docs-only change; no code or template touched.
- [x] Note reviewed against `template.yaml` (`IsFeaturePlatformDisabled` on the `TrackingTableName` output) and `feature-platform/main-stack-extensions/template.yaml` (the nested re-export) on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
