### PR TITLE
fix(seller-stacktest): forward --region, reject API Gateway 403s, sweep named log groups

### DIFF
--- a/feature-platform/seller-entitlement-service/tests/dynamic_activation_test.py
+++ b/feature-platform/seller-entitlement-service/tests/dynamic_activation_test.py
@@ -119,6 +119,41 @@ def _post(url: str, body: str, session: Optional[object], region: str):
         return 0, f"connection error: {exc}"
 
 
+# API Gateway's own 403s. A request the edge refuses — wrong SigV4 region, no
+# signature, a stage that does not exist — never reaches the Lambda, so a 403 with
+# one of these bodies proves nothing about the service's refusal logic. Every
+# signed-request assertion below must see the SERVICE's body instead (issue #889).
+_EDGE_403_MARKERS = (
+    "Credential should be scoped",
+    "Missing Authentication Token",
+    "The security token included in the request is invalid",
+    "Signature expired",
+    '"message"',  # API Gateway's envelope; the service never uses this key
+)
+
+
+def is_service_refusal(text: str) -> bool:
+    """True only for the service's own not-entitled body (``{"error": "not_entitled", …}``)."""
+    try:
+        body = json.loads(text)
+    except (TypeError, ValueError):
+        return False
+    return isinstance(body, dict) and body.get("error") == "not_entitled"
+
+
+def is_edge_refusal(text: str) -> bool:
+    """True for a 403 API Gateway produced itself, before the Lambda ran."""
+    return any(marker in (text or "") for marker in _EDGE_403_MARKERS)
+
+
+def _reject_edge_403(where: str, text: str) -> None:
+    bad(
+        f"{where}: the 403 came from API Gateway, not the service — the request "
+        f"never reached the Lambda, so this proves nothing about entitlement "
+        f"refusal. Usually a SigV4 region mismatch (pass --region). Body: {text[:160]}"
+    )
+
+
 def check_unsigned_is_refused(url: str, product_id: str, region: str) -> None:
     status, text = _post(url, json.dumps({"productId": product_id}), None, region)
     if status == 403:
@@ -139,6 +174,9 @@ def check_not_entitled(url: str, product_id: str, session, region: str) -> str:
     if status != 403:
         bad(f"unentitled account got {status}, expected 403: {text[:200]}")
         return text
+    if not is_service_refusal(text):
+        _reject_edge_403("unentitled account", text)
+        return text
     for leak in ("AccessDenied", "ValidationException", "arn:aws", "Traceback"):
         if leak in text:
             bad(f"403 body leaks internal detail ({leak!r}) to an arbitrary caller")
@@ -151,8 +189,10 @@ def check_no_product_oracle(url: str, refused_body: str, session, region: str) -
     status, text = _post(
         url, json.dumps({"productId": "prod-definitely-not-real"}), session, region
     )
-    if status == 403 and text == refused_body:
+    if status == 403 and text == refused_body and is_service_refusal(text):
         ok("unknown product is byte-identical to not-entitled — no existence oracle")
