### PR TITLE
fix(tooling): SRT scan restores the committed register; IAM gate prunes scratch/; runners line-buffer

### DIFF
--- a/benchmarks/harness/run_matrix.py
+++ b/benchmarks/harness/run_matrix.py
@@ -528,6 +528,13 @@ def verify_config_axes(cells):
 
 
 def main():
+    # Line-buffer stdout so a detached run (`setsid nohup … > log &`) shows
+    # progress and the verdict as they happen, not only at exit. Release
+    # validation polled CloudFormation instead of these logs for a night
+    # because of this.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--stack", required=True)
     ap.add_argument("--suite", default="core")

--- a/scripts/sdlc/run_stacktest.py
+++ b/scripts/sdlc/run_stacktest.py
@@ -83,6 +83,13 @@ def _resolve_vpc_params(args):
 
 
 def main():
+    # Line-buffer stdout so a detached run (`setsid nohup … > log &`) shows
+    # progress and the verdict as they happen, not only at exit. Release
+    # validation polled CloudFormation instead of these logs for a night
+    # because of this.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
+
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("suffix", nargs="?", help="stack-test name (see --list)")
     ap.add_argument("--list", action="store_true", help="list available stack-tests")

--- a/scripts/srt/register.py
+++ b/scripts/srt/register.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Restore the committed SRT disposition register before a scan.
+
+Why this exists
+---------------
+SRT keeps its working state in the gitignored ``.srt/issues.json``. The
+dispositions the team has agreed on — ``suppressed`` / ``resolved`` HIGH findings
+with a written reason — live in the **committed** ``scripts/srt/issues.json``.
+CI restores the committed file over the live one (``make srt-setup``) before it
+scans, so the scanner sees every disposition and the gate reads green.
+
+``make srt-scan`` on its own did not. It merged the new scan into whatever
+``.srt/issues.json`` already held. On a working tree whose live state predated
+suppressions committed later, the scanner met those findings "for the first
+time" and opened them: the v0.6.8 release validation saw **10 false open HIGH
+findings** from exactly this. Worse, the same mechanism runs the other way — a
+live file carrying a *stale* ``suppressed`` that was since removed from the
+committed register would hide a real finding locally.
+
+So every scan now starts from the committed register. The one thing that must
+not happen is silently discarding a disposition someone made locally but has
+not yet saved: ``srt-fix`` copies back automatically, but a hand-edit or a raw
+``./srt fix`` does not. Those are detected and the scan refuses until the
+operator either saves them (``make srt-fix``) or opts to drop them.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+# The tuple SRT keys a disposition on. An entry whose key matches keeps its
+# status across scans; anything else is a new finding.
+_KEY_FIELDS = ("path", "resourceType", "resourceName", "check_id")
+
+
+def _key(issue: dict) -> tuple:
+    return tuple(issue.get(f) for f in _KEY_FIELDS)
+
+
+def _is_high(issue: dict) -> bool:
+    return (issue.get("priority") or "").upper() == "HIGH"
+
+
+def _is_dispositioned(issue: dict) -> bool:
+    return (issue.get("status") or "").lower() not in ("", "open")
+
+
+def _load(path: Path) -> list[dict]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+@dataclass
+class RestoreResult:
+    """What ``restore_committed_register`` did, for the caller to print."""
+
+    action: str  # "restored" | "no-committed-register" | "refused"
+    committed_count: int = 0
+    # Dispositioned HIGH findings present in the live file but absent from the
+    # committed register — the ones a plain overwrite would have thrown away.
+    unsynced: list[dict] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.action != "refused"
+
+
+def unsynced_dispositions(
+    live: Iterable[dict],
+    committed: Iterable[dict],
+    is_ci_visible: Callable[[dict], bool] | None = None,
+) -> list[dict]:
+    """Live HIGH dispositions the committed register does not know about.
+
+    Only what ``fix.py`` would itself persist counts: HIGH priority, not Open,
+    and (when a predicate is given) in a file CI checks out — a suppression on
+    a gitignored build artifact can never reach the committed register, so its
+    absence there is not "unsynced", it is by design.
+    """
+    known = {_key(i) for i in committed}
+    out = []
+    for issue in live:
+        if not (_is_high(issue) and _is_dispositioned(issue)):
+            continue
+        if is_ci_visible is not None and not is_ci_visible(issue):
+            continue
+        if _key(issue) not in known:
+            out.append(issue)
+    return out
+
+
+def restore_committed_register(
+    committed_path: Path,
+    live_path: Path,
+    *,
+    is_ci_visible: Callable[[dict], bool] | None = None,
+    discard_local: bool = False,
+) -> RestoreResult:
+    """Copy the committed register over the live one, unless that would lose work.
+
+    - No committed register: do nothing (a fresh checkout with no baseline).
+    - Live file holds HIGH dispositions the committed one lacks and
+      ``discard_local`` is False: refuse, returning them, so the caller can
+      tell the operator to save them first.
+    - Otherwise: overwrite live with committed (``shutil.copy2``, same as
+      ``setup.py``) and report how many entries were restored.
+    """
+    if not committed_path.exists():
+        return RestoreResult(action="no-committed-register")
+
+    committed = _load(committed_path)
+    live = _load(live_path) if live_path.exists() else []
+
+    unsynced = unsynced_dispositions(live, committed, is_ci_visible)
+    if unsynced and not discard_local:
+        return RestoreResult(
+            action="refused", committed_count=len(committed), unsynced=unsynced
+        )
+
+    live_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(committed_path, live_path)
+    return RestoreResult(action="restored", committed_count=len(committed))
+
+
+def describe_unsynced(issues: list[dict]) -> str:
+    """One line per unsynced disposition, for the refusal message."""
+    lines = []
+    for i in issues:
+        lines.append(
+            f"  {i.get('status'):<10} {i.get('check_id') or '?':<14} "
+            f"{i.get('path') or '<no path>'}  ({i.get('resourceName') or '-'})"
+        )
+    return "\n".join(lines)

