### PR TITLE
fix(test-runner): inflate compressed configs with parse_float=Decimal

### DIFF
--- a/nested/api-resolvers/src/lambda/test_runner/index.py
+++ b/nested/api-resolvers/src/lambda/test_runner/index.py
@@ -415,7 +415,16 @@ def _decompress_config_item(item):
     )
 
     try:
-        config_data = json.loads(_gzip.decompress(raw_bytes).decode("utf-8"))
+        # parse_float=Decimal, for the same reason _capture_config gives for a
+        # pinned revision: this config is written straight into the run's
+        # DynamoDB item, and the resource client rejects Python floats ("Float
+        # types are not supported. Use Decimal types instead."). A compressed
+        # config carrying any non-integer number (the shipped `ocr-benchmark`
+        # preset has `criteria_validation.temperature: 0.0`) failed every
+        # startTestRun at submit until this matched the revision path.
+        config_data = json.loads(
+            _gzip.decompress(raw_bytes).decode("utf-8"), parse_float=Decimal
+        )
     except Exception as e:
         logger.error(f"Failed to decompress config data: {e}")
         return item

--- a/nested/api-resolvers/src/lambda/test_runner/test_compressed_config_floats.py
+++ b/nested/api-resolvers/src/lambda/test_runner/test_compressed_config_floats.py
@@ -1,0 +1,99 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""A compressed configuration must inflate to Decimals, never floats (#892).
+
+The captured configuration is written straight into the run's DynamoDB item, and
+the DynamoDB resource client refuses Python floats. The revision path already
+parses with ``parse_float=Decimal``; the compressed path did not, so a compressed
+profile carrying ``temperature: 0.0`` (the shipped ``ocr-benchmark`` preset does)
+failed every ``startTestRun`` at submit with "Float types are not supported".
+"""
+
+import gzip
+import importlib.util
+import json
+import os
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+os.environ.setdefault("TRACKING_TABLE", "tracking")
+os.environ.setdefault("CONFIG_TABLE", "config")
+os.environ.setdefault("FILE_COPY_QUEUE_URL", "https://sqs.example/queue")
+
+
+@pytest.fixture
+def index():
+    spec = importlib.util.spec_from_file_location(
+        "test_runner_index_floats", Path(__file__).with_name("index.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_runner_index_floats"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compressed_item(config: dict) -> dict:
+    return {
+        "Configuration": "Config#ocr-benchmark",
+        "IsActive": True,
+        "_config_storage": "compressed",
+        "_compressed_config": gzip.compress(json.dumps(config).encode("utf-8")),
+    }
+
+
+def _walk(o):
+    if isinstance(o, dict):
+        for v in o.values():
+            yield from _walk(v)
+    elif isinstance(o, list):
+        for v in o:
+            yield from _walk(v)
+    else:
+        yield o
+
+
+@pytest.mark.unit
+def test_compressed_config_inflates_floats_as_decimal(index):
+    item = _compressed_item(
+        {
+            "criteria_validation": {"temperature": 0.0, "top_p": 0.01},
+            "extraction": {"model": "us.anthropic.claude-sonnet-5", "max_tokens": 4096},
+            "classes": [{"name": "Invoice", "threshold": 0.95}],
+        }
+    )
+    full = index._decompress_config_item(item)
+    assert full["criteria_validation"]["temperature"] == Decimal("0.0")
+    assert full["criteria_validation"]["top_p"] == Decimal("0.01")
+    assert full["classes"][0]["threshold"] == Decimal("0.95")
+    # ints stay ints (DynamoDB is happy with either, but nothing should widen)
+    assert full["extraction"]["max_tokens"] == 4096
+    assert not any(isinstance(v, float) for v in _walk(full)), (
+        "a float survived decompression — the DynamoDB resource client will "
+        "reject the run's metadata write"
+    )
+    # metadata fields are preserved alongside the inflated body
+    assert full["Configuration"] == "Config#ocr-benchmark"
+    assert full["IsActive"] is True
+
+
+@pytest.mark.unit
+def test_compressed_config_serialises_for_dynamodb(index):
+    """The concrete failure: boto3's TypeSerializer must accept the result."""
+    from boto3.dynamodb.types import TypeSerializer
+
+    full = index._decompress_config_item(
+        _compressed_item({"criteria_validation": {"temperature": 0.0, "top_p": 0.01}})
+    )
+    body = {k: v for k, v in full.items() if not k.startswith("_")}
+    TypeSerializer().serialize(body)  # raised TypeError before the fix
+
+
+@pytest.mark.unit
+def test_legacy_inline_item_is_returned_unchanged(index):
+    item = {"Configuration": "Config#x", "extraction": {"temperature": Decimal("0")}}
+    assert index._decompress_config_item(item) is item


### PR DESCRIPTION
Fixes #892.

## The bug

`_decompress_config_item()` in the TestRunner Lambda inflated a compressed configuration with a plain `json.loads(...)`, so any non-integer number came back as a Python `float`. The captured configuration is written straight into the run's DynamoDB item through the resource client, which rejects floats:

```
[ERROR] Failed to store test run metadata: Float types are not supported. Use Decimal types instead.
```

Every `startTestRun` against such a profile failed at submit. The revision path in `_capture_config()` a few lines away already parses with `parse_float=Decimal` and explains why in its comment; the compressed path never got the same treatment.

**Reachable by a customer:** any profile large enough to be stored compressed that carries a float. The shipped `ocr-benchmark` preset has `criteria_validation.temperature: 0.0` and `top_p: 0.01`, so selecting it in Test Studio and starting a run fails. Found on a fresh published-0.6.8 stack when the v0.6.8 benchmark refresh tried to run the OCR-benchmark reference corpus: all 19 launches rejected, while `realkie-fcc-verified` (no floats) ran.

## The fix

One line: `json.loads(..., parse_float=Decimal)`, matching the revision path. `test_compressed_config_floats.py` inflates a compressed item carrying `0.0` / `0.01` / `0.95`, asserts every value is a `Decimal` (ints unchanged, metadata fields preserved), and asserts boto3's `TypeSerializer` accepts the result — which is the concrete call that failed. 23 tests in the directory pass.

## Verified live

The fixed handler was hot-patched onto the reference stack's TestRunner (`update-function-code`) and the OCR-benchmark corpus re-launched: the 19 cell launches that were rejected before are accepted after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
