### PR TITLE
ci(docs): make the docs workflow build-only; drop the always-failing Pages deploy job

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,6 +1,17 @@
-name: Deploy Documentation to GitHub Pages
+name: Build Documentation Site
 
-# checkov:skip=CKV2_GHA_1: "Permissions are properly scoped - contents:read, pages:write, id-token:write for GitHub Pages deployment"
+# Build-only validation of the Starlight docs site. It does NOT publish.
+#
+# The live GitHub Pages site is served from the `gh-pages` branch ("Deploy from
+# a branch" mode) and is published manually with `make docs-deploy`, which builds
+# locally and pushes `docs-site/dist` to that branch via `npx gh-pages`. This
+# workflow used to have a `deploy` job calling `actions/deploy-pages` from `main`,
+# but that can never succeed here: the `github-pages` environment's branch policy
+# only allows `gh-pages`, and `actions/deploy-pages` requires Pages to be in
+# "GitHub Actions" source mode anyway. Every run of that job on `main` failed
+# (2026-07 through 2026-09), so it was removed rather than left permanently red.
+# If publishing is ever moved into Actions, switch the Pages source to
+# "GitHub Actions" and allow `main` on the environment first.
 
 on:
   push:
@@ -9,16 +20,19 @@ on:
       - 'docs/**'
       - 'docs-site/**'
       - 'images/**'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'docs-site/**'
+      - 'images/**'
   workflow_dispatch: # Allow manual trigger
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: docs-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -49,20 +63,3 @@ jobs:
       - name: Build documentation site
         working-directory: docs-site
         run: npm run build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        with:
-          path: docs-site/dist
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/developer-tests.yml
+++ b/.github/workflows/developer-tests.yml
@@ -75,7 +75,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       # Node 22 is needed for the UI unit tests and for basedpyright. Use the
-      # first-party setup-node action (as deploy-docs.yml already does) rather
+      # first-party setup-node action (as build-docs.yml already does) rather
       # than piping NodeSource's installer into bash: that pipeline swallowed a
       # failed download (`curl ... | bash -` exits with bash's status, not
       # curl's), so a NodeSource 403 silently left the repo unregistered, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT-0
 
 ## [Unreleased]
 
+### Changed
+
+- **The GitHub docs workflow is now build-only (`build-docs.yml`); it no longer tries to publish to GitHub Pages.** Its `deploy` job called `actions/deploy-pages` from `main`, but the `github-pages` environment only allows the `gh-pages` branch and the Pages source is "Deploy from a branch", so the job failed on every push to `main` since July 2026 and marked the repo's Pages deployment red. The site is published with `make docs-deploy`, which pushes the local build to `gh-pages`; the workflow keeps the build job as a docs-site build check on `main`, `develop` and pull requests that touch `docs/`, `docs-site/` or `images/`, with `pages: write` and `id-token: write` permissions dropped.
+
 ## [0.6.8]
 
 ### Added


### PR DESCRIPTION
## Why

The repo shows a failed **github-pages** deployment after every push to `main`. The failing job is `deploy` in `.github/workflows/deploy-docs.yml`, which calls `actions/deploy-pages` from `main` and is rejected in 1 second:

```
Branch "main" is not allowed to deploy to github-pages due to environment protection rules.
```

The `github-pages` environment's branch policy only allows `gh-pages`, and the Pages source is "Deploy from a branch" (`gh-pages`), which `actions/deploy-pages` cannot target anyway. Every run of this job on `main` has failed since at least 2026-07-14. The live docs site is published by `make docs-deploy` (`npx gh-pages` pushing `docs-site/dist` to `gh-pages`), which works.

## What

- Remove the `deploy` job and the `pages: write` / `id-token: write` permissions it needed; keep only `contents: read`.
- Rename the workflow to `build-docs.yml` / "Build Documentation Site" so it no longer claims to deploy. The `build` job stays as a docs-site build check, and now also runs on pull requests touching `docs/`, `docs-site/`, or `images/`.
- Drop the now-unconsumed `upload-pages-artifact` step and the `pages` concurrency group.
- Header comment records why the deploy job was removed and what to change if publishing ever moves into Actions (Pages source → "GitHub Actions", allow `main` on the environment).
- Update the cross-reference comment in `developer-tests.yml` and add a CHANGELOG entry.

Publishing continues via `make docs-deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)