--- a/scripts/srt/run.py
+++ b/scripts/srt/run.py
@@ -14,6 +14,10 @@ from ci_paths import (  # noqa: E402
     partition_by_ci_visibility,
     tracked_files,
 )
+from register import (  # noqa: E402
+    describe_unsynced,
+    restore_committed_register,
+)
 from scanner_health import (  # noqa: E402
     failed_checkov_scans,
     missing_whole_repo_scanners,
@@ -146,6 +150,41 @@ def run_command(cmd: str, cwd=None, capture_output=False):
         return None if capture_output else False
 
 
+def restore_register(project_root, srt_dir):
+    """Copy scripts/srt/issues.json over .srt/issues.json; False if that would lose work.
+
+    A HIGH disposition present locally but never saved to the committed register
+    (a hand edit, or a raw `./srt fix` without fix.py's copy-back) is reported
+    and blocks the scan, unless SRT_DISCARD_LOCAL=1 says to drop it.
+    """
+    import os
+
+    tracked = tracked_files(project_root)
+    result = restore_committed_register(
+        project_root / "scripts" / "srt" / "issues.json",
+        srt_dir / "issues.json",
+        is_ci_visible=lambda i: is_in_ci_checkout(i.get("path"), tracked),
+        discard_local=os.getenv("SRT_DISCARD_LOCAL") == "1",
+    )
+    if result.action == "restored":
+        print(
+            f"✓ Restored the committed disposition register "
+            f"({result.committed_count} entries) into .srt/issues.json"
+        )
+        return True
+    if result.action == "no-committed-register":
+        print("ℹ️  No committed scripts/srt/issues.json — scanning with no baseline")
+        return True
+    print(
+        "❌ .srt/issues.json holds HIGH dispositions that are NOT in the committed\n"
+        "   register scripts/srt/issues.json. Restoring the register would discard\n"
+        "   them, so the scan is refused. Either save them (`make srt-fix` copies\n"
+        "   dispositions back), or drop them with SRT_DISCARD_LOCAL=1:\n"
+        + describe_unsynced(result.unsynced)
+    )
+    return False
+
+
 def main():
     """Run SRT security assessment."""
     import os
@@ -177,6 +216,14 @@ def main():
     print(f"Scanning project: {project_path}")
 
     warn_about_build_artifacts(project_root)
+
+    # Start every scan from the COMMITTED disposition register. `srt assess`
+    # merges into whatever .srt/issues.json already holds; a stale live file
+    # predating a committed suppression makes the scanner "discover" that
+    # finding and open it (v0.6.8: 10 false open HIGH). CI has always done this
+    # copy via `make srt-setup`; a local `make srt-scan` did not. See register.py.
+    if not restore_register(project_root, srt_dir):
+        sys.exit(1)
 
     # Recorded before the scan so a previous run's scanner summaries can't be
     # mistaken for this run's output when checking which scanners completed.

--- a/scripts/srt/setup.py
+++ b/scripts/srt/setup.py
@@ -212,8 +212,15 @@ def main():
     srt_dir = project_root / ".srt"
 
     # Check if running in CI/CD environment
+    # "CI" here really means "non-interactive". A detached or scripted run with
+    # no terminal must take the programmatic path too: `srt config` otherwise
+    # blocks on an AWS-profile prompt nobody can answer, and interrupting that
+    # prompt leaves SRT with no config and no scanner venv (seen at v0.6.8).
     is_ci = bool(
-        os.getenv("CI") or os.getenv("GITLAB_CI") or os.getenv("GITHUB_ACTIONS")
+        os.getenv("CI")
+        or os.getenv("GITLAB_CI")
+        or os.getenv("GITHUB_ACTIONS")
+        or not sys.stdin.isatty()
     )
 
     print("Setting up SRT (Sample Security Review Tool)...")

--- a/scripts/srt/tests/test_register.py
+++ b/scripts/srt/tests/test_register.py
@@ -1,0 +1,156 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""``make srt-scan`` must start from the committed disposition register.
+
+The v0.6.8 release validation ran ``make srt-scan`` on a tree whose gitignored
+``.srt/issues.json`` predated ten suppressions committed a week earlier, and the
+scanner reported all ten as open HIGH findings — a false red in a security gate.
+These tests pin the restore step that closes that, and the one case where it
+must NOT overwrite: a local disposition nobody has saved yet.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SRT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SRT_DIR))
+from register import (  # noqa: E402
+    describe_unsynced,
+    restore_committed_register,
+    unsynced_dispositions,
+)
+
+
+def _issue(path, check="LAMBDA-002", status="suppressed", priority="HIGH", name="Fn"):
+    return {
+        "source": "security-matrix",
+        "path": path,
+        "resourceType": "AWS::Lambda::Function",
+        "resourceName": name,
+        "check_id": check,
+        "priority": priority,
+        "status": status,
+    }
+
+
+@pytest.fixture
+def paths(tmp_path):
+    committed = tmp_path / "scripts" / "srt" / "issues.json"
+    live = tmp_path / ".srt" / "issues.json"
+    committed.parent.mkdir(parents=True)
+    return committed, live
+
+
+def _write(path: Path, issues):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(issues))
+
+
+@pytest.mark.unit
+def test_no_committed_register_is_a_noop(paths):
+    committed, live = paths
+    _write(live, [_issue("a.yaml", status="Open")])
+    result = restore_committed_register(committed, live)
+    assert result.action == "no-committed-register"
+    assert json.loads(live.read_text()) == [_issue("a.yaml", status="Open")]
+
+
+@pytest.mark.unit
+def test_committed_register_is_copied_over_a_missing_live_file(paths):
+    committed, live = paths
+    _write(committed, [_issue("nested/x/template.yaml")])
+    result = restore_committed_register(committed, live)
+    assert result.action == "restored"
+    assert result.committed_count == 1
+    assert json.loads(live.read_text()) == [_issue("nested/x/template.yaml")]
+
+
+@pytest.mark.unit
+def test_stale_live_state_is_replaced_so_suppressions_are_seen(paths):
+    """The v0.6.8 case: live predates a committed suppression → live loses."""
+    committed, live = paths
+    _write(committed, [_issue("scripts/security/live_checks/oidc/template.yaml")])
+    # Stale live: the same finding, still Open (never saw the suppression), plus
+    # thousands of low-priority rows the scanner keeps that we do not care about.
+    _write(
+        live,
+        [
+            _issue("scripts/security/live_checks/oidc/template.yaml", status="Open"),
+            _issue("src/a.py", check="B101", priority="LOW", status="Open"),
+        ],
+    )
+    result = restore_committed_register(committed, live)
+    assert result.action == "restored"
+    restored = json.loads(live.read_text())
+    assert restored == [_issue("scripts/security/live_checks/oidc/template.yaml")]
+    assert restored[0]["status"] == "suppressed"
+
+
+@pytest.mark.unit
+def test_an_unsaved_local_disposition_blocks_the_overwrite(paths):
+    """A HIGH finding suppressed locally but not committed must not be lost."""
+    committed, live = paths
+    _write(committed, [_issue("nested/x/template.yaml")])
+    local_only = _issue("nested/y/template.yaml", check="DDB-002", status="suppressed")
+    _write(live, [_issue("nested/x/template.yaml"), local_only])
+    result = restore_committed_register(committed, live)
+    assert result.action == "refused"
+    assert not result.ok
+    assert result.unsynced == [local_only]
+    # and the live file is untouched
+    assert len(json.loads(live.read_text())) == 2
+    # the message names it
+    text = describe_unsynced(result.unsynced)
+    assert "DDB-002" in text and "nested/y/template.yaml" in text
+
+
+@pytest.mark.unit
+def test_discard_local_overrides_the_refusal(paths):
+    committed, live = paths
+    _write(committed, [_issue("nested/x/template.yaml")])
+    _write(live, [_issue("nested/y/template.yaml", check="DDB-002")])
+    result = restore_committed_register(committed, live, discard_local=True)
+    assert result.action == "restored"
+    assert json.loads(live.read_text()) == [_issue("nested/x/template.yaml")]
+
+
+@pytest.mark.unit
+def test_only_what_fix_py_would_persist_counts_as_unsynced():
+    """Open, non-HIGH and gitignored dispositions are not 'unsaved work'."""
+    committed = [_issue("nested/x/template.yaml")]
+    live = [
+        _issue("nested/x/template.yaml"),  # known
+        _issue("nested/open.yaml", status="Open"),  # not a disposition
+        _issue(
+            "nested/low.yaml", priority="MEDIUM", status="suppressed"
+        ),  # fix.py drops
+        _issue(".aws-sam/packaged.yaml", check="KMS-007"),  # gitignored artifact
+        _issue("nested/real.yaml", check="S3-005"),  # the one real unsaved one
+    ]
+    visible = lambda i: not (i.get("path") or "").startswith(".aws-sam/")  # noqa: E731
+    got = unsynced_dispositions(live, committed, is_ci_visible=visible)
+    assert [i["path"] for i in got] == ["nested/real.yaml"]
+
+
+@pytest.mark.unit
+def test_a_resolved_entry_counts_as_a_disposition():
+    """``resolved`` is a disposition too (it is what re-detects as ``reopened``)."""
+    got = unsynced_dispositions(
+        [_issue("nested/r.yaml", status="resolved")], committed=[]
+    )
+    assert len(got) == 1
+
+
+@pytest.mark.unit
+def test_corrupt_live_file_is_treated_as_empty(paths):
+    committed, live = paths
+    _write(committed, [_issue("nested/x/template.yaml")])
+    live.parent.mkdir(parents=True)
+    live.write_text("{not json")
+    result = restore_committed_register(committed, live)
+    assert result.action == "restored"
+    assert json.loads(live.read_text()) == [_issue("nested/x/template.yaml")]