+    elif status == 403 and not is_service_refusal(text):
+        _reject_edge_403("unknown product", text)
     else:
         bad(
             f"unknown product is distinguishable (status={status}). A caller can "
@@ -217,6 +257,12 @@ def check_hostile_payloads(url: str, session, region: str) -> None:
             problems.append(f"{label}: connection failed ({text[:60]})")
         elif status >= 500:
             problems.append(f"{label}: {status}")
+        elif status == 403 and not is_service_refusal(text):
+            # An edge 403 means the payload never reached the handler, so
+            # "refused cleanly" would be claiming robustness that was not tested.
+            problems.append(
+                f"{label}: 403 from API Gateway, not the service ({text[:60]})"
+            )
         elif status not in (400, 403, 413):
             problems.append(f"{label}: unexpected {status}")
     if problems:

--- a/feature-platform/seller-entitlement-service/tests/stacktest.sh
+++ b/feature-platform/seller-entitlement-service/tests/stacktest.sh
@@ -137,8 +137,12 @@ info "endpoint: $ENDPOINT"
 # Assertion #3: the live stage really enforces SigV4, refuses cleanly, and never
 # 5xxes on hostile input.
 info "running the live security probe"
+# --region MUST be forwarded: the probe SigV4-signs for the region it is told,
+# and API Gateway rejects a request signed for the wrong one with a 403 of its
+# own ("Credential should be scoped to a valid region") — which the refusal
+# assertions below used to accept as a pass (issue #889).
 "$PYTHON" "$HERE/dynamic_activation_test.py" \
-  --endpoint "$ENDPOINT" --product-id "$SYNTHETIC_PRODUCT" \
+  --endpoint "$ENDPOINT" --product-id "$SYNTHETIC_PRODUCT" --region "$REGION" \
   || die "live security probe failed"
 
 echo

--- a/feature-platform/seller-entitlement-service/tests/teardown_test_stack.sh
+++ b/feature-platform/seller-entitlement-service/tests/teardown_test_stack.sh
@@ -76,6 +76,12 @@ TABLE_NAME="$(aws cloudformation describe-stack-resource \
   --stack-name "$STACK_NAME" --logical-resource-id ActivationsTable \
   --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' \
   --output text 2>/dev/null)" || TABLE_NAME=""
+# The REST API id names the execution-log group; capture it while the stack
+# still knows it.
+API_ID="$(aws cloudformation describe-stack-resource \
+  --stack-name "$STACK_NAME" --logical-resource-id ActivationApi \
+  --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' \
+  --output text 2>/dev/null)" || API_ID=""
 
 echo "Retained resources to clean up after stack deletion:"
 echo "  KMS key:  ${KEY_ID:-<not found>}"
@@ -115,5 +121,28 @@ if [[ -n "$KEY_ID" && "$KEY_ID" != "None" ]]; then
     warn "could not schedule deletion of key $KEY_ID (already pending?)"
   fi
 fi
+
+# Named log groups. The template gives the access-log and execution-log groups
+# fixed names and does NOT retain them, yet the access-log group is present again
+# after delete-stack returns — API Gateway re-creates it while flushing buffered
+# access logs for the stage that has just gone. Left in place, CloudFormation's
+# AWS::EarlyValidation::ResourceExistenceCheck fails the NEXT deploy of this
+# stack name at changeset creation (issue #889). Sweep them, idempotently.
+sleep 20   # let the post-delete log flush land before we look
+for LG in "/aws/apigateway/${STACK_NAME}-activation" \
+          "/${STACK_NAME}/lambda/ActivateFunction" \
+          ${API_ID:+"API-Gateway-Execution-Logs_${API_ID}/prod"}; do
+  CREATED="$(aws logs describe-log-groups --log-group-name-prefix "$LG" \
+    --region "$REGION" --query "logGroups[?logGroupName=='$LG'].creationTime" \
+    --output text 2>/dev/null)"
+  if [[ -n "$CREATED" && "$CREATED" != "None" ]]; then
+    if aws logs delete-log-group --log-group-name "$LG" --region "$REGION" \
+        >/dev/null 2>&1; then
+      ok "deleted leftover log group $LG (created $(date -u -d @$((CREATED/1000)) +%FT%TZ 2>/dev/null || echo "$CREATED"))"
+    else
+      warn "could not delete log group $LG"
+    fi
+  fi
+done
 
 ok "teardown complete"

--- a/feature-platform/seller-entitlement-service/tests/test_probe_refusal_shapes.py
+++ b/feature-platform/seller-entitlement-service/tests/test_probe_refusal_shapes.py
@@ -1,0 +1,60 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""The live probe must tell the service's 403 from API Gateway's.
+
+Issue #889: run in any region other than the probe's default, every SigV4 request
+was signed for the wrong region and API Gateway answered 403 before the Lambda
+ran. Three refusal assertions expected a 403 and accepted that one, so the probe
+passed on requests that never reached the code under test. These tests pin the
+classifier those assertions now use.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dynamic_activation_test import (  # noqa: E402
+    is_edge_refusal,
+    is_service_refusal,
+)
+
+SERVICE_BODY = json.dumps(
+    {
+        "error": "not_entitled",
+        "detail": "No active AWS Marketplace subscription for this account.",
+    }
+)
+
+
+@pytest.mark.unit
+def test_the_service_body_is_a_service_refusal():
+    assert is_service_refusal(SERVICE_BODY)
+    assert not is_edge_refusal(SERVICE_BODY)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "body",
+    [
+        '{"message":"Credential should be scoped to a valid region. "}',
+        '{"message":"Missing Authentication Token"}',
+        '{"message":"The security token included in the request is invalid."}',
+        '{"message":"Forbidden"}',
+        '{"message":"Signature expired: 20260911T230000Z is now earlier than ..."}',
+    ],
+)
+def test_api_gateway_bodies_are_edge_refusals_not_service_ones(body):
+    assert is_edge_refusal(body)
+    assert not is_service_refusal(body)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("body", ["", "0", "not json", "[]", '{"error":"other"}'])
+def test_anything_else_is_neither(body):
+    assert not is_service_refusal(body)
+    # Only the specific API Gateway markers count as an edge refusal.
+    assert not is_edge_refusal(body)