--- a/scripts/tests/test_iam_privilege_escalation.py
+++ b/scripts/tests/test_iam_privilege_escalation.py
@@ -109,8 +109,21 @@ DEPLOYMENT_ROLE_TEMPLATES: dict[str, str] = {
     ),
 }
 
+# `scratch/` is the repo's gitignored local-work directory; it can hold whole git
+# worktrees (scratch/wt-*/), i.e. full copies of every template under a path the
+# exemption list does not know. The v0.6.8 release validation failed both rules
+# on two such worktrees. Same set as the sibling gate in test_lambda_log_groups.py.
 PRUNED_DIRS = frozenset(
-    {".aws-sam", "node_modules", ".venv", "build", "dist", ".git", "__pycache__"}
+    {
+        ".aws-sam",
+        "node_modules",
+        ".venv",
+        "build",
+        "dist",
+        ".git",
+        "__pycache__",
+        "scratch",
+    }
 )
 
 
@@ -530,6 +543,39 @@ def test_discovery_finds_a_new_template(tmp_path: Path) -> None:
     assert [p.relative_to(tmp_path) for p in _template_paths(root=tmp_path)] == [
         Path("some-service/template.yml")
     ]
+
+
+@pytest.mark.unit
+def test_discovery_prunes_scratch(tmp_path: Path) -> None:
+    """A template under ``scratch/`` (e.g. a stale git worktree) is not scanned.
+
+    ``scratch/`` is gitignored local work. A worktree left there is a complete
+    copy of the repo, so every exempt deployment-role template reappears under
+    a path the exemption list does not name — and both rules fail on files that
+    are not part of the tree under review.
+    """
+    stray = tmp_path / "scratch" / "wt-old" / "iam-roles" / "role.yaml"
+    stray.parent.mkdir(parents=True)
+    stray.write_text(
+        "Resources:\n"
+        "  R:\n"
+        "    Type: AWS::IAM::Role\n"
+        "    Properties:\n"
+        "      Policies:\n"
+        "        - PolicyName: p\n"
+        "          PolicyDocument:\n"
+        "            Statement:\n"
+        "              - Effect: Allow\n"
+        "                Action: iam:AttachRolePolicy\n"
+        "                Resource: '*'\n"
+    )
+    real = tmp_path / "svc" / "template.yaml"
+    real.parent.mkdir(parents=True)
+    real.write_text("Resources:\n  B:\n    Type: AWS::S3::Bucket\n")
+    assert [p.relative_to(tmp_path) for p in _template_paths(root=tmp_path)] == [
+        Path("svc/template.yaml")
+    ]
+    assert not _scan(root=tmp_path), "the gate scanned a template under scratch/"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Three test-tooling findings from the v0.6.8 release validation (`docs/release-validation/v0.6.8.md`, Findings 2 and 4, plus the buffering note).