### PR DESCRIPTION
Fixes #889.

## What was wrong

`tests/stacktest.sh` deployed with `--region` but ran the live probe without it. Outside us-east-1 every SigV4 request was signed for the wrong region and API Gateway answered `403 {"message":"Credential should be scoped to a valid region. "}` before the Lambda ran. Three refusal assertions expected a 403 and accepted that one, so the probe passed on requests that never reached the service; only the malformed-body check (400) failed. Separately, the fixed-name access-log group `/aws/apigateway/<stack>-activation` was present again after every teardown and failed the next deploy on `AWS::EarlyValidation::ResourceExistenceCheck`.

## Changes

- `stacktest.sh` forwards `--region "$REGION"` to `dynamic_activation_test.py`.
- The probe now classifies 403 bodies. Only the service's `{"error": "not_entitled", …}` counts as a refusal; API Gateway's `{"message": …}` shapes (wrong region, missing token, expired signature) fail the assertion with a message saying the request never reached the service. Applied to the unentitled, no-existence-oracle and hostile-payload checks. `test_probe_refusal_shapes.py` pins the classifier (149 tests in the directory pass).
- `teardown_test_stack.sh` deletes the stack's named log groups after `stack-delete-complete`, idempotently, and prints each one's `creationTime`.

## Verified live — two consecutive runs in us-west-2, the region that used to pass vacuously

**Run 1 failed at changeset creation** on `ResourceExistenceCheck` — the account still held `/aws/apigateway/idp-seller-entitlement-citest-activation` from the v0.6.6 validation on 2026-08-28, i.e. exactly the defect in #889. The new teardown then swept it:

```
✓ deleted leftover log group /aws/apigateway/idp-seller-entitlement-citest-activation (created 2026-08-28T23:13:44Z)
```

**Run 2 passed**, every assertion genuine (unsigned → 403, unentitled → service 403, no oracle, 400, 413, 15 hostile payloads), and its teardown swept its own leftover:

```
✓ deleted leftover log group /aws/apigateway/idp-seller-entitlement-citest-activation (created 2026-09-12T18:25:46Z)
```

That creation time is the mechanism: CloudFormation reported `ActivationApiAccessLogGroup DELETE_COMPLETE` at **18:25:40**, and the group was created again at **18:25:46** — API Gateway re-creates it while flushing buffered access logs for the stage that has just gone. The 2026-08-28 pair shows the same ten-second gap (deleted 23:13:34, re-created 23:13:44). Without the sweep, a third run would have failed like the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