## 1. `make srt-scan` re-opened committed suppressions (false red in a security gate)

`srt assess` merges into whatever gitignored `.srt/issues.json` already holds. On a tree whose live state predated suppressions committed to `scripts/srt/issues.json`, the scanner met those findings for the first time and opened them: **10 false open HIGH** at v0.6.8. CI never saw it because `make srt-setup` copies the committed register in first; a local `make srt-scan` (and `scripts/security/run_security_tests.sh`, which calls it) did not.

- New `scripts/srt/register.py`: `restore_committed_register()` copies the committed register over the live file before every scan — the same copy `setup.py` does — and **refuses** when the live file holds HIGH dispositions the committed one lacks (a hand edit, or a raw `./srt fix` nobody saved), unless `SRT_DISCARD_LOCAL=1`. Only what `fix.py` would itself persist counts as unsaved: HIGH, dispositioned, CI-visible. `run.py` calls it before `srt assess`. 8 unit tests.
- `setup.py` takes the non-interactive path whenever stdin is not a TTY, not only under `CI=1`. `srt config` otherwise blocks on an AWS-profile prompt, and interrupting that prompt deleted SRT's config and scanner venv.

**Verified end to end** against the real SRT install: seeded `.srt/issues.json` with the committed register but one OIDC-fixture suppression flipped to `Open` → the fixed scan printed `✓ Restored the committed disposition register (111 entries)` and finished `✅ no high-priority security issues found`, with that entry `suppressed` in the live state afterwards. The refusal path: an extra unsaved HIGH suppression → exit 1 naming it, no scan; with `SRT_DISCARD_LOCAL=1` the restore proceeds.

## 2. The IAM privilege-escalation gate scanned `scratch/`

Stale `git worktree`s under gitignored `scratch/` made both rules fail on templates that are exempt under their real paths. `scratch` is now in `PRUNED_DIRS`, matching the sibling log-group gate, with a meta-test that plants a template there and asserts it is not scanned. 20/20 pass.

## 3. Detached runners printed their verdict only at exit

`run_stacktest.py` and `run_matrix.py` now line-buffer stdout, so `setsid nohup … > log &` shows progress as it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
